### PR TITLE
Disable line comments

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,6 @@
 {
     "comments": {
         // symbols used for start and end a block comment
-        "lineComment": "\"",
         "blockComment": [ "\"", "\"" ]
     },
     // symbols used as brackets


### PR DESCRIPTION
disable line comments, which just insert a single `"` at the start of the line. 

with the `lineComment` value removed from language-configuration.json, vscode will fall back to block comments and appropriately wrap the line in `"`.