### PR TITLE
feat(US-411): recursive-descent expression parser (slice 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "check-types": "tsc --noEmit -p client/tsconfig.json && tsc --noEmit -p server/tsconfig.json",
         "test:server": "node server/test/handshake.test.mjs",
         "test:client": "tsx client/test/gstLocator.test.ts",
-        "test:parser": "tsx server/test/lexer.test.ts",
+        "test:parser": "tsx server/test/run.ts",
         "lint": "eslint client/src server/src",
         "test": "vscode-test",
         "package": "vsce package --no-dependencies",

--- a/server/src/parser/ast.ts
+++ b/server/src/parser/ast.ts
@@ -1,0 +1,157 @@
+// AST for the GNU Smalltalk expression parser (US-411, slice 2).
+//
+// Pure data types — no `vscode` imports — so the parser and its tests run in
+// plain Node via `tsx`. Every node carries byte offsets and LSP-shaped
+// positions (reused from token.ts), so downstream LSP features (US-412+) get
+// ranges directly.
+
+import type { Position } from './token';
+
+export enum NodeKind {
+  /** Top-level: optional temporaries + a statement sequence. */
+  Program = 'Program',
+  /** `[ :params | | temps | statements ]`. */
+  Block = 'Block',
+  /** `^ expression`. */
+  Return = 'Return',
+  /** `target := value` (also legacy `target _ value`). */
+  Assignment = 'Assignment',
+  /** A unary, binary, or keyword message send. */
+  Message = 'Message',
+  /** `receiver msg ; msg ; …`. */
+  Cascade = 'Cascade',
+  /** A zero-width marker standing in for the cascade receiver inside each cascade segment. */
+  CascadeReceiver = 'CascadeReceiver',
+  /** A variable / identifier reference. */
+  Variable = 'Variable',
+  /** A scalar literal: integer, float, scaled decimal, string, symbol, character. */
+  Literal = 'Literal',
+  /** `#( … )`. */
+  LiteralArray = 'LiteralArray',
+  /** `#[ … ]`. */
+  ByteArray = 'ByteArray',
+  /** `{ expr. expr. … }`. */
+  DynamicArray = 'DynamicArray',
+  /** A recovery node standing in for an unparseable fragment; paired with a diagnostic. */
+  Error = 'Error',
+}
+
+export type MessageType = 'unary' | 'binary' | 'keyword';
+
+export type LiteralKind =
+  | 'integer'
+  | 'float'
+  | 'scaledDecimal'
+  | 'string'
+  | 'symbol'
+  | 'character';
+
+/** Fields every node carries: kind + source range. */
+export interface NodeBase {
+  readonly kind: NodeKind;
+  readonly start: number;
+  readonly end: number;
+  readonly startPos: Position;
+  readonly endPos: Position;
+}
+
+/** A named declaration (a temporary or a block parameter) with its own range. */
+export interface NameRef {
+  readonly name: string;
+  readonly start: number;
+  readonly end: number;
+  readonly startPos: Position;
+  readonly endPos: Position;
+}
+
+export interface ProgramNode extends NodeBase {
+  readonly kind: NodeKind.Program;
+  readonly temporaries: NameRef[];
+  readonly statements: Node[];
+}
+
+export interface BlockNode extends NodeBase {
+  readonly kind: NodeKind.Block;
+  readonly parameters: NameRef[];
+  readonly temporaries: NameRef[];
+  readonly statements: Node[];
+}
+
+export interface ReturnNode extends NodeBase {
+  readonly kind: NodeKind.Return;
+  readonly value: Node;
+}
+
+export interface AssignmentNode extends NodeBase {
+  readonly kind: NodeKind.Assignment;
+  readonly target: VariableNode;
+  readonly value: Node;
+}
+
+export interface MessageNode extends NodeBase {
+  readonly kind: NodeKind.Message;
+  readonly receiver: Node;
+  readonly selector: string;
+  readonly messageType: MessageType;
+  readonly arguments: Node[];
+}
+
+export interface CascadeNode extends NodeBase {
+  readonly kind: NodeKind.Cascade;
+  /** The shared receiver, parsed once; each segment is a chain rooted at a {@link CascadeReceiverNode}. */
+  readonly receiver: Node;
+  /** One message chain per `;` segment (incl. the first), each rooted at a `CascadeReceiver` marker. */
+  readonly messages: Node[];
+}
+
+/** Zero-width placeholder for the cascade receiver inside a segment's message chain. */
+export interface CascadeReceiverNode extends NodeBase {
+  readonly kind: NodeKind.CascadeReceiver;
+}
+
+export interface VariableNode extends NodeBase {
+  readonly kind: NodeKind.Variable;
+  readonly name: string;
+}
+
+export interface LiteralNode extends NodeBase {
+  readonly kind: NodeKind.Literal;
+  readonly literalKind: LiteralKind;
+  /** Raw source text of the literal (no value evaluation in the front end). */
+  readonly value: string;
+}
+
+export interface LiteralArrayNode extends NodeBase {
+  readonly kind: NodeKind.LiteralArray;
+  readonly elements: Node[];
+}
+
+export interface ByteArrayNode extends NodeBase {
+  readonly kind: NodeKind.ByteArray;
+  readonly elements: Node[];
+}
+
+export interface DynamicArrayNode extends NodeBase {
+  readonly kind: NodeKind.DynamicArray;
+  readonly elements: Node[];
+}
+
+export interface ErrorNode extends NodeBase {
+  readonly kind: NodeKind.Error;
+  readonly message: string;
+}
+
+export type Node =
+  | ProgramNode
+  | BlockNode
+  | ReturnNode
+  | AssignmentNode
+  | MessageNode
+  | CascadeNode
+  | CascadeReceiverNode
+  | VariableNode
+  | LiteralNode
+  | LiteralArrayNode
+  | ByteArrayNode
+  | DynamicArrayNode
+  | ErrorNode;

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -1,0 +1,511 @@
+// Recursive-descent parser for GNU Smalltalk expressions (US-411, slice 2).
+//
+// `parse()` turns source into an AST (with positions) plus a diagnostics list.
+// Like the lexer it NEVER throws: a malformed statement records a diagnostic,
+// yields an `Error` node, and the statement loop synchronizes on `.`/`]`/`!`/EOF.
+// Every loop makes progress (parsePrimary always consumes >= 1 token, even on
+// error), so no input can hang the parser.
+//
+// Precedence climb (tightest first): primary -> unary -> binary -> keyword ->
+// cascade -> assignment. See specs/US-411-*/plan.md ("Slice 2") for the design
+// decisions, notably the block-header `looksLikeTemporaries` lookahead.
+
+import { tokenize } from './lexer';
+import {
+  DiagnosticSeverity,
+  TokenKind,
+  type LexDiagnostic,
+  type Token,
+} from './token';
+import {
+  NodeKind,
+  type AssignmentNode,
+  type BlockNode,
+  type CascadeNode,
+  type CascadeReceiverNode,
+  type LiteralKind,
+  type MessageNode,
+  type MessageType,
+  type NameRef,
+  type Node,
+  type ProgramNode,
+  type VariableNode,
+} from './ast';
+
+const NUMBER_KINDS = new Set<TokenKind>([
+  TokenKind.Integer,
+  TokenKind.Float,
+  TokenKind.ScaledDecimal,
+]);
+
+export interface ParseResult {
+  readonly ast: ProgramNode;
+  readonly diagnostics: LexDiagnostic[];
+}
+
+const LITERAL_KIND: Partial<Record<TokenKind, LiteralKind>> = {
+  [TokenKind.Integer]: 'integer',
+  [TokenKind.Float]: 'float',
+  [TokenKind.ScaledDecimal]: 'scaledDecimal',
+  [TokenKind.String]: 'string',
+  [TokenKind.Symbol]: 'symbol',
+  [TokenKind.Char]: 'character',
+};
+
+export function parse(source: string): ParseResult {
+  const { tokens, diagnostics } = tokenize(source);
+  // Comments are trivia; positions still come from the real (non-comment) tokens.
+  const stream = tokens.filter((t) => t.kind !== TokenKind.Comment);
+  return new Parser(stream, diagnostics).parseProgram();
+}
+
+class Parser {
+  private index = 0;
+  private prev: Token;
+
+  constructor(
+    private readonly tokens: Token[],
+    private readonly diagnostics: LexDiagnostic[],
+  ) {
+    this.prev = tokens[0] as Token; // stream always has at least EOF
+  }
+
+  parseProgram(): ParseResult {
+    const startTok = this.current();
+    const { temporaries, statements } = this.parseSequenceBody(TokenKind.EOF);
+    const ast: ProgramNode = {
+      kind: NodeKind.Program,
+      temporaries,
+      statements,
+      ...this.span(startTok),
+    };
+    return { ast, diagnostics: this.diagnostics };
+  }
+
+  // --- Statement sequences ---------------------------------------------------
+
+  /** `[ '|' temps '|' ] statement ( '.' statement )*` up to `stop`. */
+  private parseSequenceBody(stop: TokenKind): { temporaries: NameRef[]; statements: Node[] } {
+    const temporaries = this.parseTemporaries();
+    const statements: Node[] = [];
+    while (!this.atEnd() && !this.at(stop)) {
+      // Tolerate stray separators: empty statements and chunk bangs.
+      if (this.at(TokenKind.Period) || this.at(TokenKind.Bang)) {
+        this.advance();
+        continue;
+      }
+      // REPL-style sources redeclare `| temps |` between statements; merge them.
+      if (this.looksLikeTemporaries()) {
+        temporaries.push(...this.parseTemporaries());
+        continue;
+      }
+      const stmt = this.parseStatement();
+      statements.push(stmt);
+      if (this.at(TokenKind.Period)) {
+        this.advance();
+      } else if (!this.atEnd() && !this.at(stop) && !this.at(TokenKind.Bang)) {
+        // A statement should be followed by `.`, the stop token, or EOF.
+        if (stmt.kind !== NodeKind.Error) {
+          this.diag('Expected "." after statement', this.current());
+        }
+        this.synchronize(stop);
+      }
+    }
+    return { temporaries, statements };
+  }
+
+  private parseTemporaries(): NameRef[] {
+    if (!this.looksLikeTemporaries()) {
+      return [];
+    }
+    this.advance(); // opening |
+    const temps: NameRef[] = [];
+    while (this.at(TokenKind.Identifier)) {
+      temps.push(this.nameRef(this.current()));
+      this.advance();
+    }
+    if (this.at(TokenKind.Pipe)) {
+      this.advance(); // closing |
+    }
+    return temps;
+  }
+
+  /** True when the current `|` opens a `| id* |` temporaries section (closing `|` confirmed). */
+  private looksLikeTemporaries(): boolean {
+    if (!this.at(TokenKind.Pipe)) {
+      return false;
+    }
+    let k = 1;
+    while (this.peek(k).kind === TokenKind.Identifier) {
+      k++;
+    }
+    return this.peek(k).kind === TokenKind.Pipe;
+  }
+
+  private synchronize(stop: TokenKind): void {
+    while (
+      !this.atEnd() &&
+      !this.at(stop) &&
+      !this.at(TokenKind.Period) &&
+      !this.at(TokenKind.Bang) &&
+      !this.at(TokenKind.RBracket)
+    ) {
+      this.advance();
+    }
+  }
+
+  private parseStatement(): Node {
+    if (this.at(TokenKind.Caret)) {
+      const startTok = this.current();
+      this.advance(); // ^
+      const value = this.parseExpression();
+      return { kind: NodeKind.Return, value, ...this.span(startTok) };
+    }
+    return this.parseExpression();
+  }
+
+  // --- Expressions (precedence climb) ----------------------------------------
+
+  private parseExpression(): Node {
+    // Assignment: `identifier ':=' expression` (right-associative; also legacy `_`).
+    if (this.at(TokenKind.Identifier) && this.peek(1).kind === TokenKind.Assign) {
+      const idTok = this.current();
+      this.advance(); // identifier
+      const target: VariableNode = { kind: NodeKind.Variable, name: idTok.text, ...this.range(idTok) };
+      this.advance(); // := or _
+      const value = this.parseExpression();
+      const node: AssignmentNode = { kind: NodeKind.Assignment, target, value, ...this.span(idTok) };
+      return node;
+    }
+    return this.parseCascade();
+  }
+
+  private parseCascade(): Node {
+    const startTok = this.current();
+    const expr = this.parseKeywordMessage();
+    if (!this.at(TokenKind.Semicolon) || expr.kind !== NodeKind.Message) {
+      return expr;
+    }
+    // The cascade receiver is the receiver of the first message's outermost send.
+    const receiver = expr.receiver;
+    const marker = this.cascadeReceiver(receiver);
+    // Segment 0 is the first message re-rooted at the marker; the rest are fresh chains.
+    const messages: Node[] = [{ ...expr, receiver: marker }];
+    while (this.at(TokenKind.Semicolon)) {
+      this.advance(); // ;
+      messages.push(this.parseCascadeSegment(this.cascadeReceiver(receiver)));
+    }
+    const node: CascadeNode = { kind: NodeKind.Cascade, receiver, messages, ...this.span(startTok) };
+    return node;
+  }
+
+  /** One `;` segment: a full unary > binary > keyword message chain on the implicit receiver. */
+  private parseCascadeSegment(receiver: Node): Node {
+    let node = receiver;
+    while (this.at(TokenKind.Identifier)) {
+      const selector = this.current().text;
+      this.advance();
+      node = this.message(node, selector, 'unary', []);
+    }
+    while (this.at(TokenKind.BinarySelector) || this.at(TokenKind.Pipe)) {
+      const selector = this.current().text;
+      this.advance();
+      node = this.message(node, selector, 'binary', [this.parseUnaryMessage()]);
+    }
+    if (this.at(TokenKind.Keyword)) {
+      let selector = '';
+      const args: Node[] = [];
+      while (this.at(TokenKind.Keyword)) {
+        selector += this.current().text;
+        this.advance();
+        args.push(this.parseBinaryMessage());
+      }
+      node = this.message(node, selector, 'keyword', args);
+    }
+    if (node === receiver) {
+      this.diag('Expected a message selector after ";"', this.current());
+    }
+    return node;
+  }
+
+  private cascadeReceiver(of: Node): CascadeReceiverNode {
+    return {
+      kind: NodeKind.CascadeReceiver,
+      start: of.end,
+      end: of.end,
+      startPos: of.endPos,
+      endPos: of.endPos,
+    };
+  }
+
+  private parseKeywordMessage(): Node {
+    let receiver = this.parseBinaryMessage();
+    if (this.at(TokenKind.Keyword)) {
+      let selector = '';
+      const args: Node[] = [];
+      while (this.at(TokenKind.Keyword)) {
+        selector += this.current().text;
+        this.advance();
+        args.push(this.parseBinaryMessage());
+      }
+      receiver = this.message(receiver, selector, 'keyword', args);
+    }
+    return receiver;
+  }
+
+  private parseBinaryMessage(): Node {
+    let receiver = this.parseUnaryMessage();
+    // A lone `|` acts as the bitOr binary selector in expression position.
+    while (this.at(TokenKind.BinarySelector) || this.at(TokenKind.Pipe)) {
+      const selector = this.current().text;
+      this.advance();
+      const arg = this.parseUnaryMessage();
+      receiver = this.message(receiver, selector, 'binary', [arg]);
+    }
+    return receiver;
+  }
+
+  private parseUnaryMessage(): Node {
+    let receiver = this.parsePrimary();
+    while (this.at(TokenKind.Identifier)) {
+      const selector = this.current().text;
+      this.advance();
+      receiver = this.message(receiver, selector, 'unary', []);
+    }
+    return receiver;
+  }
+
+  // --- Primaries -------------------------------------------------------------
+
+  private parsePrimary(): Node {
+    const t = this.current();
+    // Negative numeric literal: the lexer emits `-` as a binary selector, so in primary
+    // position `-` immediately before a number folds into a signed literal.
+    if (t.kind === TokenKind.BinarySelector && t.text === '-' && NUMBER_KINDS.has(this.peek(1).kind)) {
+      const numTok = this.peek(1);
+      this.advance(); // -
+      this.advance(); // number
+      const literalKind = LITERAL_KIND[numTok.kind] as LiteralKind;
+      return {
+        kind: NodeKind.Literal,
+        literalKind,
+        value: `-${numTok.text}`,
+        start: t.start,
+        end: numTok.end,
+        startPos: t.startPos,
+        endPos: numTok.endPos,
+      };
+    }
+    const literalKind = LITERAL_KIND[t.kind];
+    if (literalKind) {
+      this.advance();
+      return { kind: NodeKind.Literal, literalKind, value: t.text, ...this.range(t) };
+    }
+    switch (t.kind) {
+      case TokenKind.Identifier:
+        this.advance();
+        return { kind: NodeKind.Variable, name: t.text, ...this.range(t) };
+      case TokenKind.LParen:
+        return this.parseParenthesized();
+      case TokenKind.HashParen:
+        return this.parseCollection(NodeKind.LiteralArray, TokenKind.RParen);
+      case TokenKind.HashBracket:
+        return this.parseCollection(NodeKind.ByteArray, TokenKind.RBracket);
+      case TokenKind.LBrace:
+        return this.parseDynamicArray();
+      case TokenKind.LBracket:
+        return this.parseBlock();
+      default:
+        this.advance(); // consume the offending token to guarantee progress
+        this.diag(`Unexpected ${t.kind} "${t.text}"`, t);
+        return { kind: NodeKind.Error, message: `Unexpected ${t.kind}`, ...this.range(t) };
+    }
+  }
+
+  private parseParenthesized(): Node {
+    this.advance(); // (
+    const inner = this.parseExpression();
+    if (this.at(TokenKind.RParen)) {
+      this.advance();
+    } else {
+      this.diag('Expected ")"', this.current());
+    }
+    return inner;
+  }
+
+  /** `#( … )` literal array or `#[ … ]` byte array — elements are literal tokens. */
+  private parseCollection(kind: NodeKind.LiteralArray | NodeKind.ByteArray, close: TokenKind): Node {
+    const startTok = this.current();
+    this.advance(); // #( or #[
+    const elements: Node[] = [];
+    while (!this.atEnd() && !this.at(close)) {
+      elements.push(this.parseLiteralElement());
+    }
+    if (this.at(close)) {
+      this.advance();
+    } else {
+      this.diag(`Expected "${close === TokenKind.RParen ? ')' : ']'}"`, this.current());
+    }
+    return kind === NodeKind.LiteralArray
+      ? { kind: NodeKind.LiteralArray, elements, ...this.span(startTok) }
+      : { kind: NodeKind.ByteArray, elements, ...this.span(startTok) };
+  }
+
+  /** An element inside a literal `#( … )` / `#[ … ]`: a literal, a bareword (treated as a
+   *  symbol), an operator (symbol), or a nested literal collection. Always consumes >= 1 token. */
+  private parseLiteralElement(): Node {
+    const t = this.current();
+    const literalKind = LITERAL_KIND[t.kind];
+    if (literalKind) {
+      this.advance();
+      return { kind: NodeKind.Literal, literalKind, value: t.text, ...this.range(t) };
+    }
+    switch (t.kind) {
+      case TokenKind.Identifier:
+      case TokenKind.Keyword:
+      case TokenKind.BinarySelector:
+      case TokenKind.Pipe:
+        // Inside a literal array these are symbol elements.
+        this.advance();
+        return { kind: NodeKind.Literal, literalKind: 'symbol', value: t.text, ...this.range(t) };
+      case TokenKind.HashParen:
+      case TokenKind.LParen:
+        return this.parseCollection(NodeKind.LiteralArray, TokenKind.RParen);
+      case TokenKind.HashBracket:
+        return this.parseCollection(NodeKind.ByteArray, TokenKind.RBracket);
+      default:
+        this.advance();
+        this.diag(`Unexpected ${t.kind} in literal array`, t);
+        return { kind: NodeKind.Error, message: `Unexpected ${t.kind}`, ...this.range(t) };
+    }
+  }
+
+  /** `{ expr. expr. … }` — elements are full expressions. */
+  private parseDynamicArray(): Node {
+    const startTok = this.current();
+    this.advance(); // {
+    const elements: Node[] = [];
+    while (!this.atEnd() && !this.at(TokenKind.RBrace)) {
+      if (this.at(TokenKind.Period)) {
+        this.advance();
+        continue;
+      }
+      elements.push(this.parseExpression());
+      if (this.at(TokenKind.Period)) {
+        this.advance();
+      } else if (!this.at(TokenKind.RBrace) && !this.atEnd()) {
+        this.diag('Expected "." or "}" in dynamic array', this.current());
+        this.synchronize(TokenKind.RBrace);
+      }
+    }
+    if (this.at(TokenKind.RBrace)) {
+      this.advance();
+    } else {
+      this.diag('Expected "}"', this.current());
+    }
+    return { kind: NodeKind.DynamicArray, elements, ...this.span(startTok) };
+  }
+
+  /** `[ (':' id)* '|'? '| temps |'? statements ]`. */
+  private parseBlock(): Node {
+    const startTok = this.current();
+    this.advance(); // [
+    const parameters: NameRef[] = [];
+    while (this.at(TokenKind.Colon) && this.peek(1).kind === TokenKind.Identifier) {
+      this.advance(); // :
+      parameters.push(this.nameRef(this.current()));
+      this.advance(); // identifier
+    }
+    if (parameters.length > 0 && this.at(TokenKind.Pipe)) {
+      this.advance(); // argument terminator |
+      // A doubled `||` (args/body separator with no temporaries) leaves a stray pipe.
+      if (this.at(TokenKind.Pipe) && !this.looksLikeTemporaries()) {
+        this.advance();
+      }
+    }
+    const { temporaries, statements } = this.parseSequenceBody(TokenKind.RBracket);
+    if (this.at(TokenKind.RBracket)) {
+      this.advance();
+    } else {
+      this.diag('Expected "]" to close block', this.current());
+    }
+    const node: BlockNode = {
+      kind: NodeKind.Block,
+      parameters,
+      temporaries,
+      statements,
+      ...this.span(startTok),
+    };
+    return node;
+  }
+
+  // --- Node + token helpers --------------------------------------------------
+
+  private message(receiver: Node, selector: string, messageType: MessageType, args: Node[]): MessageNode {
+    return {
+      kind: NodeKind.Message,
+      receiver,
+      selector,
+      messageType,
+      arguments: args,
+      start: receiver.start,
+      end: this.prev.end,
+      startPos: receiver.startPos,
+      endPos: this.prev.endPos,
+    };
+  }
+
+  private nameRef(tok: Token): NameRef {
+    return { name: tok.text, ...this.range(tok) };
+  }
+
+  private range(tok: Token): { start: number; end: number; startPos: Token['startPos']; endPos: Token['endPos'] } {
+    return { start: tok.start, end: tok.end, startPos: tok.startPos, endPos: tok.endPos };
+  }
+
+  private span(startTok: Token): { start: number; end: number; startPos: Token['startPos']; endPos: Token['endPos'] } {
+    return {
+      start: startTok.start,
+      end: this.prev.end,
+      startPos: startTok.startPos,
+      endPos: this.prev.endPos,
+    };
+  }
+
+  private current(): Token {
+    return this.tokens[this.index] as Token;
+  }
+
+  private peek(offset: number): Token {
+    const i = Math.min(this.index + offset, this.tokens.length - 1);
+    return this.tokens[i] as Token;
+  }
+
+  private at(kind: TokenKind): boolean {
+    return this.current().kind === kind;
+  }
+
+  private atEnd(): boolean {
+    return this.current().kind === TokenKind.EOF;
+  }
+
+  private advance(): Token {
+    const t = this.current();
+    if (this.index < this.tokens.length - 1) {
+      this.index++;
+    }
+    this.prev = t;
+    return t;
+  }
+
+  private diag(message: string, tok: Token): void {
+    this.diagnostics.push({
+      message,
+      severity: DiagnosticSeverity.Error,
+      start: tok.start,
+      end: tok.end,
+      startPos: tok.startPos,
+      endPos: tok.endPos,
+    });
+  }
+}

--- a/server/test/__snapshots__/06_core_message_sends.ast.txt
+++ b/server/test/__snapshots__/06_core_message_sends.ast.txt
@@ -1,0 +1,248 @@
+Program temps=[var, anArray, aString, aNumber, count] @110..3746
+  Assignment target='var' @142..151
+    Literal integer "10" @149..151
+  Assignment target='anArray' @153..172
+    LiteralArray @164..172
+      Literal integer "1" @166..167
+      Literal integer "2" @168..169
+      Literal integer "3" @170..171
+  Assignment target='aString' @174..196
+    Literal string "'smalltalk'" @185..196
+  Assignment target='aNumber' @198..210
+    Literal integer "5" @209..210
+  Message unary 'printNl' @240..251
+    Variable 'var' @240..243
+  Message unary 'printNl' @253..273
+    Message unary 'size' @253..265
+      Variable 'anArray' @253..260
+  Message unary 'printNl' @275..299
+    Message unary 'reversed' @275..291
+      Variable 'aString' @275..282
+  Message unary 'printNl' @301..330
+    Message unary 'name' @301..322
+      Message unary 'class' @301..317
+        Message unary 'new' @301..311
+          Variable 'Object' @301..307
+  Message unary 'printNl' @360..380
+    Message unary 'class' @360..372
+      Message binary '+' @360..365
+        Literal integer "1" @360..361
+        Literal integer "2" @364..365
+  Message unary 'printNl' @430..453
+    Message unary 'value' @430..445
+      Block params=[] temps=[] @430..439
+        Message binary '+' @432..437
+          Literal integer "1" @432..433
+          Literal integer "1" @436..437
+  Message unary 'printNl' @507..527
+    Message unary 'factorial' @507..519
+      Literal integer "10" @507..509
+  Message unary 'printNl' @575..591
+    Message binary '+' @575..582
+      Variable 'var' @575..578
+      Literal integer "5" @581..582
+  Message unary 'printNl' @594..614
+    Message binary '*' @594..605
+      Variable 'aNumber' @594..601
+      Literal integer "2" @604..605
+  Message unary 'printNl' @617..634
+    Message binary '/' @617..625
+      Literal integer "100" @617..620
+      Literal integer "10" @623..625
+  Message unary 'printNl' @637..653
+    Message binary '\\' @637..644
+      Literal integer "10" @637..639
+      Literal integer "3" @643..644
+  Message unary 'printNl' @667..689
+    Message binary '-' @667..680
+      Variable 'var' @667..670
+      Variable 'aNumber' @673..680
+  Message unary 'printNl' @731..753
+    Message binary '>' @731..744
+      Variable 'var' @731..734
+      Variable 'aNumber' @737..744
+  Message unary 'printNl' @756..777
+    Message binary '<' @756..768
+      Variable 'aNumber' @756..763
+      Literal integer "10" @766..768
+  Message unary 'printNl' @780..797
+    Message binary '=' @780..788
+      Variable 'var' @780..783
+      Literal integer "10" @786..788
+  Message unary 'printNl' @800..821
+    Message binary '~=' @800..812
+      Variable 'aNumber' @800..807
+      Literal integer "5" @811..812
+  Message unary 'printNl' @838..856
+    Message binary '>=' @838..847
+      Variable 'var' @838..841
+      Literal integer "10" @845..847
+  Message unary 'printNl' @859..880
+    Message binary '<=' @859..871
+      Variable 'aNumber' @859..866
+      Literal integer "5" @870..871
+  Message unary 'printNl' @942..963
+    Message binary '&' @942..954
+      Variable 'true' @942..946
+      Variable 'false' @949..954
+  Message unary 'printNl' @966..987
+    Message binary '|' @966..978
+      Variable 'true' @966..970
+      Variable 'false' @973..978
+  Message binary ',' @1017..1050
+    Variable 'anArray' @1017..1024
+    Message unary 'printNl' @1026..1050
+      LiteralArray @1026..1042
+        Literal string "'add'" @1028..1033
+        Literal symbol "," @1033..1034
+        Literal string "'this'" @1035..1041
+  Message unary 'printNl' @1087..1106
+    Message binary '->' @1087..1097
+      Literal integer "1" @1087..1088
+      Literal string "'one'" @1092..1097
+  Message unary 'printNl' @1208..1230
+    Message binary '+' @1208..1221
+      Message binary '+' @1208..1217
+        Message binary '+' @1208..1213
+          Literal integer "1" @1208..1209
+          Literal integer "2" @1212..1213
+        Literal integer "3" @1216..1217
+      Literal integer "4" @1220..1221
+  Message unary 'printNl' @1250..1269
+    Message binary '*' @1250..1260
+      Message binary '-' @1250..1256
+        Literal integer "10" @1250..1252
+        Literal integer "2" @1255..1256
+      Literal integer "3" @1259..1260
+  Message unary 'printNl' @1597..1618
+    Message binary '-' @1597..1609
+      Literal integer "10" @1597..1599
+      Message binary '*' @1603..1608
+        Literal integer "2" @1603..1604
+        Literal integer "3" @1607..1608
+  Assignment target='count' @1682..1692
+    Literal integer "0" @1691..1692
+  Assignment target='count' @1694..1712
+    Message binary '+' @1703..1712
+      Variable 'count' @1703..1708
+      Literal integer "1" @1711..1712
+  Message unary 'printNl' @1714..1727
+    Variable 'count' @1714..1719
+  Message unary 'printNl' @1768..1786
+    Message binary '==' @1768..1777
+      Variable 'var' @1768..1771
+      Literal integer "10" @1775..1777
+  Message unary 'printNl' @1847..1865
+    Message binary '~~' @1847..1856
+      Variable 'var' @1847..1850
+      Literal integer "11" @1854..1856
+  Message unary 'printNl' @1908..1929
+    Message binary '<=' @1908..1920
+      Variable 'aNumber' @1908..1915
+      Literal integer "5" @1919..1920
+  Message keyword 'at:put:' @1981..2003
+    Variable 'anArray' @1981..1988
+    Literal integer "1" @1993..1994
+    Literal integer "100" @2000..2003
+  Message unary 'printNl' @2005..2020
+    Variable 'anArray' @2005..2012
+  Message keyword 'at:put:' @2022..2065
+    Variable 'Smalltalk' @2022..2031
+    Literal symbol "#MyGlobal" @2036..2045
+    Literal string "'Hello Global'" @2051..2065
+  Message unary 'printNl' @2067..2083
+    Variable 'MyGlobal' @2067..2075
+  Message keyword 'new:' @2127..2140
+    Variable 'Array' @2127..2132
+    Literal integer "10" @2138..2140
+  Message keyword 'copyFrom:to:' @2193..2218
+    Variable 'anArray' @2193..2200
+    Literal integer "1" @2211..2212
+    Literal integer "2" @2217..2218
+  Message keyword 'copyReplaceAll:with:' @2220..2264
+    Variable 'aString' @2220..2227
+    Literal string "'talk'" @2244..2250
+    Literal string "'rocks'" @2257..2264
+  Message unary 'printNl' @2266..2281
+    Variable 'aString' @2266..2273
+  Message keyword 'newDay:month:year:' @2284..2326
+    Variable 'Date' @2284..2288
+    Literal integer "1" @2297..2298
+    Literal string "'January'" @2306..2315
+    Literal integer "2024" @2322..2326
+  Message keyword 'to:do:' @2372..2402
+    Literal integer "1" @2372..2373
+    Literal integer "5" @2378..2379
+    Block params=[i] temps=[] @2384..2402
+      Message unary 'printNl' @2391..2400
+        Variable 'i' @2391..2392
+  Message keyword 'ifTrue:ifFalse:' @2445..2521
+    Variable 'true' @2445..2449
+    Block params=[] temps=[] @2458..2484
+      Message unary 'printNl' @2460..2482
+        Literal string "'It was true!'" @2460..2474
+    Block params=[] temps=[] @2494..2521
+      Message unary 'printNl' @2496..2519
+        Literal string "'It was false!'" @2496..2511
+  Message keyword 'at:put:' @2587..2626
+    Variable 'anArray' @2587..2594
+    Message binary '+' @2600..2605
+      Literal integer "1" @2600..2601
+      Literal integer "1" @2604..2605
+    Message unary 'size' @2613..2625
+      Variable 'aString' @2613..2620
+  Message unary 'printNl' @2628..2643
+    Variable 'anArray' @2628..2635
+  Cascade @2674..2784
+    Message unary 'new' @2675..2689
+      Variable 'Dictionary' @2675..2685
+    ;
+      Message keyword 'at:put:' @2675..2726
+        CascadeReceiver @2689..2689
+        Literal string "'name'" @2699..2705
+        Literal string "'GNU Smalltalk'" @2711..2726
+    ;
+      Message keyword 'at:put:' @2689..2770
+        CascadeReceiver @2689..2689
+        Literal string "'version'" @2736..2745
+        Message unary 'version' @2752..2769
+          Variable 'Smalltalk' @2752..2761
+    ;
+      Message unary 'yourself' @2689..2784
+        CascadeReceiver @2689..2689
+  Message keyword 'show:' @2827..2866
+    Variable 'Transcript' @2827..2837
+    Message unary 'monthName' @2845..2865
+      Message unary 'today' @2845..2855
+        Variable 'Date' @2845..2849
+  Message unary 'printNl' @3024..3057
+    Message unary 'name' @3024..3049
+      Message unary 'dayOfWeek' @3024..3044
+        Message unary 'today' @3024..3034
+          Variable 'Date' @3024..3028
+  Message unary 'printNl' @3101..3146
+    Message unary 'size' @3101..3138
+      Message keyword 'at:put:' @3101..3132
+        Message keyword 'new:' @3101..3113
+          Variable 'Array' @3101..3106
+          Literal integer "5" @3112..3113
+        Literal integer "1" @3119..3120
+        Literal string "'test'" @3126..3132
+  Message unary 'printNl' @3360..3386
+    Message keyword 'at:' @3360..3377
+      LiteralArray @3360..3371
+        Literal integer "10" @3362..3364
+        Literal integer "20" @3365..3367
+        Literal integer "30" @3368..3370
+      Literal integer "1" @3376..3377
+  Message unary 'printNl' @3422..3443
+    Message unary 'size' @3422..3434
+      Literal string "'hello'" @3422..3429
+  Message unary 'printNl' @3502..3526
+    Message unary 'value' @3502..3517
+      Block params=[] temps=[] @3502..3511
+        Message binary '*' @3504..3509
+          Literal integer "2" @3504..3505
+          Literal integer "3" @3508..3509
+
+--- diagnostics ---

--- a/server/test/__snapshots__/07_core_assignments_cascades.ast.txt
+++ b/server/test/__snapshots__/07_core_assignments_cascades.ast.txt
@@ -1,0 +1,108 @@
+Program temps=[var1, var2, var3, anObject] @101..1875
+  Assignment target='var1' @212..222
+    Literal integer "10" @220..222
+  Message unary 'printNl' @224..236
+    Variable 'var1' @224..228
+  Assignment target='var2' @303..312
+    Literal integer "20" @310..312
+  Message unary 'printNl' @314..326
+    Variable 'var2' @314..318
+  Assignment target='var3' @374..398
+    Message unary 'reversed' @382..398
+      Literal string "'hello'" @382..389
+  Message unary 'printNl' @400..412
+    Variable 'var3' @400..404
+  Assignment target='var1' @507..534
+    Assignment target='var2' @515..534
+      Assignment target='var3' @523..534
+        Literal integer "100" @531..534
+  Message unary 'printNl' @536..548
+    Variable 'var1' @536..540
+  Message unary 'printNl' @550..562
+    Variable 'var2' @550..554
+  Message unary 'printNl' @564..576
+    Variable 'var3' @564..568
+  Assignment target='var1' @579..603
+    Assignment target='var2' @586..603
+      Assignment target='var3' @593..603
+        Literal integer "200" @600..603
+  Message unary 'printNl' @605..617
+    Variable 'var1' @605..609
+  Message unary 'printNl' @619..631
+    Variable 'var2' @619..623
+  Message unary 'printNl' @633..645
+    Variable 'var3' @633..637
+  Assignment target='anObject' @834..867
+    Message unary 'new' @846..867
+      Variable 'OrderedCollection' @846..863
+  Cascade @889..932
+    Variable 'anObject' @889..897
+    ;
+      Message keyword 'add:' @889..908
+        CascadeReceiver @897..897
+        Literal integer "1" @907..908
+    ;
+      Message keyword 'add:' @897..920
+        CascadeReceiver @897..897
+        Literal integer "2" @919..920
+    ;
+      Message keyword 'add:' @897..932
+        CascadeReceiver @897..897
+        Literal integer "3" @931..932
+  Message unary 'printNl' @934..950
+    Variable 'anObject' @934..942
+  Cascade @994..1112
+    Variable 'anObject' @994..1002
+    ;
+      Message keyword 'addLast:' @994..1017
+        CascadeReceiver @1002..1002
+        Literal integer "4" @1016..1017
+    ;
+      Message unary 'reverse' @1002..1047
+        CascadeReceiver @1002..1002
+    ;
+      Message keyword 'addAll:' @1002..1085
+        CascadeReceiver @1002..1002
+        LiteralArray @1079..1085
+          Literal integer "5" @1081..1082
+          Literal integer "6" @1083..1084
+    ;
+      Message unary 'yourself' @1002..1112
+        CascadeReceiver @1002..1002
+  Message unary 'printNl' @1188..1204
+    Variable 'anObject' @1188..1196
+  Cascade @1485..1517
+    Variable 'anObject' @1485..1493
+    ;
+      Message unary 'removeFirst' @1485..1505
+        CascadeReceiver @1493..1493
+    ;
+      Message unary 'removeLast' @1493..1517
+        CascadeReceiver @1493..1493
+  Message unary 'printNl' @1519..1535
+    Variable 'anObject' @1519..1527
+  Cascade @1582..1719
+    Message keyword 'newFromPairs:' @1583..1646
+      Variable 'Dictionary' @1583..1593
+      DynamicArray @1608..1646
+        Message binary '->' @1610..1626
+          Literal string "'key1'" @1610..1616
+          Literal string "'val1'" @1620..1626
+        Message binary '->' @1628..1644
+          Literal string "'key2'" @1628..1634
+          Literal string "'val2'" @1638..1644
+    ;
+      Message keyword 'at:put:' @1583..1674
+        CascadeReceiver @1646..1646
+        Literal string "'key3'" @1656..1662
+        Literal string "'val3'" @1668..1674
+    ;
+      Message keyword 'removeKey:' @1646..1697
+        CascadeReceiver @1646..1646
+        Literal string "'key1'" @1691..1697
+    ;
+      Message unary 'printNl' @1646..1719
+        Message unary 'yourself' @1646..1711
+          CascadeReceiver @1646..1646
+
+--- diagnostics ---

--- a/server/test/__snapshots__/08_core_blocks.ast.txt
+++ b/server/test/__snapshots__/08_core_blocks.ast.txt
@@ -1,0 +1,314 @@
+Program temps=[aBlock, result, blockTaker, anArray, selectedArray, aCollection, transformedCollection] @79..4420
+  Assignment target='aBlock' @153..172
+    Block params=[] temps=[] @163..172
+      Message binary '+' @165..170
+        Literal integer "1" @165..166
+        Literal integer "1" @169..170
+  Assignment target='result' @174..196
+    Message unary 'value' @184..196
+      Variable 'aBlock' @184..190
+  Message unary 'printNl' @198..212
+    Variable 'result' @198..204
+  Assignment target='aBlock' @250..365
+    Block params=[] temps=[] @260..365
+      Message keyword 'show:' @266..299
+        Variable 'Transcript' @266..276
+        Literal string "'Inside block. '" @283..299
+      Message binary '*' @305..310
+        Literal integer "2" @305..306
+        Literal integer "3" @309..310
+  Assignment target='result' @367..389
+    Message unary 'value' @377..389
+      Variable 'aBlock' @377..383
+  Message unary 'printNl' @391..405
+    Variable 'result' @391..397
+  Assignment target='aBlock' @424..436
+    Block params=[] temps=[] @434..436
+  Assignment target='result' @438..460
+    Message unary 'value' @448..460
+      Variable 'aBlock' @448..454
+  Message unary 'printNl' @509..523
+    Variable 'result' @509..515
+  Assignment target='aBlock' @589..613
+    Block params=[x] temps=[] @599..613
+      Message binary '*' @606..611
+        Variable 'x' @606..607
+        Variable 'x' @610..611
+  Assignment target='result' @615..640
+    Message keyword 'value:' @625..640
+      Variable 'aBlock' @625..631
+      Literal integer "5" @639..640
+  Message unary 'printNl' @658..672
+    Variable 'result' @658..664
+  Assignment target='aBlock' @709..736
+    Block params=[a, b] temps=[] @719..736
+      Message binary '+' @729..734
+        Variable 'a' @729..730
+        Variable 'b' @733..734
+  Assignment target='result' @738..774
+    Message keyword 'value:value:' @748..774
+      Variable 'aBlock' @748..754
+      Literal integer "10" @762..764
+      Literal integer "20" @772..774
+  Message unary 'printNl' @802..816
+    Variable 'result' @802..808
+  Assignment target='aBlock' @875..912
+    Block params=[name] temps=[] @885..912
+      Message binary ',' @895..910
+        Literal string "'Hello, '" @895..904
+        Variable 'name' @906..910
+  Message unary 'printNl' @915..953
+    Message keyword 'value:' @915..944
+      Variable 'aBlock' @915..921
+      Literal string "'GNU Smalltalk'" @929..944
+  Assignment target='aBlock' @1015..1047
+    Block params=[val] temps=[] @1025..1047
+      Message unary 'inspect' @1034..1045
+        Variable 'val' @1034..1037
+  Assignment target='aBlock' @1182..1256
+    Block params=[] temps=[temp] @1192..1256
+      Assignment target='temp' @1207..1217
+        Literal integer "10" @1215..1217
+      Assignment target='temp' @1223..1239
+        Message binary '+' @1231..1239
+          Variable 'temp' @1231..1235
+          Literal integer "5" @1238..1239
+      Message binary '*' @1245..1253
+        Variable 'temp' @1245..1249
+        Literal integer "2" @1252..1253
+  Assignment target='result' @1258..1280
+    Message unary 'value' @1268..1280
+      Variable 'aBlock' @1268..1274
+  Message unary 'printNl' @1282..1296
+    Variable 'result' @1282..1288
+  Assignment target='aBlock' @1343..1443
+    Block params=[] temps=[temp1, temp2, sum] @1353..1443
+      Assignment target='temp1' @1379..1389
+        Literal integer "5" @1388..1389
+      Assignment target='temp2' @1395..1405
+        Literal integer "7" @1404..1405
+      Assignment target='sum' @1411..1431
+        Message binary '+' @1418..1431
+          Variable 'temp1' @1418..1423
+          Variable 'temp2' @1426..1431
+      Variable 'sum' @1437..1440
+  Assignment target='result' @1445..1467
+    Message unary 'value' @1455..1467
+      Variable 'aBlock' @1455..1461
+  Message unary 'printNl' @1469..1483
+    Variable 'result' @1469..1475
+  Assignment target='aBlock' @1520..1543
+    Block params=[] temps=[] @1530..1543
+      Message binary '+' @1536..1541
+        Literal integer "1" @1536..1537
+        Literal integer "1" @1540..1541
+  Message unary 'printNl' @1580..1601
+    Message unary 'value' @1580..1592
+      Variable 'aBlock' @1580..1586
+  Assignment target='aBlock' @1701..1786
+    Block params=[x, y] temps=[tempProduct] @1711..1786
+      Assignment target='tempProduct' @1741..1761
+        Message binary '*' @1756..1761
+          Variable 'x' @1756..1757
+          Variable 'y' @1760..1761
+      Message binary '+' @1767..1783
+        Variable 'tempProduct' @1767..1778
+        Literal integer "10" @1781..1783
+  Assignment target='result' @1788..1822
+    Message keyword 'value:value:' @1798..1822
+      Variable 'aBlock' @1798..1804
+      Literal integer "3" @1812..1813
+      Literal integer "4" @1821..1822
+  Message unary 'printNl' @1837..1851
+    Variable 'result' @1837..1843
+  Assignment target='aBlock' @2174..2319
+    Block params=[input] temps=[processedInput] @2184..2319
+      Assignment target='processedInput' @2218..2250
+        Message unary 'reversed' @2236..2250
+          Variable 'input' @2236..2241
+      Cascade @2256..2291
+        Variable 'Transcript' @2256..2266
+        ;
+          Message keyword 'show:' @2256..2287
+            CascadeReceiver @2266..2266
+            Variable 'processedInput' @2273..2287
+        ;
+          Message unary 'cr' @2266..2291
+            CascadeReceiver @2266..2266
+      Message unary 'size' @2297..2316
+        Variable 'processedInput' @2297..2311
+  Message unary 'printNl' @2322..2351
+    Message keyword 'value:' @2322..2342
+      Variable 'aBlock' @2322..2328
+      Literal string "'test'" @2336..2342
+  Assignment target='aBlock' @2436..2532
+    Block params=[str1, str2] temps=[] @2446..2532
+      Message binary ',' @2514..2529
+        Message binary ',' @2514..2523
+          Variable 'str1' @2514..2518
+          Literal string "' '" @2520..2523
+        Variable 'str2' @2525..2529
+  Assignment target='result' @2534..2580
+    Message keyword 'value:value:' @2544..2580
+      Variable 'aBlock' @2544..2550
+      Literal string "'Hello'" @2558..2565
+      Literal string "'World'" @2573..2580
+  Message unary 'printNl' @2582..2596
+    Variable 'result' @2582..2588
+  Assignment target='aBlock' @2626..2834
+    Block params=[] temps=[outerVar] @2636..2834
+      Assignment target='outerVar' @2655..2670
+        Literal integer "100" @2667..2670
+      Message unary 'value' @2676..2807
+        Block params=[] temps=[innerVar] @2676..2801
+          Assignment target='innerVar' @2699..2713
+            Literal integer "20" @2711..2713
+          Message binary '+' @2723..2742
+            Variable 'outerVar' @2723..2731
+            Variable 'innerVar' @2734..2742
+  Assignment target='result' @2836..2858
+    Message unary 'value' @2846..2858
+      Variable 'aBlock' @2846..2852
+  Message unary 'printNl' @2860..2874
+    Variable 'result' @2860..2866
+  Assignment target='blockTaker' @2973..3027
+    Block params=[actionBlock] temps=[] @2987..3027
+      Message binary '+' @3004..3025
+        Message unary 'value' @3004..3021
+          Variable 'actionBlock' @3004..3015
+        Literal integer "1" @3024..3025
+  Assignment target='result' @3029..3066
+    Message keyword 'value:' @3039..3066
+      Variable 'blockTaker' @3039..3049
+      Block params=[] temps=[] @3057..3066
+        Message binary '*' @3059..3064
+          Literal integer "5" @3059..3060
+          Literal integer "5" @3063..3064
+  Message unary 'printNl' @3068..3082
+    Variable 'result' @3068..3074
+  Message unary 'printNl' @3122..3158
+    Message unary 'value' @3122..3149
+      Block params=[] temps=[] @3122..3143
+        Message unary 'value' @3124..3141
+          Block params=[] temps=[] @3124..3135
+            Message binary '+' @3126..3133
+              Literal integer "10" @3126..3128
+              Literal integer "10" @3131..3133
+  Assignment target='aBlock' @3221..3329
+    Block params=[x] temps=[y] @3231..3329
+      Assignment target='y' @3245..3273
+        Message keyword 'value:' @3250..3273
+          Block params=[z] temps=[] @3250..3264
+            Message binary '*' @3257..3262
+              Variable 'z' @3257..3258
+              Literal integer "2" @3261..3262
+          Variable 'x' @3272..3273
+      Message binary '+' @3322..3327
+        Variable 'y' @3322..3323
+        Literal integer "5" @3326..3327
+  Message unary 'printNl' @3332..3356
+    Message keyword 'value:' @3332..3347
+      Variable 'aBlock' @3332..3338
+      Literal integer "7" @3346..3347
+  Message keyword 'to:do:' @3401..3476
+    Literal integer "1" @3401..3402
+    Literal integer "3" @3407..3408
+    Block params=[i] temps=[] @3413..3476
+      Cascade @3424..3473
+        Variable 'Transcript' @3424..3434
+        ;
+          Message keyword 'show:' @3424..3459
+            CascadeReceiver @3434..3434
+            Literal string "'Loop iteration: '" @3441..3459
+        ;
+          Message keyword 'print:' @3434..3469
+            CascadeReceiver @3434..3434
+            Variable 'i' @3468..3469
+        ;
+          Message unary 'cr' @3434..3473
+            CascadeReceiver @3434..3434
+  Message keyword 'ifTrue:' @3479..3524
+    Variable 'true' @3479..3483
+    Block params=[] temps=[] @3492..3524
+      Message unary 'printNl' @3494..3522
+        Literal string "'Condition is true.'" @3494..3514
+  Message keyword 'ifFalse:ifTrue:' @3527..3614
+    Variable 'false' @3527..3532
+    Block params=[] temps=[] @3542..3575
+      Message unary 'printNl' @3544..3573
+        Literal string "'Condition is false.'" @3544..3565
+    Block params=[] temps=[] @3590..3614
+  Assignment target='anArray' @3687..3712
+    LiteralArray @3698..3712
+      Literal integer "1" @3700..3701
+      Literal integer "2" @3702..3703
+      Literal integer "3" @3704..3705
+      Literal integer "4" @3706..3707
+      Literal integer "5" @3708..3709
+      Literal integer "6" @3710..3711
+  Assignment target='selectedArray' @3714..3770
+    Message keyword 'select:' @3731..3770
+      Variable 'anArray' @3731..3738
+      Block params=[each] temps=[] @3747..3770
+        Message unary 'isEven' @3757..3768
+          Variable 'each' @3757..3761
+  Message unary 'printNl' @3772..3793
+    Variable 'selectedArray' @3772..3785
+  Assignment target='aCollection' @3924..3967
+    LiteralArray @3939..3967
+      Literal integer "1" @3941..3942
+      Literal string "'special'" @3943..3952
+      Literal integer "2" @3953..3954
+      Literal string "'another'" @3955..3964
+      Literal integer "3" @3965..3966
+  Assignment target='transformedCollection' @3969..4102
+    Message keyword 'collect:' @3994..4102
+      Variable 'aCollection' @3994..4005
+      Block params=[item] temps=[] @4015..4102
+        Message keyword 'ifTrue:ifFalse:' @4026..4100
+          Message unary 'isString' @4026..4039
+            Variable 'item' @4026..4030
+          Block params=[] temps=[] @4048..4075
+            Message unary 'value' @4050..4073
+              Block params=[] temps=[] @4050..4067
+                Message unary 'reversed' @4052..4065
+                  Variable 'item' @4052..4056
+          Block params=[] temps=[] @4085..4100
+            Message binary '*' @4087..4098
+              Variable 'item' @4087..4091
+              Variable 'item' @4094..4098
+  Message unary 'printNl' @4104..4133
+    Variable 'transformedCollection' @4104..4125
+  Assignment target='aBlock' @4181..4230
+    Block params=[] temps=[] @4191..4230
+      Return @4193..4197
+        Literal integer "42" @4195..4197
+      Message unary 'printNl' @4199..4228
+        Literal string "'This is not reached'" @4199..4220
+  Message unary 'printNl' @4233..4254
+    Message unary 'value' @4233..4245
+      Variable 'aBlock' @4233..4239
+  Assignment target='aBlock' @4257..4337
+    Block params=[x] temps=[] @4267..4337
+      Message keyword 'ifTrue:ifFalse:' @4274..4312
+        Message binary '>' @4274..4279
+          Variable 'x' @4274..4275
+          Literal integer "0" @4278..4279
+        Block params=[] temps=[] @4288..4295
+          Return @4290..4293
+            Variable 'x' @4292..4293
+        Block params=[] temps=[] @4305..4312
+          Return @4307..4310
+            Literal integer "0" @4309..4310
+      Message unary 'printNl' @4314..4335
+        Literal string "'Unreachable'" @4314..4327
+  Message unary 'printNl' @4340..4364
+    Message keyword 'value:' @4340..4355
+      Variable 'aBlock' @4340..4346
+      Literal integer "5" @4354..4355
+  Message unary 'printNl' @4367..4392
+    Message keyword 'value:' @4367..4383
+      Variable 'aBlock' @4367..4373
+      Literal integer "-5" @4381..4383
+
+--- diagnostics ---

--- a/server/test/parser.test.ts
+++ b/server/test/parser.test.ts
@@ -1,0 +1,261 @@
+// Unit + snapshot tests for the GNU Smalltalk expression parser (US-411, slice 2).
+// Runs in Node via tsx. Same idiom as lexer.test.ts.
+//
+//   npm run test:parser                # run (lexer + parser suites)
+//   npm run test:parser -- --update    # regenerate the AST snapshots
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '../src/parser/parser.ts';
+import {
+  NodeKind,
+  type CascadeNode,
+  type MessageNode,
+  type Node,
+  type AssignmentNode,
+  type BlockNode,
+} from '../src/parser/ast.ts';
+
+const UPDATE = process.argv.includes('--update');
+const ROOT = process.cwd();
+const FIXTURE_DIR = path.join(ROOT, 'docs/research/gst-syntax/test-cases');
+const SNAPSHOT_DIR = path.join(ROOT, 'server/test/__snapshots__');
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+const stmts = (src: string): Node[] => parse(src).ast.statements;
+const firstStmt = (src: string): Node => {
+  const s = stmts(src);
+  assert.ok(s.length >= 1, `expected a statement for ${JSON.stringify(src)}`);
+  return s[0] as Node;
+};
+function asMessage(n: Node): MessageNode {
+  assert.equal(n.kind, NodeKind.Message);
+  return n as MessageNode;
+}
+
+// --- Precedence (AC2) --------------------------------------------------------
+test('binary is left-associative: 1 + 2 * 3 => (1 + 2) * 3', () => {
+  const m = asMessage(firstStmt('1 + 2 * 3'));
+  assert.equal(m.selector, '*');
+  const lhs = asMessage(m.receiver);
+  assert.equal(lhs.selector, '+');
+});
+
+test('unary binds tighter than binary: 2 * 3 factorial', () => {
+  const m = asMessage(firstStmt('2 * 3 factorial'));
+  assert.equal(m.selector, '*');
+  const arg = asMessage(m.arguments[0] as Node);
+  assert.equal(arg.messageType, 'unary');
+  assert.equal(arg.selector, 'factorial');
+});
+
+test('keyword is loosest and joins parts: a foo: 1 + 2 bar: 3', () => {
+  const m = asMessage(firstStmt('a foo: 1 + 2 bar: 3'));
+  assert.equal(m.messageType, 'keyword');
+  assert.equal(m.selector, 'foo:bar:');
+  assert.equal(m.arguments.length, 2);
+  assert.equal(asMessage(m.arguments[0] as Node).selector, '+');
+});
+
+test('a lone pipe is a binary selector: true | false', () => {
+  const m = asMessage(firstStmt('true | false'));
+  assert.equal(m.messageType, 'binary');
+  assert.equal(m.selector, '|');
+});
+
+// --- Assignment & return (AC2) ----------------------------------------------
+test('assignment is right-associative: a := b := 1', () => {
+  const a = firstStmt('a := b := 1') as AssignmentNode;
+  assert.equal(a.kind, NodeKind.Assignment);
+  assert.equal(a.target.name, 'a');
+  const inner = a.value as AssignmentNode;
+  assert.equal(inner.kind, NodeKind.Assignment);
+  assert.equal(inner.target.name, 'b');
+});
+
+test('legacy underscore assignment parses', () => {
+  const a = firstStmt('x _ 20') as AssignmentNode;
+  assert.equal(a.kind, NodeKind.Assignment);
+  assert.equal(a.target.name, 'x');
+});
+
+test('caret return statement', () => {
+  const r = firstStmt('^ 42');
+  assert.equal(r.kind, NodeKind.Return);
+});
+
+// --- Cascades (AC2) ----------------------------------------------------------
+test('cascade keeps the first send receiver; segments are message chains', () => {
+  const c = firstStmt('x foo; bar; baz: 1') as CascadeNode;
+  assert.equal(c.kind, NodeKind.Cascade);
+  assert.equal((c.receiver as { name?: string }).name, 'x');
+  const segs = c.messages.map((m) => m as MessageNode);
+  assert.deepEqual(segs.map((s) => s.selector), ['foo', 'bar', 'baz:']);
+  assert.deepEqual(segs.map((s) => s.messageType), ['unary', 'unary', 'keyword']);
+  // Each segment is rooted at the zero-width cascade-receiver marker.
+  assert.equal(segs[0]?.receiver.kind, NodeKind.CascadeReceiver);
+});
+
+test('cascade segment can be a chain (yourself printNl)', () => {
+  const c = firstStmt('d at: 1; yourself printNl') as CascadeNode;
+  const last = c.messages.at(-1) as MessageNode;
+  assert.equal(last.selector, 'printNl');
+  assert.equal((last.receiver as MessageNode).selector, 'yourself');
+});
+
+// --- Blocks (AC2) ------------------------------------------------------------
+test('block with params and temporaries', () => {
+  const b = firstStmt('[ :x | | t | t := x. t ]') as BlockNode;
+  assert.equal(b.kind, NodeKind.Block);
+  assert.deepEqual(b.parameters.map((p) => p.name), ['x']);
+  assert.deepEqual(b.temporaries.map((t) => t.name), ['t']);
+  assert.equal(b.statements.length, 2);
+});
+
+test('empty temporaries: [ | | 1 ]', () => {
+  const b = firstStmt('[ | | 1 ]') as BlockNode;
+  assert.deepEqual(b.temporaries, []);
+  assert.equal(b.statements.length, 1);
+});
+
+test('doubled-pipe separator with no temporaries: [ :a :b || a ]', () => {
+  const b = firstStmt('[ :a :b || a ]') as BlockNode;
+  assert.deepEqual(b.parameters.map((p) => p.name), ['a', 'b']);
+  assert.deepEqual(b.temporaries, []);
+  assert.equal(b.statements.length, 1);
+  assert.equal((b.statements[0] as { name?: string }).name, 'a');
+});
+
+test('block with explicit return', () => {
+  const b = firstStmt('[ ^42 ]') as BlockNode;
+  assert.equal(b.statements[0]?.kind, NodeKind.Return);
+});
+
+// --- Collection primaries (AC2) ---------------------------------------------
+test('literal array, byte array, dynamic array', () => {
+  assert.equal(firstStmt('#(1 $a #sym)').kind, NodeKind.LiteralArray);
+  assert.equal(firstStmt('#[1 2 255]').kind, NodeKind.ByteArray);
+  const d = firstStmt('{ 1 + 1. 2 }');
+  assert.equal(d.kind, NodeKind.DynamicArray);
+  assert.equal((d as { elements: Node[] }).elements.length, 2);
+});
+
+// --- Recovery / never-throws (AC4 preview, required for AC2 robustness) ------
+test('malformed input recovers with an Error node and never throws', () => {
+  const r = parse(') + + .');
+  assert.equal(r.ast.kind, NodeKind.Program);
+  assert.ok(r.diagnostics.length >= 1, 'expected at least one diagnostic');
+  // Recovery yields Error nodes somewhere in the tree (here, nested in a binary send).
+  assert.ok(
+    JSON.stringify(r.ast).includes(`"kind":"${NodeKind.Error}"`),
+    'expected an Error node somewhere in the AST',
+  );
+});
+
+test('parsing every fixture returns a Program and never throws', () => {
+  for (const file of fs.readdirSync(FIXTURE_DIR)) {
+    if (!file.endsWith('.st')) continue;
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, file), 'utf8');
+    const { ast } = parse(src);
+    assert.equal(ast.kind, NodeKind.Program, `${file} should parse to a Program`);
+  }
+});
+
+// --- AST snapshots over the expression fixtures (AC2) ------------------------
+const SNAPSHOT_FIXTURES = [
+  '06_core_message_sends',
+  '07_core_assignments_cascades',
+  '08_core_blocks',
+];
+
+function names(list: ReadonlyArray<{ name: string }>): string {
+  return list.map((n) => n.name).join(', ');
+}
+
+function dump(node: Node, indent: string, out: string[]): void {
+  const at = `@${node.start}..${node.end}`;
+  const child = indent + '  ';
+  switch (node.kind) {
+    case NodeKind.Program:
+      out.push(`${indent}Program temps=[${names(node.temporaries)}] ${at}`);
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
+    case NodeKind.Block:
+      out.push(`${indent}Block params=[${names(node.parameters)}] temps=[${names(node.temporaries)}] ${at}`);
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
+    case NodeKind.Return:
+      out.push(`${indent}Return ${at}`);
+      dump(node.value, child, out);
+      break;
+    case NodeKind.Assignment:
+      out.push(`${indent}Assignment target='${node.target.name}' ${at}`);
+      dump(node.value, child, out);
+      break;
+    case NodeKind.Message:
+      out.push(`${indent}Message ${node.messageType} '${node.selector}' ${at}`);
+      dump(node.receiver, child, out);
+      node.arguments.forEach((a) => dump(a, child, out));
+      break;
+    case NodeKind.Cascade:
+      out.push(`${indent}Cascade ${at}`);
+      dump(node.receiver, child, out);
+      node.messages.forEach((m) => {
+        out.push(`${child};`);
+        dump(m, child + '  ', out);
+      });
+      break;
+    case NodeKind.CascadeReceiver:
+      out.push(`${indent}CascadeReceiver ${at}`);
+      break;
+    case NodeKind.Variable:
+      out.push(`${indent}Variable '${node.name}' ${at}`);
+      break;
+    case NodeKind.Literal:
+      out.push(`${indent}Literal ${node.literalKind} ${JSON.stringify(node.value)} ${at}`);
+      break;
+    case NodeKind.LiteralArray:
+    case NodeKind.ByteArray:
+    case NodeKind.DynamicArray:
+      out.push(`${indent}${node.kind} ${at}`);
+      node.elements.forEach((e) => dump(e, child, out));
+      break;
+    case NodeKind.Error:
+      out.push(`${indent}Error ${JSON.stringify(node.message)} ${at}`);
+      break;
+  }
+}
+
+function serialize(src: string): string {
+  const { ast, diagnostics } = parse(src);
+  const out: string[] = [];
+  dump(ast, '', out);
+  const diag = diagnostics.map((d) => `${d.severity} ${JSON.stringify(d.message)} @${d.start}..${d.end}`);
+  return [...out, '', '--- diagnostics ---', ...diag, ''].join('\n');
+}
+
+for (const name of SNAPSHOT_FIXTURES) {
+  test(`ast snapshot: ${name}`, () => {
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, `${name}.st`), 'utf8');
+    const actual = serialize(src);
+    const snapPath = path.join(SNAPSHOT_DIR, `${name}.ast.txt`);
+    if (UPDATE) {
+      fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+      fs.writeFileSync(snapPath, actual);
+      console.log(`    (updated ${path.relative(ROOT, snapPath)})`);
+      return;
+    }
+    if (!fs.existsSync(snapPath)) {
+      throw new Error(`Missing snapshot ${path.relative(ROOT, snapPath)}; run: npm run test:parser -- --update`);
+    }
+    assert.equal(actual, fs.readFileSync(snapPath, 'utf8'), `AST snapshot drift for ${name}; review, then: npm run test:parser -- --update`);
+  });
+}
+
+console.log(`parser: ${passed} tests passed.`);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -1,0 +1,4 @@
+// Entry point for the parser test suites (lexer + parser), so a single
+// `npm run test:parser [-- --update]` runs both and shares process.argv.
+import './lexer.test.ts';
+import './parser.test.ts';

