### PR TITLE
feat(US-411): GST brace container format (slice 3a)

### DIFF
--- a/server/src/parser/ast.ts
+++ b/server/src/parser/ast.ts
@@ -24,6 +24,14 @@ export enum NodeKind {
   CascadeReceiver = 'CascadeReceiver',
   /** A variable / identifier reference. */
   Variable = 'Variable',
+  /** A GST scoped definition: `<expr> [ … ]` (subclass / namespace / extend / class-side scope). */
+  Definition = 'Definition',
+  /** A GST scoped method: `Class [class] >> pattern [ … ]`. */
+  MethodDefinition = 'MethodDefinition',
+  /** A `<…>` attribute / pragma (e.g. `<primitive: 80>`, `<gst.methodCategory: '…'>`). */
+  Pragma = 'Pragma',
+  /** A `| a b |` instance-variable declaration inside a class body. */
+  InstanceVariables = 'InstanceVariables',
   /** A scalar literal: integer, float, scaled decimal, string, symbol, character. */
   Literal = 'Literal',
   /** `#( … )`. */
@@ -114,6 +122,45 @@ export interface VariableNode extends NodeBase {
   readonly name: string;
 }
 
+/** How a `<expr> [ … ]` scoped definition reads, derived from the defining expression. */
+export type DefinitionKind = 'subclass' | 'namespace' | 'extend' | 'classScope' | 'scoped';
+
+export interface DefinitionNode extends NodeBase {
+  readonly kind: NodeKind.Definition;
+  readonly definitionKind: DefinitionKind;
+  /** The expression preceding the `[` (e.g. `Object subclass: #Foo`). */
+  readonly definer: Node;
+  /** The class/namespace name, when derivable from the definer's symbol argument. */
+  readonly name?: string;
+  /** Body items: instance-var decls, pragmas, method/nested definitions, statements. */
+  readonly body: Node[];
+}
+
+export interface MethodDefinitionNode extends NodeBase {
+  readonly kind: NodeKind.MethodDefinition;
+  /** The owning class reference (e.g. `Foo`); absent for the short form `sel [ … ]` inside a body. */
+  readonly target?: Node;
+  /** True for `Foo class >> …`. */
+  readonly classSide: boolean;
+  readonly selector: string;
+  readonly messageType: MessageType;
+  readonly parameters: NameRef[];
+  readonly pragmas: PragmaNode[];
+  readonly temporaries: NameRef[];
+  readonly statements: Node[];
+}
+
+export interface PragmaNode extends NodeBase {
+  readonly kind: NodeKind.Pragma;
+  readonly selector: string;
+  readonly arguments: Node[];
+}
+
+export interface InstanceVariablesNode extends NodeBase {
+  readonly kind: NodeKind.InstanceVariables;
+  readonly names: NameRef[];
+}
+
 export interface LiteralNode extends NodeBase {
   readonly kind: NodeKind.Literal;
   readonly literalKind: LiteralKind;
@@ -133,6 +180,8 @@ export interface ByteArrayNode extends NodeBase {
 
 export interface DynamicArrayNode extends NodeBase {
   readonly kind: NodeKind.DynamicArray;
+  /** Constructor-local temporaries (`{ | t | … }`); usually empty. */
+  readonly temporaries: NameRef[];
   readonly elements: Node[];
 }
 
@@ -150,6 +199,10 @@ export type Node =
   | CascadeNode
   | CascadeReceiverNode
   | VariableNode
+  | DefinitionNode
+  | MethodDefinitionNode
+  | PragmaNode
+  | InstanceVariablesNode
   | LiteralNode
   | LiteralArrayNode
   | ByteArrayNode

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -23,11 +23,14 @@ import {
   type BlockNode,
   type CascadeNode,
   type CascadeReceiverNode,
+  type DefinitionKind,
   type LiteralKind,
   type MessageNode,
   type MessageType,
+  type MethodDefinitionNode,
   type NameRef,
   type Node,
+  type PragmaNode,
   type ProgramNode,
   type VariableNode,
 } from './ast';
@@ -37,6 +40,11 @@ const NUMBER_KINDS = new Set<TokenKind>([
   TokenKind.Float,
   TokenKind.ScaledDecimal,
 ]);
+
+/** GST definitions are not `.`-separated from what follows them. */
+function isDefinition(node: Node): boolean {
+  return node.kind === NodeKind.Definition || node.kind === NodeKind.MethodDefinition;
+}
 
 export interface ParseResult {
   readonly ast: ProgramNode;
@@ -103,8 +111,9 @@ class Parser {
       statements.push(stmt);
       if (this.at(TokenKind.Period)) {
         this.advance();
-      } else if (!this.atEnd() && !this.at(stop) && !this.at(TokenKind.Bang)) {
-        // A statement should be followed by `.`, the stop token, or EOF.
+      } else if (!this.atEnd() && !this.at(stop) && !this.at(TokenKind.Bang) && !isDefinition(stmt)) {
+        // A plain statement should be followed by `.`, the stop token, or EOF.
+        // GST definitions (`… [ … ]`) are not `.`-separated from what follows.
         if (stmt.kind !== NodeKind.Error) {
           this.diag('Expected "." after statement', this.current());
         }
@@ -155,13 +164,277 @@ class Parser {
   }
 
   private parseStatement(): Node {
+    // GST brace container: `Class [class] >> pattern [ … ]` method definition.
+    if (this.looksLikeMethodDef()) {
+      return this.parseMethodDefinition();
+    }
     if (this.at(TokenKind.Caret)) {
       const startTok = this.current();
       this.advance(); // ^
       const value = this.parseExpression();
       return { kind: NodeKind.Return, value, ...this.span(startTok) };
     }
-    return this.parseExpression();
+    const expr = this.parseExpression();
+    // GST brace container: `<expr> [ … ]` scoped definition (subclass / namespace / extend / class scope).
+    if (this.at(TokenKind.LBracket)) {
+      return this.parseScopedDefinition(expr);
+    }
+    return expr;
+  }
+
+  // --- GST brace container (AC3) ---------------------------------------------
+
+  /** Lookahead for `Identifier [class] >>` — the start of a scoped method definition. */
+  private looksLikeMethodDef(): boolean {
+    if (!this.at(TokenKind.Identifier)) {
+      return false;
+    }
+    let k = 1;
+    if (this.peek(k).kind === TokenKind.Identifier && this.peek(k).text === 'class') {
+      k++;
+    }
+    return this.peek(k).kind === TokenKind.BinarySelector && this.peek(k).text === '>>';
+  }
+
+  private parseMethodDefinition(): Node {
+    const startTok = this.current();
+    const target: VariableNode = { kind: NodeKind.Variable, name: startTok.text, ...this.range(startTok) };
+    this.advance(); // class name
+    let classSide = false;
+    if (this.at(TokenKind.Identifier) && this.current().text === 'class') {
+      classSide = true;
+      this.advance();
+    }
+    this.advance(); // '>>' (guaranteed by looksLikeMethodDef)
+    const pattern = this.parseMethodPattern();
+    const { pragmas, temporaries, statements } = this.parseMethodBody();
+    const node: MethodDefinitionNode = {
+      kind: NodeKind.MethodDefinition,
+      target,
+      classSide,
+      selector: pattern.selector,
+      messageType: pattern.messageType,
+      parameters: pattern.parameters,
+      pragmas,
+      temporaries,
+      statements,
+      ...this.span(startTok),
+    };
+    return node;
+  }
+
+  /** Lookahead for a short-form method `pattern [ … ]` (no `Class >>`), valid inside a body. */
+  private looksLikeShortMethodDef(): boolean {
+    if (this.at(TokenKind.Keyword)) {
+      return true; // a leading keyword has no receiver, so it is a keyword method pattern
+    }
+    if (
+      this.at(TokenKind.BinarySelector) &&
+      this.current().text !== '<' &&
+      this.current().text !== '>' &&
+      this.peek(1).kind === TokenKind.Identifier
+    ) {
+      return true; // `+ arg [ … ]`
+    }
+    return this.at(TokenKind.Identifier) && this.peek(1).kind === TokenKind.LBracket; // `sel [ … ]`
+  }
+
+  private parseShortMethodDefinition(): Node {
+    const startTok = this.current();
+    const pattern = this.parseMethodPattern();
+    const { pragmas, temporaries, statements } = this.parseMethodBody();
+    const node: MethodDefinitionNode = {
+      kind: NodeKind.MethodDefinition,
+      classSide: false,
+      selector: pattern.selector,
+      messageType: pattern.messageType,
+      parameters: pattern.parameters,
+      pragmas,
+      temporaries,
+      statements,
+      ...this.span(startTok),
+    };
+    return node;
+  }
+
+  /** A method pattern: unary `sel`, binary `+ arg`, or keyword `k1: a1 k2: a2 …`. */
+  private parseMethodPattern(): { selector: string; messageType: MessageType; parameters: NameRef[] } {
+    const parameters: NameRef[] = [];
+    if (this.at(TokenKind.Keyword)) {
+      let selector = '';
+      while (this.at(TokenKind.Keyword)) {
+        selector += this.current().text;
+        this.advance();
+        if (this.at(TokenKind.Identifier)) {
+          parameters.push(this.nameRef(this.current()));
+          this.advance();
+        } else {
+          this.diag('Expected a parameter name in keyword method pattern', this.current());
+        }
+      }
+      return { selector, messageType: 'keyword', parameters };
+    }
+    if (this.at(TokenKind.BinarySelector) || this.at(TokenKind.Pipe)) {
+      const selector = this.current().text;
+      this.advance();
+      if (this.at(TokenKind.Identifier)) {
+        parameters.push(this.nameRef(this.current()));
+        this.advance();
+      } else {
+        this.diag('Expected a parameter name in binary method pattern', this.current());
+      }
+      return { selector, messageType: 'binary', parameters };
+    }
+    if (this.at(TokenKind.Identifier)) {
+      const selector = this.current().text;
+      this.advance();
+      return { selector, messageType: 'unary', parameters };
+    }
+    this.diag('Expected a method selector pattern', this.current());
+    return { selector: '', messageType: 'unary', parameters };
+  }
+
+  private parseMethodBody(): { pragmas: PragmaNode[]; temporaries: NameRef[]; statements: Node[] } {
+    const pragmas: PragmaNode[] = [];
+    if (this.at(TokenKind.LBracket)) {
+      this.advance();
+    } else {
+      this.diag('Expected "[" to open method body', this.current());
+    }
+    while (this.atPragma()) {
+      pragmas.push(this.parsePragma());
+    }
+    const { temporaries, statements } = this.parseSequenceBody(TokenKind.RBracket);
+    if (this.at(TokenKind.RBracket)) {
+      this.advance();
+    } else {
+      this.diag('Expected "]" to close method body', this.current());
+    }
+    return { pragmas, temporaries, statements };
+  }
+
+  private parseScopedDefinition(definer: Node): Node {
+    this.advance(); // '['
+    const body = this.parseClassBody();
+    if (this.at(TokenKind.RBracket)) {
+      this.advance();
+    } else {
+      this.diag('Expected "]" to close definition', this.current());
+    }
+    const { definitionKind, name } = this.classifyDefiner(definer);
+    return {
+      kind: NodeKind.Definition,
+      definitionKind,
+      definer,
+      ...(name !== undefined ? { name } : {}),
+      body,
+      start: definer.start,
+      end: this.prev.end,
+      startPos: definer.startPos,
+      endPos: this.prev.endPos,
+    };
+  }
+
+  /** Class-body items: instance-var decls, pragmas, method/nested definitions, statements. */
+  private parseClassBody(): Node[] {
+    const items: Node[] = [];
+    while (!this.atEnd() && !this.at(TokenKind.RBracket)) {
+      if (this.at(TokenKind.Period) || this.at(TokenKind.Bang)) {
+        this.advance();
+        continue;
+      }
+      if (this.looksLikeTemporaries()) {
+        const startTok = this.current();
+        const declared = this.parseTemporaries();
+        items.push({ kind: NodeKind.InstanceVariables, names: declared, ...this.span(startTok) });
+        continue;
+      }
+      if (this.atPragma()) {
+        items.push(this.parsePragma());
+        continue;
+      }
+      if (this.looksLikeMethodDef()) {
+        items.push(this.parseMethodDefinition());
+        continue;
+      }
+      // Short-form method definition inside a body: `pattern [ … ]` (no `Class >>`).
+      if (this.looksLikeShortMethodDef()) {
+        items.push(this.parseShortMethodDefinition());
+        continue;
+      }
+      const expr = this.parseExpression();
+      if (this.at(TokenKind.LBracket)) {
+        items.push(this.parseScopedDefinition(expr));
+      } else {
+        items.push(expr);
+        if (this.at(TokenKind.Period)) {
+          this.advance(); // class-body items need no `.`, but tolerate it
+        }
+      }
+    }
+    return items;
+  }
+
+  private atPragma(): boolean {
+    return this.at(TokenKind.BinarySelector) && this.current().text === '<';
+  }
+
+  private parsePragma(): PragmaNode {
+    const startTok = this.current();
+    this.advance(); // '<'
+    let selector = '';
+    const args: Node[] = [];
+    while (
+      !this.atEnd() &&
+      !this.at(TokenKind.RBracket) &&
+      !(this.at(TokenKind.BinarySelector) && this.current().text === '>')
+    ) {
+      if (this.at(TokenKind.Keyword)) {
+        selector += this.current().text;
+        this.advance();
+        args.push(this.parsePrimary()); // primary only, so the closing '>' is not consumed
+      } else {
+        this.advance(); // tolerate namespace qualifiers / stray tokens
+      }
+    }
+    if (this.at(TokenKind.BinarySelector) && this.current().text === '>') {
+      this.advance();
+    } else {
+      this.diag('Expected ">" to close attribute', this.current());
+    }
+    return { kind: NodeKind.Pragma, selector, arguments: args, ...this.span(startTok) };
+  }
+
+  private classifyDefiner(definer: Node): { definitionKind: DefinitionKind; name?: string } {
+    if (definer.kind === NodeKind.Message) {
+      const name = this.symbolName(definer.arguments);
+      if (definer.messageType === 'keyword') {
+        if (definer.selector.includes('subclass:')) {
+          return name !== undefined ? { definitionKind: 'subclass', name } : { definitionKind: 'subclass' };
+        }
+        if (definer.selector === 'current:') {
+          return name !== undefined ? { definitionKind: 'namespace', name } : { definitionKind: 'namespace' };
+        }
+      } else if (definer.messageType === 'unary') {
+        if (definer.selector === 'extend') {
+          return { definitionKind: 'extend' };
+        }
+        if (definer.selector === 'class') {
+          return { definitionKind: 'classScope' };
+        }
+      }
+    }
+    return { definitionKind: 'scoped' };
+  }
+
+  /** The first symbol-literal argument's name (without the leading `#`/quotes), if any. */
+  private symbolName(args: Node[]): string | undefined {
+    for (const a of args) {
+      if (a.kind === NodeKind.Literal && a.literalKind === 'symbol') {
+        return a.value.replace(/^#/, '').replace(/^'(.*)'$/, '$1');
+      }
+    }
+    return undefined;
   }
 
   // --- Expressions (precedence climb) ----------------------------------------
@@ -302,9 +575,24 @@ class Parser {
       return { kind: NodeKind.Literal, literalKind, value: t.text, ...this.range(t) };
     }
     switch (t.kind) {
-      case TokenKind.Identifier:
+      case TokenKind.Identifier: {
+        // Scoped name: `Namespace::Class` (a run of `:: Identifier`).
         this.advance();
-        return { kind: NodeKind.Variable, name: t.text, ...this.range(t) };
+        let name = t.text;
+        while (this.at(TokenKind.Scope) && this.peek(1).kind === TokenKind.Identifier) {
+          this.advance(); // ::
+          name += `::${this.current().text}`;
+          this.advance(); // identifier
+        }
+        return {
+          kind: NodeKind.Variable,
+          name,
+          start: t.start,
+          end: this.prev.end,
+          startPos: t.startPos,
+          endPos: this.prev.endPos,
+        };
+      }
       case TokenKind.LParen:
         return this.parseParenthesized();
       case TokenKind.HashParen:
@@ -384,6 +672,7 @@ class Parser {
   private parseDynamicArray(): Node {
     const startTok = this.current();
     this.advance(); // {
+    const temporaries = this.parseTemporaries(); // `{ | t | … }` constructor locals
     const elements: Node[] = [];
     while (!this.atEnd() && !this.at(TokenKind.RBrace)) {
       if (this.at(TokenKind.Period)) {
@@ -403,7 +692,7 @@ class Parser {
     } else {
       this.diag('Expected "}"', this.current());
     }
-    return { kind: NodeKind.DynamicArray, elements, ...this.span(startTok) };
+    return { kind: NodeKind.DynamicArray, temporaries, elements, ...this.span(startTok) };
   }
 
   /** `[ (':' id)* '|'? '| temps |'? statements ]`. */

--- a/server/test/__snapshots__/11_gst_specific_namespace_class_def.ast.txt
+++ b/server/test/__snapshots__/11_gst_specific_namespace_class_def.ast.txt
@@ -1,0 +1,277 @@
+Program temps=[] @259..6625
+  Definition namespace name='TestSpace1' @259..862
+    Message keyword 'current:' @259..289
+      Variable 'Namespace' @259..268
+      Literal symbol "#TestSpace1" @278..289
+    Cascade @337..378
+      Variable 'Transcript' @337..347
+      ;
+        Message keyword 'show:' @337..374
+          CascadeReceiver @347..347
+          Literal string "'Inside TestSpace1.'" @354..374
+      ;
+        Message unary 'cr' @347..378
+          CascadeReceiver @347..347
+    Definition subclass name='MyClassInTestSpace1' @385..860
+      Message keyword 'subclass:' @385..422
+        Variable 'Object' @385..391
+        Literal symbol "#MyClassInTestSpace1" @402..422
+      InstanceVariables [instVarInNamespace] @483..505
+      MethodDefinition class unary 'new' params=[] temps=[] @515..604
+        Variable 'MyClassInTestSpace1' @515..534
+        Return @562..594
+          Message unary 'initializeInNamespace' @563..594
+            Message unary 'new' @563..572
+              Variable 'super' @563..568
+      MethodDefinition unary 'initializeInNamespace' params=[] temps=[] @614..784
+        Assignment target='instVarInNamespace' @650..699
+          Literal string "'Initialized in TestSpace1'" @672..699
+        Cascade @713..773
+          Variable 'Transcript' @713..723
+          ;
+            Message keyword 'show:' @713..769
+              CascadeReceiver @723..723
+              Literal string "'MyClassInTestSpace1 instance created.'" @730..769
+          ;
+            Message unary 'cr' @723..773
+              CascadeReceiver @723..723
+      MethodDefinition unary 'printVar' params=[] temps=[] @794..854
+        Message unary 'printNl' @817..843
+          Variable 'instVarInNamespace' @817..835
+  Definition subclass name='MySimpleClass' @1093..1300
+    Message keyword 'subclass:' @1093..1124
+      Variable 'Object' @1093..1099
+      Literal symbol "#MySimpleClass" @1110..1124
+    Cascade @1239..1297
+      Variable 'Transcript' @1239..1249
+      ;
+        Message keyword 'show:' @1239..1293
+          CascadeReceiver @1249..1249
+          Literal string "'MySimpleClass definition processed.'" @1256..1293
+      ;
+        Message unary 'cr' @1249..1297
+          CascadeReceiver @1249..1249
+  Definition subclass name='MyClassWithIvars' @1348..1880
+    Message keyword 'subclass:' @1348..1382
+      Variable 'Object' @1348..1354
+      Literal symbol "#MyClassWithIvars" @1365..1382
+    InstanceVariables [instVar1, instVar2] @1389..1410
+    MethodDefinition unary 'initialize' params=[] temps=[] @1523..1614
+      Variable 'MyClassWithIvars' @1523..1539
+      Assignment target='instVar1' @1564..1578
+        Literal integer "10" @1576..1578
+      Assignment target='instVar2' @1588..1607
+        Literal string "'hello'" @1600..1607
+    MethodDefinition unary 'printIvars' params=[] temps=[] @1620..1778
+      Variable 'MyClassWithIvars' @1620..1636
+      Cascade @1661..1711
+        Variable 'Transcript' @1661..1671
+        ;
+          Message keyword 'show:' @1661..1690
+            CascadeReceiver @1671..1671
+            Literal string "'instVar1: '" @1678..1690
+        ;
+          Message keyword 'print:' @1671..1707
+            CascadeReceiver @1671..1671
+            Variable 'instVar1' @1699..1707
+        ;
+          Message unary 'cr' @1671..1711
+            CascadeReceiver @1671..1671
+      Cascade @1721..1771
+        Variable 'Transcript' @1721..1731
+        ;
+          Message keyword 'show:' @1721..1750
+            CascadeReceiver @1731..1731
+            Literal string "'instVar2: '" @1738..1750
+        ;
+          Message keyword 'print:' @1731..1767
+            CascadeReceiver @1731..1731
+            Variable 'instVar2' @1759..1767
+        ;
+          Message unary 'cr' @1731..1771
+            CascadeReceiver @1731..1731
+    MethodDefinition class unary 'greeting' params=[] temps=[] @1784..1878
+      Variable 'MyClassWithIvars' @1784..1800
+      Return @1829..1871
+        Literal string "'Hello from MyClassWithIvars class side!'" @1830..1871
+  Definition subclass name='MyClassWithClassVars' @2346..2755
+    Message keyword 'subclass:' @2346..2384
+      Variable 'Object' @2346..2352
+      Literal symbol "#MyClassWithClassVars" @2363..2384
+    Definition classScope @2391..2590
+      Message unary 'class' @2391..2417
+        Variable 'MyClassWithClassVars' @2391..2411
+      Assignment target='ClassVar1' @2496..2512
+        Literal integer "100" @2509..2512
+      Assignment target='AnotherClassVar' @2556..2583
+        Literal string "'shared'" @2575..2583
+    MethodDefinition class unary 'getClassVar1Value' params=[] temps=[] @2596..2671
+      Variable 'MyClassWithClassVars' @2596..2616
+      Return @2654..2664
+        Variable 'ClassVar1' @2655..2664
+    MethodDefinition unary 'printShared' params=[] temps=[] @2677..2753
+      Variable 'MyClassWithClassVars' @2677..2697
+      Message unary 'printNl' @2723..2746
+        Variable 'AnotherClassVar' @2723..2738
+  Definition namespace name='ParentNamespace' @2916..3053
+    Message keyword 'current:' @2916..2951
+      Variable 'Namespace' @2916..2925
+      Literal symbol "#ParentNamespace" @2935..2951
+    Definition subclass name='BaseClass' @2958..3051
+      Message keyword 'subclass:' @2958..2985
+        Variable 'Object' @2958..2964
+        Literal symbol "#BaseClass" @2975..2985
+      MethodDefinition unary 'baseMethod' params=[] temps=[] @2996..3045
+        Variable 'BaseClass' @2996..3005
+        Return @3022..3043
+          Literal string "'Base method result'" @3023..3043
+  Definition subclass name='MyDerivedClass' @3099..3377
+    Message keyword 'subclass:' @3099..3151
+      Variable 'ParentNamespace::BaseClass' @3099..3125
+      Literal symbol "#MyDerivedClass" @3136..3151
+    MethodDefinition unary 'derivedMethod' params=[] temps=[] @3222..3375
+      Variable 'MyDerivedClass' @3222..3236
+      Cascade @3264..3334
+        Variable 'Transcript' @3264..3274
+        ;
+          Message keyword 'show:' @3264..3305
+            CascadeReceiver @3274..3274
+            Literal string "'Derived method calls: '" @3281..3305
+        ;
+          Message keyword 'print:' @3274..3330
+            CascadeReceiver @3274..3274
+            Message unary 'baseMethod' @3314..3330
+              Variable 'super' @3314..3319
+        ;
+          Message unary 'cr' @3274..3334
+            CascadeReceiver @3274..3274
+      Return @3344..3368
+        Literal string "'Derived method result'" @3345..3368
+  Definition subclass name='OuterClass' @3502..3975
+    Message keyword 'subclass:' @3502..3530
+      Variable 'Object' @3502..3508
+      Literal symbol "#OuterClass" @3519..3530
+    Definition classScope @3537..3905
+      Message unary 'class' @3537..3553
+        Variable 'OuterClass' @3537..3547
+      MethodDefinition class unary 'outerClassMethod' params=[] temps=[] @3601..3663
+        Variable 'OuterClass' @3601..3611
+        Return @3640..3661
+          Literal string "'Outer class method'" @3641..3661
+      Definition subclass name='InnerClassOnClassSide' @3755..3899
+        Message keyword 'subclass:' @3755..3794
+          Variable 'Object' @3755..3761
+          Literal symbol "#InnerClassOnClassSide" @3772..3794
+        MethodDefinition unary 'innerInstanceMethod' params=[] temps=[] @3809..3889
+          Variable 'InnerClassOnClassSide' @3809..3830
+          Return @3856..3887
+            Literal string "'Inner instance on class side'" @3857..3887
+    MethodDefinition unary 'outerInstanceMethod' params=[] temps=[] @3911..3973
+      Variable 'OuterClass' @3911..3921
+      Return @3947..3971
+        Literal string "'Outer instance method'" @3948..3971
+  Definition subclass name='MyClassWithAttributes' @4148..4554
+    Message keyword 'subclass:' @4148..4187
+      Variable 'Object' @4148..4154
+      Literal symbol "#MyClassWithAttributes" @4165..4187
+    Pragma 'classCategory:' @4194..4232
+      Literal string "'Test-Attributes'" @4214..4231
+    InstanceVariables [ivar] @4266..4274
+    Pragma 'methodCategory:' @4280..4313
+      Literal string "'accessing'" @4301..4312
+    MethodDefinition unary 'getIvar' params=[] temps=[] @4318..4429
+      Variable 'MyClassWithAttributes' @4318..4339
+      Pragma 'methodComment:' @4361..4409
+        Literal string "'Returns the value of ivar'" @4381..4408
+      Return @4418..4423
+        Variable 'ivar' @4419..4423
+    MethodDefinition keyword 'setIvar:' params=[newValue] temps=[] @4435..4552
+      Variable 'MyClassWithAttributes' @4435..4456
+      Pragma 'methodCategory:' @4488..4520
+        Literal string "'mutating'" @4509..4519
+      Assignment target='ivar' @4529..4545
+        Variable 'newValue' @4537..4545
+  Cascade @4730..4798
+    Message unary 'new' @4730..4743
+      Variable 'Namespace' @4730..4739
+    ;
+      Message keyword 'name:' @4730..4769
+        CascadeReceiver @4743..4743
+        Literal symbol "#MyFixtureNamespace" @4750..4769
+    ;
+      Message keyword 'import:' @4743..4788
+        CascadeReceiver @4743..4743
+        Variable 'Smalltalk' @4779..4788
+    ;
+      Message unary 'yourself' @4743..4798
+        CascadeReceiver @4743..4743
+  Variable 'MyFixtureNamespace' @4863..4881
+  Message keyword 'subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:' @4882..5064
+    Variable 'MyTraditionalClass' @4882..4900
+    Literal symbol "#Object" @4911..4918
+    Literal string "'ivarA ivarB'" @4943..4956
+    Literal string "'ClassVarA ClassVarB'" @4978..4999
+    Literal string "''" @5019..5021
+    Literal string "'MyCategory-MyFixtureNamespace'" @5033..5064
+  Variable 'MyFixtureNamespace' @5067..5085
+  Message keyword 'compile:' @5086..5131
+    Variable 'MyTraditionalClass' @5086..5104
+    Literal string "'myMethod ^ivarA'" @5114..5131
+  Message keyword 'subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:' @5258..5451
+    Variable 'Object' @5258..5264
+    Literal symbol "#MyParserSimpleClass" @5275..5295
+    Literal string "'instVarOne instVarTwo'" @5320..5343
+    Literal string "'ClassVarOne ClassVarTwo'" @5365..5390
+    Literal string "''" @5410..5412
+    Literal string "'MyCategory-ParserExamples'" @5424..5451
+  Message keyword 'compile:' @5454..5546
+    Message unary 'class' @5454..5479
+      Variable 'MyParserSimpleClass' @5454..5473
+    Literal string "'initialize ClassVarOne := 10. ClassVarTwo := ''hello''.'" @5489..5546
+  Message keyword 'subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:' @5660..5895
+    Variable 'Object' @5660..5666
+    Literal symbol "#MyParserDetailedClass" @5677..5699
+    Literal string "'| explicitIvar1 explicitIvar2 | anotherIvar'" @5724..5769
+    Literal string "'MyClassVar'" @5822..5834
+    Literal string "''" @5854..5856
+    Literal string "'MyCategory-ParserDetailed'" @5868..5895
+  Message keyword 'compile:' @5898..5975
+    Message unary 'class' @5898..5925
+      Variable 'MyParserDetailedClass' @5898..5919
+    Literal string "'initializeClassVars MyClassVar := nil.'" @5935..5975
+  Variable 'Smalltalk' @6099..6108
+  Message keyword 'definition:' @6109..6624
+    Variable 'Namespace' @6109..6118
+    Block params=[] temps=[] @6131..6624
+      Error "Unexpected Keyword" @6137..6142
+      Message unary 'Smalltalk' @6166..6183
+        Error "Unexpected Keyword" @6166..6173
+      Variable 'OuterParserSpace' @6190..6206
+      Message keyword 'definition:' @6207..6621
+        Variable 'Object' @6207..6213
+        Block params=[] temps=[] @6226..6621
+          Error "Unexpected Keyword" @6236..6241
+          Message unary 'Smalltalk' @6269..6290
+            Error "Unexpected Keyword" @6269..6280
+          Variable 'Object' @6291..6297
+          Error "Unexpected Keyword" @6307..6325
+          Error "Unexpected Keyword" @6347..6362
+          Error "Unexpected Keyword" @6394..6411
+          Error "Unexpected Keyword" @6424..6433
+          Message keyword 'compile:' @6476..6527
+            Variable 'InnerParserClass' @6476..6492
+            Literal string "'getInnerIvar ^innerIvar'" @6502..6527
+          Message keyword 'compile:' @6537..6614
+            Message unary 'class' @6537..6559
+              Variable 'InnerParserClass' @6537..6553
+            Literal string "'initializeInner InnerParserClassVar := 100.'" @6569..6614
+
+--- diagnostics ---
+Error "Unexpected Keyword \"name:\"" @6137..6142
+Error "Unexpected Keyword \"import:\"" @6166..6173
+Error "Unexpected Keyword \"name:\"" @6236..6241
+Error "Unexpected Keyword \"superclass:\"" @6269..6280
+Error "Unexpected Keyword \"instanceVariables:\"" @6307..6325
+Error "Unexpected Keyword \"classVariables:\"" @6347..6362
+Error "Unexpected Keyword \"poolDictionaries:\"" @6394..6411
+Error "Unexpected Keyword \"category:\"" @6424..6433

--- a/server/test/__snapshots__/12_gst_specific_extend_scoped_methods.ast.txt
+++ b/server/test/__snapshots__/12_gst_specific_extend_scoped_methods.ast.txt
@@ -1,0 +1,141 @@
+Program temps=[myInstance, myExtendedInstance, demoObj, demoObj2, result] @283..3166
+  Assignment target='myInstance' @317..341
+    Message unary 'new' @331..341
+      Variable 'Object' @331..337
+  Definition extend @344..704
+    Message unary 'extend' @344..361
+      Variable 'myInstance' @344..354
+    InstanceVariables [extensionVar] @414..430
+    MethodDefinition unary 'initializeExtension' params=[] temps=[] @482..613
+      Assignment target='extensionVar' @512..539
+        Literal string "'Extended!'" @528..539
+      Cascade @549..606
+        Variable 'Transcript' @549..559
+        ;
+          Message keyword 'show:' @549..602
+            CascadeReceiver @559..559
+            Literal string "'Instance extended and initialized.'" @566..602
+        ;
+          Message unary 'cr' @559..606
+            CascadeReceiver @559..559
+    MethodDefinition unary 'greetFromExtension' params=[] temps=[] @619..702
+      Return @648..695
+        Message binary ',' @649..695
+          Literal string "'Hello from extended instance: '" @649..681
+          Variable 'extensionVar' @683..695
+  Message unary 'initializeExtension' @751..781
+    Variable 'myInstance' @751..761
+  Message unary 'printNl' @784..822
+    Message unary 'greetFromExtension' @784..813
+      Variable 'myInstance' @784..794
+  Assignment target='myExtendedInstance' @881..913
+    Variable 'myInstance' @903..913
+  Assignment target='myInstance' @936..960
+    Message unary 'new' @950..960
+      Variable 'Object' @950..956
+  Definition subclass name='MyScopedMethodDemo' @1366..1487
+    Message keyword 'subclass:' @1366..1402
+      Variable 'Object' @1366..1372
+      Literal symbol "#MyScopedMethodDemo" @1383..1402
+    InstanceVariables [data] @1409..1417
+    MethodDefinition keyword 'initializeWith:' params=[aValue] temps=[] @1422..1485
+      Variable 'MyScopedMethodDemo' @1422..1440
+      Assignment target='data' @1469..1483
+        Variable 'aValue' @1477..1483
+  MethodDefinition unary 'printData' params=[] temps=[] @1556..1690
+    Variable 'MyScopedMethodDemo' @1556..1574
+    Cascade @1645..1687
+      Variable 'Transcript' @1645..1655
+      ;
+        Message keyword 'show:' @1645..1670
+          CascadeReceiver @1655..1655
+          Literal string "'Data: '" @1662..1670
+      ;
+        Message keyword 'print:' @1655..1683
+          CascadeReceiver @1655..1655
+          Variable 'data' @1679..1683
+      ;
+        Message unary 'cr' @1655..1687
+          CascadeReceiver @1655..1655
+  MethodDefinition class unary 'classSideUtility' params=[] temps=[] @1761..1915
+    Variable 'MyScopedMethodDemo' @1761..1779
+    Return @1881..1912
+      Literal string "'Utility method on class side'" @1882..1912
+  Assignment target='demoObj' @1957..1990
+    Message unary 'new' @1968..1990
+      Variable 'MyScopedMethodDemo' @1968..1986
+  Message keyword 'initializeWith:' @1992..2027
+    Variable 'demoObj' @1992..1999
+    Literal string "'Test Data'" @2016..2027
+  Message unary 'printData' @2029..2046
+    Variable 'demoObj' @2029..2036
+  Message unary 'printNl' @2049..2093
+    Message unary 'classSideUtility' @2049..2084
+      Variable 'MyScopedMethodDemo' @2049..2067
+  MethodDefinition unary 'processData' params=[] temps=[temp] @2143..2276
+    Variable 'MyScopedMethodDemo' @2143..2161
+    Assignment target='temp' @2196..2217
+      Message unary 'reversed' @2204..2217
+        Variable 'data' @2204..2208
+    Return @2253..2273
+      Message binary ',' @2254..2273
+        Literal string "'Processed: '" @2254..2267
+        Variable 'temp' @2269..2273
+  Message unary 'printNl' @2279..2307
+    Message unary 'processData' @2279..2298
+      Variable 'demoObj' @2279..2286
+  MethodDefinition unary 'getData' params=[] temps=[] @2362..2406
+    Variable 'MyScopedMethodDemo' @2362..2380
+    Return @2398..2403
+      Variable 'data' @2399..2403
+  Message unary 'printNl' @2409..2433
+    Message unary 'getData' @2409..2424
+      Variable 'demoObj' @2409..2416
+  MethodDefinition binary '+' params=[anotherDemoObject] temps=[] @2462..2614
+    Variable 'MyScopedMethodDemo' @2462..2480
+    Return @2571..2611
+      Message binary ',' @2572..2611
+        Message unary 'getData' @2572..2584
+          Variable 'self' @2572..2576
+        Message unary 'getData' @2586..2611
+          Variable 'anotherDemoObject' @2586..2603
+  Assignment target='demoObj2' @2637..2671
+    Message unary 'new' @2649..2671
+      Variable 'MyScopedMethodDemo' @2649..2667
+  Message keyword 'initializeWith:' @2673..2709
+    Variable 'demoObj2' @2673..2681
+    Literal string "'More Data'" @2698..2709
+  Assignment target='result' @2711..2739
+    Message binary '+' @2721..2739
+      Variable 'demoObj' @2721..2728
+      Variable 'demoObj2' @2731..2739
+  Message unary 'printNl' @2741..2755
+    Variable 'result' @2741..2747
+  MethodDefinition keyword 'update:ifOld:' params=[newData, oldDataBlock] temps=[] @2785..2940
+    Variable 'MyScopedMethodDemo' @2785..2803
+    Message keyword 'ifTrue:' @2849..2895
+      Message binary '=' @2849..2863
+        Variable 'data' @2849..2853
+        Variable 'newData' @2856..2863
+      Block params=[] temps=[] @2872..2895
+        Return @2874..2893
+          Message unary 'value' @2875..2893
+            Variable 'oldDataBlock' @2875..2887
+    Assignment target='data' @2901..2916
+      Variable 'newData' @2909..2916
+    Return @2922..2937
+      Literal string "'Data updated'" @2923..2937
+  Message unary 'printNl' @2944..3014
+    Message keyword 'update:ifOld:' @2944..3005
+      Variable 'demoObj' @2944..2951
+      Literal string "'New Data'" @2960..2970
+      Block params=[] temps=[] @2978..3005
+        Literal string "'Data was already new!'" @2980..3003
+  Message unary 'printNl' @3017..3087
+    Message keyword 'update:ifOld:' @3017..3078
+      Variable 'demoObj' @3017..3024
+      Literal string "'New Data'" @3033..3043
+      Block params=[] temps=[] @3051..3078
+        Literal string "'Data was already new!'" @3053..3076
+
+--- diagnostics ---

--- a/server/test/__snapshots__/13_gst_specific_attributes_array_constructor.ast.txt
+++ b/server/test/__snapshots__/13_gst_specific_attributes_array_constructor.ast.txt
@@ -1,0 +1,92 @@
+Program temps=[constructedArray, anotherArray] @228..1913
+  Definition subclass name='MyClassWithAttrs' @228..625
+    Message keyword 'subclass:' @228..262
+      Variable 'Object' @228..234
+      Literal symbol "#MyClassWithAttrs" @245..262
+    Pragma 'classCategory:' @269..307
+      Literal string "'Test-Attributes'" @289..306
+    InstanceVariables [myVar] @341..350
+    Pragma 'methodCategory:' @356..389
+      Literal string "'accessing'" @377..388
+    MethodDefinition unary 'getMyVar' params=[] temps=[] @394..503
+      Variable 'MyClassWithAttrs' @394..410
+      Pragma 'methodComment:' @433..482
+        Literal string "'Returns the value of myVar'" @453..481
+      Return @491..497
+        Variable 'myVar' @492..497
+    MethodDefinition keyword 'setMyVar:' params=[newValue] temps=[] @509..623
+      Variable 'MyClassWithAttrs' @509..525
+      Pragma 'methodCategory:' @558..590
+        Literal string "'mutating'" @579..589
+      Assignment target='myVar' @599..616
+        Variable 'newValue' @608..616
+  Assignment target='constructedArray' @936..979
+    DynamicArray @956..979
+      Literal integer "1" @958..959
+      Literal string "'two'" @961..966
+      Literal character "$c" @968..970
+      Literal symbol "#four" @972..977
+  Message unary 'printNl' @981..1005
+    Variable 'constructedArray' @981..997
+  Assignment target='anotherArray' @1047..1133
+    DynamicArray @1063..1133
+      Message binary '+' @1065..1070
+        Literal integer "1" @1065..1066
+        Literal integer "2" @1069..1070
+      Message unary 'today' @1072..1082
+        Variable 'Date' @1072..1076
+      Message unary 'version' @1084..1101
+        Variable 'Smalltalk' @1084..1093
+      Cascade @1104..1130
+        Message unary 'new' @1104..1113
+          Variable 'Array' @1104..1109
+        ;
+          Message keyword 'add:' @1104..1120
+            CascadeReceiver @1113..1113
+            Literal integer "5" @1119..1120
+        ;
+          Message unary 'yourself' @1113..1130
+            CascadeReceiver @1113..1113
+  Message unary 'printNl' @1135..1155
+    Variable 'anotherArray' @1135..1147
+  DynamicArray @1214..1216
+  DynamicArray @1263..1275
+    Literal string "'lonely'" @1265..1273
+  DynamicArray @1331..1371
+    Message unary 'value' @1333..1354
+      Block params=[] temps=[] @1333..1348
+        Message unary 'factorial' @1335..1346
+          Literal integer "3" @1335..1336
+    Literal string "'after block'" @1356..1369
+  DynamicArray @1419..1466
+    Literal integer "1" @1421..1422
+    DynamicArray @1424..1442
+      Literal string "'nested'" @1426..1434
+      Variable 'true' @1436..1440
+    LiteralArray @1444..1464
+      Literal string "'literal array'" @1447..1462
+  Assignment target='constructedArray' @1528..1833
+    DynamicArray temps=[temp] @1548..1833
+      Assignment target='temp' @1567..1577
+        Literal integer "10" @1575..1577
+      Message keyword 'show:' @1583..1628
+        Variable 'Transcript' @1583..1593
+        Literal string "'First element construction'" @1600..1628
+      Message binary '*' @1634..1645
+        Variable 'temp' @1634..1638
+        Variable 'temp' @1641..1645
+      Message keyword 'show:' @1670..1716
+        Variable 'Transcript' @1670..1680
+        Literal string "'Second element construction'" @1687..1716
+      Literal string "'String element'" @1722..1738
+      Message keyword 'collect:' @1765..1801
+        Message keyword 'to:' @1765..1772
+          Literal integer "1" @1765..1766
+          Literal integer "3" @1771..1772
+        Block params=[i] temps=[] @1783..1801
+          Message unary 'squared' @1790..1799
+            Variable 'i' @1790..1791
+  Message unary 'printNl' @1835..1859
+    Variable 'constructedArray' @1835..1851
+
+--- diagnostics ---

--- a/server/test/astDump.ts
+++ b/server/test/astDump.ts
@@ -1,0 +1,98 @@
+// Shared AST serializer for parser/container snapshot tests (US-411).
+// Produces a compact, indented tree with `@start..end` ranges, plus a
+// diagnostics section — deterministic and stable across runs.
+import { parse } from '../src/parser/parser.ts';
+import { NodeKind, type Node } from '../src/parser/ast.ts';
+
+function names(list: ReadonlyArray<{ name: string }>): string {
+  return list.map((n) => n.name).join(', ');
+}
+
+export function dump(node: Node, indent: string, out: string[]): void {
+  const at = `@${node.start}..${node.end}`;
+  const child = indent + '  ';
+  switch (node.kind) {
+    case NodeKind.Program:
+      out.push(`${indent}Program temps=[${names(node.temporaries)}] ${at}`);
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
+    case NodeKind.Block:
+      out.push(`${indent}Block params=[${names(node.parameters)}] temps=[${names(node.temporaries)}] ${at}`);
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
+    case NodeKind.Return:
+      out.push(`${indent}Return ${at}`);
+      dump(node.value, child, out);
+      break;
+    case NodeKind.Assignment:
+      out.push(`${indent}Assignment target='${node.target.name}' ${at}`);
+      dump(node.value, child, out);
+      break;
+    case NodeKind.Message:
+      out.push(`${indent}Message ${node.messageType} '${node.selector}' ${at}`);
+      dump(node.receiver, child, out);
+      node.arguments.forEach((a) => dump(a, child, out));
+      break;
+    case NodeKind.Cascade:
+      out.push(`${indent}Cascade ${at}`);
+      dump(node.receiver, child, out);
+      node.messages.forEach((m) => {
+        out.push(`${child};`);
+        dump(m, child + '  ', out);
+      });
+      break;
+    case NodeKind.CascadeReceiver:
+      out.push(`${indent}CascadeReceiver ${at}`);
+      break;
+    case NodeKind.Definition:
+      out.push(`${indent}Definition ${node.definitionKind}${node.name ? ` name='${node.name}'` : ''} ${at}`);
+      dump(node.definer, child, out);
+      node.body.forEach((b) => dump(b, child, out));
+      break;
+    case NodeKind.MethodDefinition:
+      out.push(
+        `${indent}MethodDefinition ${node.classSide ? 'class ' : ''}${node.messageType} '${node.selector}'` +
+          ` params=[${names(node.parameters)}] temps=[${names(node.temporaries)}] ${at}`,
+      );
+      if (node.target) {
+        dump(node.target, child, out);
+      }
+      node.pragmas.forEach((p) => dump(p, child, out));
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
+    case NodeKind.Pragma:
+      out.push(`${indent}Pragma '${node.selector}' ${at}`);
+      node.arguments.forEach((a) => dump(a, child, out));
+      break;
+    case NodeKind.InstanceVariables:
+      out.push(`${indent}InstanceVariables [${names(node.names)}] ${at}`);
+      break;
+    case NodeKind.Variable:
+      out.push(`${indent}Variable '${node.name}' ${at}`);
+      break;
+    case NodeKind.Literal:
+      out.push(`${indent}Literal ${node.literalKind} ${JSON.stringify(node.value)} ${at}`);
+      break;
+    case NodeKind.DynamicArray:
+      out.push(`${indent}DynamicArray${node.temporaries.length ? ` temps=[${names(node.temporaries)}]` : ''} ${at}`);
+      node.elements.forEach((e) => dump(e, child, out));
+      break;
+    case NodeKind.LiteralArray:
+    case NodeKind.ByteArray:
+      out.push(`${indent}${node.kind} ${at}`);
+      node.elements.forEach((e) => dump(e, child, out));
+      break;
+    case NodeKind.Error:
+      out.push(`${indent}Error ${JSON.stringify(node.message)} ${at}`);
+      break;
+  }
+}
+
+/** Serialize a source string's AST + diagnostics to a stable snapshot string. */
+export function serializeAst(src: string): string {
+  const { ast, diagnostics } = parse(src);
+  const out: string[] = [];
+  dump(ast, '', out);
+  const diag = diagnostics.map((d) => `${d.severity} ${JSON.stringify(d.message)} @${d.start}..${d.end}`);
+  return [...out, '', '--- diagnostics ---', ...diag, ''].join('\n');
+}

--- a/server/test/container.test.ts
+++ b/server/test/container.test.ts
@@ -1,0 +1,142 @@
+// Unit + snapshot tests for the GST brace container format (US-411, slice 3a).
+// Runs in Node via tsx.
+//
+//   npm run test:parser                # run (lexer + parser + container suites)
+//   npm run test:parser -- --update    # regenerate snapshots
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '../src/parser/parser.ts';
+import {
+  NodeKind,
+  type DefinitionNode,
+  type MethodDefinitionNode,
+  type Node,
+} from '../src/parser/ast.ts';
+import { serializeAst } from './astDump.ts';
+
+const UPDATE = process.argv.includes('--update');
+const ROOT = process.cwd();
+const FIXTURE_DIR = path.join(ROOT, 'docs/research/gst-syntax/test-cases');
+const SNAPSHOT_DIR = path.join(ROOT, 'server/test/__snapshots__');
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+const firstStmt = (src: string): Node => {
+  const s = parse(src).ast.statements;
+  assert.ok(s.length >= 1, `expected a statement for ${JSON.stringify(src)}`);
+  return s[0] as Node;
+};
+const asDef = (n: Node): DefinitionNode => {
+  assert.equal(n.kind, NodeKind.Definition);
+  return n as DefinitionNode;
+};
+const asMethod = (n: Node): MethodDefinitionNode => {
+  assert.equal(n.kind, NodeKind.MethodDefinition);
+  return n as MethodDefinitionNode;
+};
+
+// --- Class definitions (AC3) -------------------------------------------------
+test('subclass definition with instance variables', () => {
+  const d = asDef(firstStmt('Object subclass: #Foo [ | a b | ]'));
+  assert.equal(d.definitionKind, 'subclass');
+  assert.equal(d.name, 'Foo');
+  const ivars = d.body[0];
+  assert.equal(ivars?.kind, NodeKind.InstanceVariables);
+  assert.deepEqual((ivars as { names: { name: string }[] }).names.map((n) => n.name), ['a', 'b']);
+});
+
+test('namespace, extend, and class-side scopes', () => {
+  assert.equal(asDef(firstStmt('Namespace current: #X [ ]')).definitionKind, 'namespace');
+  assert.equal(asDef(firstStmt('Namespace current: #X [ ]')).name, 'X');
+  assert.equal(asDef(firstStmt('obj extend [ foo [ ^1 ] ]')).definitionKind, 'extend');
+  assert.equal(asDef(firstStmt('Foo class [ Bar := 1 ]')).definitionKind, 'classScope');
+});
+
+test('nested method definitions live in the class body', () => {
+  const d = asDef(firstStmt('Object subclass: #Foo [ Foo >> bar [ ^1 ] ]'));
+  const m = asMethod(d.body[0] as Node);
+  assert.equal(m.selector, 'bar');
+});
+
+// --- Method definitions (AC3) ------------------------------------------------
+test('unary, class-side, keyword, and binary method patterns', () => {
+  const unary = asMethod(firstStmt('Foo >> bar [ ^1 ]'));
+  assert.equal(unary.messageType, 'unary');
+  assert.equal(unary.selector, 'bar');
+  assert.equal(unary.classSide, false);
+  assert.equal((unary.target as { name?: string }).name, 'Foo');
+
+  const cls = asMethod(firstStmt('Foo class >> make [ ^self new ]'));
+  assert.equal(cls.classSide, true);
+
+  const kw = asMethod(firstStmt('Foo >> at: k put: v [ ^k ]'));
+  assert.equal(kw.messageType, 'keyword');
+  assert.equal(kw.selector, 'at:put:');
+  assert.deepEqual(kw.parameters.map((p) => p.name), ['k', 'v']);
+
+  const bin = asMethod(firstStmt('Foo >> + other [ ^other ]'));
+  assert.equal(bin.messageType, 'binary');
+  assert.equal(bin.selector, '+');
+  assert.deepEqual(bin.parameters.map((p) => p.name), ['other']);
+});
+
+test('method body with temporaries and a return', () => {
+  const m = asMethod(firstStmt('Foo >> run [ | t | t := 1. ^t ]'));
+  assert.deepEqual(m.temporaries.map((t) => t.name), ['t']);
+  assert.equal(m.statements.length, 2);
+  assert.equal(m.statements[1]?.kind, NodeKind.Return);
+});
+
+// --- Pragmas / attributes (AC3) ---------------------------------------------
+test('method pragma and class-body attribute', () => {
+  const m = asMethod(firstStmt('Foo >> prim [ <primitive: 80> ^1 ]'));
+  assert.equal(m.pragmas.length, 1);
+  assert.equal(m.pragmas[0]?.selector, 'primitive:');
+
+  const d = asDef(firstStmt("Object subclass: #C [ <gst.classCategory: 'x'> | v | ]"));
+  assert.equal(d.body[0]?.kind, NodeKind.Pragma);
+  assert.equal(d.body[1]?.kind, NodeKind.InstanceVariables);
+});
+
+// --- Robustness --------------------------------------------------------------
+test('container fixtures never throw and return a Program', () => {
+  for (const file of ['10_gst_specific_chunks_eval', '11_gst_specific_namespace_class_def',
+    '12_gst_specific_extend_scoped_methods', '13_gst_specific_attributes_array_constructor',
+    '14_gst_specific_binding_compile_time_constants']) {
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, `${file}.st`), 'utf8');
+    assert.equal(parse(src).ast.kind, NodeKind.Program, `${file} should parse to a Program`);
+  }
+});
+
+// --- Snapshots over the brace-format fixtures (AC3) --------------------------
+const SNAPSHOT_FIXTURES = [
+  '11_gst_specific_namespace_class_def',
+  '12_gst_specific_extend_scoped_methods',
+  '13_gst_specific_attributes_array_constructor',
+];
+
+for (const name of SNAPSHOT_FIXTURES) {
+  test(`container snapshot: ${name}`, () => {
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, `${name}.st`), 'utf8');
+    const actual = serializeAst(src);
+    const snapPath = path.join(SNAPSHOT_DIR, `${name}.ast.txt`);
+    if (UPDATE) {
+      fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+      fs.writeFileSync(snapPath, actual);
+      console.log(`    (updated ${path.relative(ROOT, snapPath)})`);
+      return;
+    }
+    if (!fs.existsSync(snapPath)) {
+      throw new Error(`Missing snapshot ${path.relative(ROOT, snapPath)}; run: npm run test:parser -- --update`);
+    }
+    assert.equal(actual, fs.readFileSync(snapPath, 'utf8'), `AST snapshot drift for ${name}; review, then: npm run test:parser -- --update`);
+  });
+}
+
+console.log(`container: ${passed} tests passed.`);

--- a/server/test/parser.test.ts
+++ b/server/test/parser.test.ts
@@ -15,6 +15,7 @@ import {
   type AssignmentNode,
   type BlockNode,
 } from '../src/parser/ast.ts';
+import { serializeAst } from './astDump.ts';
 
 const UPDATE = process.argv.includes('--update');
 const ROOT = process.cwd();
@@ -174,76 +175,10 @@ const SNAPSHOT_FIXTURES = [
   '08_core_blocks',
 ];
 
-function names(list: ReadonlyArray<{ name: string }>): string {
-  return list.map((n) => n.name).join(', ');
-}
-
-function dump(node: Node, indent: string, out: string[]): void {
-  const at = `@${node.start}..${node.end}`;
-  const child = indent + '  ';
-  switch (node.kind) {
-    case NodeKind.Program:
-      out.push(`${indent}Program temps=[${names(node.temporaries)}] ${at}`);
-      node.statements.forEach((s) => dump(s, child, out));
-      break;
-    case NodeKind.Block:
-      out.push(`${indent}Block params=[${names(node.parameters)}] temps=[${names(node.temporaries)}] ${at}`);
-      node.statements.forEach((s) => dump(s, child, out));
-      break;
-    case NodeKind.Return:
-      out.push(`${indent}Return ${at}`);
-      dump(node.value, child, out);
-      break;
-    case NodeKind.Assignment:
-      out.push(`${indent}Assignment target='${node.target.name}' ${at}`);
-      dump(node.value, child, out);
-      break;
-    case NodeKind.Message:
-      out.push(`${indent}Message ${node.messageType} '${node.selector}' ${at}`);
-      dump(node.receiver, child, out);
-      node.arguments.forEach((a) => dump(a, child, out));
-      break;
-    case NodeKind.Cascade:
-      out.push(`${indent}Cascade ${at}`);
-      dump(node.receiver, child, out);
-      node.messages.forEach((m) => {
-        out.push(`${child};`);
-        dump(m, child + '  ', out);
-      });
-      break;
-    case NodeKind.CascadeReceiver:
-      out.push(`${indent}CascadeReceiver ${at}`);
-      break;
-    case NodeKind.Variable:
-      out.push(`${indent}Variable '${node.name}' ${at}`);
-      break;
-    case NodeKind.Literal:
-      out.push(`${indent}Literal ${node.literalKind} ${JSON.stringify(node.value)} ${at}`);
-      break;
-    case NodeKind.LiteralArray:
-    case NodeKind.ByteArray:
-    case NodeKind.DynamicArray:
-      out.push(`${indent}${node.kind} ${at}`);
-      node.elements.forEach((e) => dump(e, child, out));
-      break;
-    case NodeKind.Error:
-      out.push(`${indent}Error ${JSON.stringify(node.message)} ${at}`);
-      break;
-  }
-}
-
-function serialize(src: string): string {
-  const { ast, diagnostics } = parse(src);
-  const out: string[] = [];
-  dump(ast, '', out);
-  const diag = diagnostics.map((d) => `${d.severity} ${JSON.stringify(d.message)} @${d.start}..${d.end}`);
-  return [...out, '', '--- diagnostics ---', ...diag, ''].join('\n');
-}
-
 for (const name of SNAPSHOT_FIXTURES) {
   test(`ast snapshot: ${name}`, () => {
     const src = fs.readFileSync(path.join(FIXTURE_DIR, `${name}.st`), 'utf8');
-    const actual = serialize(src);
+    const actual = serializeAst(src);
     const snapPath = path.join(SNAPSHOT_DIR, `${name}.ast.txt`);
     if (UPDATE) {
       fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -2,3 +2,4 @@
 // `npm run test:parser [-- --update]` runs both and shares process.argv.
 import './lexer.test.ts';
 import './parser.test.ts';
+import './container.test.ts';

--- a/specs/US-411-Parser-And-Symbol-Table/plan.md
+++ b/specs/US-411-Parser-And-Symbol-Table/plan.md
@@ -135,3 +135,54 @@ an AST.
 - `npm run test:parser` covers lexer **and** parser suites (unit + AST snapshots for `06,07,08`).
 - `check-types` + `lint` clean. Slice exit: fixtures `06,07,08` produce no `Error` node /
   diagnostic; recovery tests prove no-throw on malformed input.
+
+---
+
+# Slice 3 — GST containers (AC3)
+
+**Status:** slice 3a (brace) in progress on `feature/US-411-gst-containers`. Slice 2 merged (#32).
+
+## Scope split (kept reviewable)
+AC3 names two container formats; landing both at once is unreviewably large, so:
+- **Slice 3a (this PR): the GST brace format** — `Object subclass: #Foo [ … ]` class bodies,
+  `Foo >> sel [ … ]` / `Foo class >> sel [ … ]` and short-form `sel [ … ]` method definitions,
+  `obj extend [ … ]`, `Namespace current: #X [ … ]`, `Foo class [ … ]` class-side scopes, instance
+  -variable declarations, `<…>` attributes/pragmas (incl. `<primitive: …>`), method patterns
+  (unary/binary/keyword), and `Namespace::Class` scoped names. Snapshots over fixtures `11,12,13`.
+- **Slice 3b (next): the GST chunk method format** (`!Class methodsFor: '…'! … ! !`) and the GST
+  primaries `#{…}` binding / `##(…)` compile-time constants (fixture 14), plus the esoteric
+  "nested receiver" definition blocks (`Namespace definition: [ name: … ]`, implicit-receiver
+  keyword messages) and dotted-namespace paths (`A.B`) seen in fixture 11's tail.
+
+## Approach — files & integration
+The container layer is **layered over the slice-2 core** (the expression parser is untouched):
+- **`ast.ts`** — new nodes `Definition` (with `definitionKind`: subclass | namespace | extend |
+  classScope | scoped), `MethodDefinition` (target?, classSide, selector, messageType, params,
+  pragmas, temps, statements), `Pragma`, `InstanceVariables`; `DynamicArray` gains `temporaries`.
+- **`parser.ts`** — container recognition sits in `parseStatement` + a new `parseClassBody`:
+  - **Method def** `Class [class] >> pattern [ body ]` detected by `looksLikeMethodDef` lookahead
+    (so binary/keyword patterns like `>> + arg` don't break the expression parser).
+  - **Scoped def** `<expr> [ body ]`: parse the expression; a **trailing `[`** (left after a
+    complete keyword/unary message, vs a block that is a keyword arg) introduces a container body.
+    `classifyDefiner` derives the kind/name from the definer's shape.
+  - **Class-body items**: instance-var `| … |`, `<…>` pragmas, full/short method defs, nested
+    defs, and statements — `.` optional between items.
+  - **Short-form method** `pattern [ body ]` inside a body via `looksLikeShortMethodDef` (a leading
+    `Keyword`, a `BinarySelector + Identifier`, or `Identifier` directly before `[`).
+  - **Scoped names** `A::B` handled in `parsePrimary`.
+
+## Key decisions
+- Method defs are **not** `.`-separated from following items (GST grammar); the sequence loop
+  skips the `.`-requirement for `Definition`/`MethodDefinition` nodes.
+- Pragmas `<…>` are recognized only in body-leading / class-body position (a bare `<`), so `a < b`
+  stays a binary message; pragma selector is built from its `Keyword` parts, args via `parsePrimary`
+  (so the closing `>` is never consumed).
+- The container logic is isolated behind clear seams (`parseMethodDefinition`, `parseScopedDefinition`,
+  `parseClassBody`); the **chunk format plugs in alongside** in slice 3b without touching the core.
+
+## Verification
+- `server/test/container.test.ts` — unit tests for class/method/extend/namespace/class-scope defs,
+  all method patterns, pragmas, and a no-throw sweep over fixtures `10–14`; AST snapshots over
+  `11,12,13`. Shared `astDump.ts` serializer.
+- Slice exit: fixtures `12,13` snapshot with **zero diagnostics**; fixture `11`'s brace core is
+  clean — its only diagnostics are in the slice-3b tail (implicit-receiver `definition:` blocks).

--- a/specs/US-411-Parser-And-Symbol-Table/tasks.md
+++ b/specs/US-411-Parser-And-Symbol-Table/tasks.md
@@ -45,8 +45,21 @@ S3 GST containers (AC3) → S4 symbol table + recovery (AC4, AC5).
 - [x] T057 `server/test/parser.test.ts` — unit assertions per construct + recovery tests (malformed statement → `ErrorNode` + diagnostic, no throw) + AST snapshots over fixtures `06,07,08`; `run.ts` runs lexer+parser suites under `test:parser`.
 - [x] T058 `check-types`, `lint`, `test:parser` green; open slice-2 PR (links #23).
 
+## Phase 6 — Slice 3a: GST brace container (AC3) — branch `feature/US-411-gst-containers`
+- [x] T060 `ast.ts` — `Definition`, `MethodDefinition`, `Pragma`, `InstanceVariables` nodes; `DynamicArray.temporaries`.
+- [x] T061 Method definitions: `Class >> sel`, `Class class >> sel` (full) + `sel [ … ]` (short) with unary/binary/keyword patterns; `looksLikeMethodDef`/`looksLikeShortMethodDef`. *(AC3)*
+- [x] T062 Scoped definitions: `<expr> [ body ]` via trailing-`[`; `classifyDefiner` → subclass/namespace/extend/classScope; class/namespace name extraction. *(AC3)*
+- [x] T063 Class body: instance-var decls, nested defs, statements; `.` optional between items. *(AC3)*
+- [x] T064 Pragmas/attributes `<…>` (incl. `<primitive: …>`) in class/method bodies; `A::B` scoped names; `{ | t | … }` array-constructor temps. *(AC3)*
+- [x] T065 `server/test/container.test.ts` + shared `astDump.ts` — unit tests + no-throw sweep over `10–14` + AST snapshots `11,12,13`.
+- [x] T066 `check-types`, `lint`, `test:parser` green; open slice-3a PR (links #23).
+
+## Phase 7 — Slice 3b: GST chunk container + GST primaries (AC3, remainder)
+- [ ] S3b-1 Chunk method format `!Class methodsFor: '…'! … ! !` (mode switch over `!` chunks).
+- [ ] S3b-2 GST primaries: `#{…}` binding constants, `##(…)` compile-time constants (fixture 14).
+- [ ] S3b-3 Esoteric tail: implicit-receiver `definition: [ name: … ]` blocks, dotted-namespace `A.B` paths (fixture 11 tail).
+
 ## Later slices (tracked here, planned per-slice when started)
-- [ ] S3 GST containers (AC3): `Container` interface, brace + chunk plug-ins, **method patterns + primitives** (moved here from S2, see plan.md).
 - [ ] S4 Symbol table + recovery (AC4, AC5): `symbolTable.ts`, synchronization, kernel smoke test.
 
 ## Story-level Done (after S4)


### PR DESCRIPTION
## Summary

Third slice of the US-411 front-end: the **GST brace container format**, layered over the slice-2 expression parser (which is untouched). `parse()` now recognizes class definitions, scoped method definitions, and the other brace-scoped forms, producing container AST nodes — and still **never throws**.

**Closes:** _n/a — slice 3a; does not close the story_ &nbsp;|&nbsp; **Story:** US-411 (#23) &nbsp;|&nbsp; **ADR (if any):** ADR-0001

### Scope split (AC3, kept reviewable)
AC3 names **two** container formats; landing both at once would be unreviewably large, so:
- **This PR — brace format**: `Object subclass: #Foo [ … ]` class bodies; `Foo >> sel [ … ]` / `Foo class >> sel [ … ]` and short-form `sel [ … ]` method defs (unary/binary/keyword patterns); `obj extend [ … ]`; `Namespace current: #X [ … ]`; `Foo class [ … ]` class-side scopes; instance-var decls; `<…>` attributes/pragmas incl. `<primitive: …>`; `Namespace::Class` scoped names; `{ | t | … }` constructor temps.
- **Slice 3b (next)**: the GST **chunk** method format (`!Class methodsFor: '…'! … ! !`), GST primaries `#{…}` / `##(…)` (fixture 14), and the esoteric "nested receiver" `definition:` blocks + dotted-namespace paths in fixture 11's tail.

### What's here
- `server/src/parser/ast.ts` — `Definition` (`definitionKind`: subclass/namespace/extend/classScope/scoped), `MethodDefinition` (optional `target`, `classSide`, selector, messageType, params, pragmas, temps, statements), `Pragma`, `InstanceVariables`; `DynamicArray.temporaries`.
- `server/src/parser/parser.ts` — container recognition in `parseStatement` + `parseClassBody`, layered over the core:
  - Method defs via `looksLikeMethodDef` / `looksLikeShortMethodDef` lookahead (so binary/keyword patterns like `>> + arg` don't break the expression parser).
  - Scoped defs via the **trailing-`[`** rule (distinguishing a class body from a block that is a keyword arg); `classifyDefiner` derives kind + class/namespace name.
  - Pragmas recognized only in body-leading position (a bare `<`), so `a < b` stays a binary message.
- `server/test/container.test.ts` + shared `astDump.ts` — unit tests (class/method/extend/namespace/class-scope defs, all method patterns, pragmas) + a **no-throw sweep over fixtures 10–14** + AST snapshots over `11,12,13`.

## Output Eval — *is the artifact right?*

- [x] AC met for this slice — **AC3 (brace)**; chunk + GST primaries are slice 3b.
- [x] Output eval added — AST snapshots `11,12,13` under `npm run test:parser` (55 checks total: lexer 26 + parser 19 + container 10). **Fixtures 12,13 snapshot with zero diagnostics; fixture 11's brace core is clean** (remaining diagnostics are all in the slice-3b tail). Grammar `npm run eval` unaffected.
- [ ] CI green on Linux, macOS, Windows — _pending the Actions run._
- [ ] Manual QA in an Extension Development Host — **N/A**: parser is internal, not yet wired to a provider.
- [ ] [Output rubric](evals/rubrics/output-eval.md) — for reviewer.

Local: `check-types` ✓ · `lint` ✓ · `test:parser` 55/55 ✓ · `test:client` 6/6 ✓ · `test:server` ✓.

## Trajectory Eval — *was it produced the right way?*

- [x] Traces to US-411/#23; slice-3 `plan.md`/`tasks.md` authored; the AC3 scope split (brace now / chunk next) recorded with rationale.
- [x] Tests written with the change; container decisions documented; no drift left behind.
- [x] Conventional scoped commit; outcomes reported faithfully (the fixture-11 tail diagnostics are called out, not hidden; CI box left unchecked until it runs).
- [ ] [Trajectory rubric](evals/rubrics/trajectory-eval.md): ☐ Sound ☐ Sound w/ notes ☐ Unsound — for reviewer.

## Human sign-off

- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice (story DoD completes after slice 4).