--- a/specs/US-411-Parser-And-Symbol-Table/plan.md
+++ b/specs/US-411-Parser-And-Symbol-Table/plan.md
@@ -76,3 +76,62 @@ Hand-written single-pass scanner, mirroring the `char_table` dispatch from
 - Slice exit: lexer-relevant fixtures snapshot cleanly with no `Error` token on well-formed input.
   (Full-story `npm run eval`, kernel smoke test, and `verification.md` are completed at the end of
   the story, after the symbol-table slice.)
+
+---
+
+# Slice 2 — Expression parser (AC2)
+
+**Status:** in progress (slice 1 merged in PR #31). Branch `feature/US-411-expression-parser`.
+
+## Summary
+A recursive-descent parser over the slice-1 token stream that produces an **AST with positions**
+for the ANSI expression/statement core: literals & primaries, message sends with
+**unary > binary > keyword** precedence, assignment chains, cascades, and blocks (params +
+temporaries + body). Like the lexer it **never throws** — on a malformed statement it records a
+diagnostic, emits an `Error` node, and synchronizes to the next `.`/`]`/`!`/EOF, always returning
+an AST.
+
+## Scope refinement
+- **In:** `parse(source) → { ast, diagnostics }`; `Program` = optional `| temps |` + statement
+  sequence; statements (`^expr` / `expr`); assignment (right-assoc, `:=` and `_`); cascades;
+  message precedence; blocks; primaries — variables, scalar literals, literal arrays `#(…)`, byte
+  arrays `#[…]`, dynamic arrays `{…}`, parenthesized expressions.
+- **Out (moved to slice 3):** **method patterns + `<primitive: …>`** — these only appear at a
+  container boundary (chunk `!sel…!` / brace `Foo >> sel [ … ]`), which slice 3 introduces. Slice 2
+  delivers the statement-sequence/expression core that method bodies reuse. (AC2 names method
+  patterns; the spec stays the source of truth and this is a documented decomposition, re-confirmed
+  in slice 3's plan.)
+
+## Approach — files
+- **`server/src/parser/ast.ts`** — `NodeKind` + node interfaces, all carrying `start/end` offsets
+  and `startPos/endPos` (reusing `Position` from `token.ts`): `Program`, `Block`, `Return`,
+  `Assignment`, `Message` (receiver, selector, arguments, `messageType`), `Cascade`, `Variable`,
+  `Literal` (scalar), `LiteralArray`, `ByteArray`, `DynamicArray`, and `ErrorNode`.
+- **`server/src/parser/parser.ts`** — `parse(source): { ast, diagnostics }`. Tokenizes via the
+  lexer, drops `Comment` trivia, then a `Parser` walks the token array. Precedence climb:
+  `parseExpression` (assignment) → `parseCascade` → `parseKeywordMessage` → `parseBinaryMessage`
+  → `parseUnaryMessage` → `parsePrimary`.
+- **`server/test/parser.test.ts`** + `__snapshots__/*.ast.txt` — unit assertions + AST snapshots
+  over fixtures `06,07,08` (message sends, assignments/cascades, blocks).
+
+## Key parsing decisions (recorded so snapshots are intentional)
+- **Precedence**: unary binds tightest (a run of trailing `Identifier` sends), then binary
+  (left-assoc run of `BinarySelector` — **and a lone `Pipe`** acting as the `|` binary selector,
+  e.g. `true | false`), then keyword (one keyword message whose args are binary-level expressions).
+- **Assignment** is right-associative and only when `Identifier` is immediately followed by
+  `Assign`; `var1 := var2 := 100` nests. Covers both `:=` and `_`.
+- **Cascades**: `recv msg ; msg ; …` — the cascade receiver is the *receiver of the first message
+  send*; subsequent `;`-messages target it. A `Cascade` node holds `receiver` + `messages[]`.
+- **Block header** (the subtle part): `params = (':' Identifier)*`; if params present, consume one
+  `|` arg-terminator; then the body is a statement sequence that itself parses an optional
+  `| temps |`. Temporaries are only committed when a **closing `|`** is confirmed by lookahead
+  (`looksLikeTemporaries`), so `[ :a :b || a , b ]` (doubled-pipe separator, no temps) and
+  `[ :x | | t | … ]` (separator then real temps) both parse — and `[ | | … ]` is empty temps.
+- **Trivia**: `Comment` tokens are filtered before parsing; positions still come from real tokens.
+- **Recovery**: `parsePrimary` on an unexpected token emits an `ErrorNode` + diagnostic and the
+  statement loop synchronizes on `.`/`]`/`!`/EOF — never throws.
+
+## Verification
+- `npm run test:parser` covers lexer **and** parser suites (unit + AST snapshots for `06,07,08`).
+- `check-types` + `lint` clean. Slice exit: fixtures `06,07,08` produce no `Error` node /
+  diagnostic; recovery tests prove no-throw on malformed input.

--- a/specs/US-411-Parser-And-Symbol-Table/tasks.md
+++ b/specs/US-411-Parser-And-Symbol-Table/tasks.md
@@ -34,9 +34,19 @@ S3 GST containers (AC3) → S4 symbol table + recovery (AC4, AC5).
 - [x] T040 `npm run check-types`, `npm run lint`, `npm run test:parser` all green.
 - [ ] T041 Open slice-1 PR (links #23); lexer fixtures snapshot cleanly, no `Error` on well-formed input.
 
+## Phase 5 — Slice 2: Expression parser (AC2) — branch `feature/US-411-expression-parser`
+- [x] T050 `server/src/parser/ast.ts` — `NodeKind` + node interfaces with offsets + LSP positions (`Program`, `Block`, `Return`, `Assignment`, `Message`, `Cascade`, `CascadeReceiver`, `Variable`, `Literal`, `LiteralArray`, `ByteArray`, `DynamicArray`, `ErrorNode`).
+- [x] T051 `server/src/parser/parser.ts` — `parse()`: tokenize, drop `Comment` trivia, `Program` = `| temps |` (incl. interspersed REPL redeclarations) + statement sequence; never-throws scaffold with synchronization on `.`/`]`/`!`/EOF.
+- [x] T052 Primaries: variables, scalar literals, **negative numeric literals** (folded `-` from the lexer), `#(…)` literal array, `#[…]` byte array, `{…}` dynamic array, `(…)` parenthesized. *(AC2)*
+- [x] T053 Message precedence: unary run → binary run (incl. lone `|`) → single keyword message. *(AC2)*
+- [x] T054 Assignment (right-assoc, `:=`/`_`) and `^` return statements. *(AC2)*
+- [x] T055 Cascades: receiver = first send's receiver; segments are full message **chains** rooted at a `CascadeReceiver` marker. *(AC2)*
+- [x] T056 Blocks: params `(':' id)*`, arg-terminator `|`, `| temps |` with `looksLikeTemporaries` lookahead (handles `||` separator and empty `| |`), body sequence. *(AC2)*
+- [x] T057 `server/test/parser.test.ts` — unit assertions per construct + recovery tests (malformed statement → `ErrorNode` + diagnostic, no throw) + AST snapshots over fixtures `06,07,08`; `run.ts` runs lexer+parser suites under `test:parser`.
+- [x] T058 `check-types`, `lint`, `test:parser` green; open slice-2 PR (links #23).
+
 ## Later slices (tracked here, planned per-slice when started)
-- [ ] S2 Expression parser (AC2): `ast.ts`, `parser.ts` (unary>binary>keyword, cascades, blocks, statements).
-- [ ] S3 GST containers (AC3): `Container` interface, brace + chunk plug-ins, method patterns + primitives.
+- [ ] S3 GST containers (AC3): `Container` interface, brace + chunk plug-ins, **method patterns + primitives** (moved here from S2, see plan.md).
 - [ ] S4 Symbol table + recovery (AC4, AC5): `symbolTable.ts`, synchronization, kernel smoke test.
 
 ## Story-level Done (after S4)


### PR DESCRIPTION
## Summary

Second slice of the US-411 front-end: a **recursive-descent parser** over the slice-1 token stream that produces an **AST with positions** plus a diagnostics list. `parse(source) → { ast, diagnostics }` covers the ANSI expression/statement core and **never throws** — a malformed statement records a diagnostic, emits an `Error` node, and the statement loop synchronizes on `.`/`]`/`!`/EOF, always returning a `Program`.

**Closes:** _n/a — slice 2 of 4; does not close the story_ &nbsp;|&nbsp; **Story:** US-411 (#23) &nbsp;|&nbsp; **ADR (if any):** ADR-0001

Scope is **AC2**. Builds on slice 1 (lexer, PR #31, merged).

### What's here
- `server/src/parser/ast.ts` — `NodeKind` + node interfaces (`Program`, `Block`, `Return`, `Assignment`, `Message`, `Cascade`/`CascadeReceiver`, `Variable`, `Literal`, `LiteralArray`, `ByteArray`, `DynamicArray`, `Error`), every node carrying byte offsets + LSP positions.
- `server/src/parser/parser.ts` — precedence climb `primary > unary > binary > keyword > cascade > assignment`:
  - **Precedence**: unary tightest, binary left-assoc (a lone `|` acts as the `|` binary selector), one keyword message joining its parts.
  - **Assignment** right-assoc (`:=` and legacy `_`); `^` returns.
  - **Cascades**: receiver = the first send's receiver; each `;` segment is a full message **chain** rooted at a zero-width `CascadeReceiver` marker (so `yourself printNl` parses, without duplicating the receiver).
  - **Blocks**: params `(':' id)*`, arg-terminator `|`, `| temps |` via a `looksLikeTemporaries` lookahead that disambiguates the `||` separator and empty `| |` forms.
  - **Primaries**: variables, scalar literals, **negative numeric literals** (folding the lexer's leading `-`, which it emits as a binary selector), `#( … )`, `#[ … ]`, `{ … }`, parenthesized.
  - Interspersed REPL-style `| temps |` redeclarations are merged into the sequence.
- `server/test/parser.test.ts` + `__snapshots__/*.ast.txt` — 19 unit tests (precedence, assignment, cascades incl. chains, blocks, recovery) + a **no-throw sweep over all 15 fixtures** + AST snapshots over `06,07,08`. New `run.ts` runs the lexer + parser suites under `test:parser`.

### Scope note
**Method patterns + `<primitive: …>` move to slice 3** — they appear only at a container boundary (chunk `!sel…!` / brace `Foo >> sel [ … ]`), which slice 3 introduces. Slice 2 delivers the expression/statement/block core that method bodies reuse. Recorded in `specs/US-411-*/plan.md`.

## Output Eval — *is the artifact right?*

- [x] Acceptance Criteria for this slice met — **AC2** (precedence, cascades, blocks, primaries; never-throws recovery).
- [x] Output eval added — AST-snapshot harness over fixtures `06,07,08` (**zero diagnostics / zero Error nodes** on well-formed input), under `npm run test:parser` (45 checks total with the lexer suite). Grammar `npm run eval` unaffected.
- [ ] CI green on Linux, macOS, Windows — _pending the Actions run on this PR._
- [ ] Manual QA in an Extension Development Host — **N/A**: parser is internal, not yet wired to a provider.
- [ ] [Output rubric](evals/rubrics/output-eval.md) — for reviewer.

Local: `check-types` ✓ · `lint` ✓ · `test:parser` 45/45 ✓ · `test:client` 6/6 ✓ · `test:server` ✓.

## Trajectory Eval — *was it produced the right way?*

- [x] Traces to US-411/#23; slice-2 `plan.md`/`tasks.md` authored before coding; scope refinement (method patterns → slice 3) recorded.
- [x] Tests written with the change; parsing decisions documented; no drift left behind.
- [x] Conventional scoped commit; outcomes reported faithfully (CI box left unchecked until it runs).
- [ ] [Trajectory rubric](evals/rubrics/trajectory-eval.md): ☐ Sound ☐ Sound w/ notes ☐ Unsound — for reviewer.

## Human sign-off

- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice (story DoD completes after slice 4).