### PR TITLE
feat(US-411): GST chunk method format + GST primaries (slice 3b)

### DIFF
--- a/server/src/parser/ast.ts
+++ b/server/src/parser/ast.ts
@@ -24,6 +24,10 @@ export enum NodeKind {
   CascadeReceiver = 'CascadeReceiver',
   /** A variable / identifier reference. */
   Variable = 'Variable',
+  /** A GST binding constant `#{Namespace::Class}`. */
+  BindingConstant = 'BindingConstant',
+  /** A GST compile-time constant `##( … )`. */
+  CompileTimeConstant = 'CompileTimeConstant',
   /** A GST scoped definition: `<expr> [ … ]` (subclass / namespace / extend / class-side scope). */
   Definition = 'Definition',
   /** A GST scoped method: `Class [class] >> pattern [ … ]`. */
@@ -122,8 +126,8 @@ export interface VariableNode extends NodeBase {
   readonly name: string;
 }
 
-/** How a `<expr> [ … ]` scoped definition reads, derived from the defining expression. */
-export type DefinitionKind = 'subclass' | 'namespace' | 'extend' | 'classScope' | 'scoped';
+/** How a definition reads: a `<expr> [ … ]` scoped form, or a `methodsFor:` chunk section. */
+export type DefinitionKind = 'subclass' | 'namespace' | 'extend' | 'classScope' | 'scoped' | 'methodsFor';
 
 export interface DefinitionNode extends NodeBase {
   readonly kind: NodeKind.Definition;
@@ -159,6 +163,18 @@ export interface PragmaNode extends NodeBase {
 export interface InstanceVariablesNode extends NodeBase {
   readonly kind: NodeKind.InstanceVariables;
   readonly names: NameRef[];
+}
+
+export interface BindingConstantNode extends NodeBase {
+  readonly kind: NodeKind.BindingConstant;
+  /** The bound name, e.g. `Transcript` or `TestBindings::MyBoundClass`. */
+  readonly path: string;
+}
+
+export interface CompileTimeConstantNode extends NodeBase {
+  readonly kind: NodeKind.CompileTimeConstant;
+  readonly temporaries: NameRef[];
+  readonly statements: Node[];
 }
 
 export interface LiteralNode extends NodeBase {
@@ -203,6 +219,8 @@ export type Node =
   | MethodDefinitionNode
   | PragmaNode
   | InstanceVariablesNode
+  | BindingConstantNode
+  | CompileTimeConstantNode
   | LiteralNode
   | LiteralArrayNode
   | ByteArrayNode

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -119,8 +119,94 @@ class Parser {
         }
         this.synchronize(stop);
       }
+      // GST chunk container: `Class methodsFor: '…'! method ! … ! !` (top level only).
+      if (stop === TokenKind.EOF && this.isMethodsForHeader(stmt) && this.at(TokenKind.Bang)) {
+        statements[statements.length - 1] = this.parseMethodsForSection(stmt);
+      }
     }
     return { temporaries, statements };
+  }
+
+  // --- GST chunk container (AC3) ---------------------------------------------
+
+  private isMethodsForHeader(stmt: Node): boolean {
+    return (
+      stmt.kind === NodeKind.Message &&
+      stmt.messageType === 'keyword' &&
+      stmt.selector.includes('methodsFor:')
+    );
+  }
+
+  private parseMethodsForSection(header: Node): Node {
+    let target: Node = header;
+    let classSide = false;
+    if (header.kind === NodeKind.Message) {
+      const recv = header.receiver;
+      if (recv.kind === NodeKind.Message && recv.messageType === 'unary' && recv.selector === 'class') {
+        classSide = true;
+        target = recv.receiver;
+      } else {
+        target = recv;
+      }
+    }
+    this.advance(); // '!' after the header
+    const body: Node[] = [];
+    while (!this.atEnd()) {
+      if (this.at(TokenKind.Bang)) {
+        this.advance(); // chunk separator / empty terminating chunk
+        continue;
+      }
+      // The section ends at the first chunk that reads as a doit, not a method pattern.
+      if (!this.chunkLooksLikeMethod()) {
+        break;
+      }
+      body.push(this.parseChunkMethod(target, classSide));
+    }
+    return {
+      kind: NodeKind.Definition,
+      definitionKind: 'methodsFor',
+      definer: header,
+      body,
+      start: header.start,
+      end: this.prev.end,
+      startPos: header.startPos,
+      endPos: this.prev.endPos,
+    };
+  }
+
+  /** A chunk is a method when it starts with a method pattern, not a `receiver keyword:` doit. */
+  private chunkLooksLikeMethod(): boolean {
+    if (this.at(TokenKind.Keyword)) {
+      return true;
+    }
+    if (
+      this.at(TokenKind.BinarySelector) &&
+      this.current().text !== '<' &&
+      this.current().text !== '>' &&
+      this.peek(1).kind === TokenKind.Identifier
+    ) {
+      return true;
+    }
+    return this.at(TokenKind.Identifier) && this.peek(1).kind !== TokenKind.Keyword;
+  }
+
+  private parseChunkMethod(target: Node, classSide: boolean): Node {
+    const startTok = this.current();
+    const pattern = this.parseMethodPattern();
+    const { temporaries, statements } = this.parseSequenceBody(TokenKind.Bang);
+    const node: MethodDefinitionNode = {
+      kind: NodeKind.MethodDefinition,
+      target,
+      classSide,
+      selector: pattern.selector,
+      messageType: pattern.messageType,
+      parameters: pattern.parameters,
+      pragmas: [],
+      temporaries,
+      statements,
+      ...this.span(startTok),
+    };
+    return node;
   }
 
   private parseTemporaries(): NameRef[] {
@@ -603,6 +689,15 @@ class Parser {
         return this.parseDynamicArray();
       case TokenKind.LBracket:
         return this.parseBlock();
+      case TokenKind.HashBrace:
+        return this.parseBindingConstant();
+      case TokenKind.Hash:
+        if (this.peek(1).kind === TokenKind.HashParen) {
+          return this.parseCompileTimeConstant();
+        }
+        this.advance();
+        this.diag('Unexpected "#"', t);
+        return { kind: NodeKind.Error, message: 'Unexpected "#"', ...this.range(t) };
       default:
         this.advance(); // consume the offending token to guarantee progress
         this.diag(`Unexpected ${t.kind} "${t.text}"`, t);
@@ -693,6 +788,40 @@ class Parser {
       this.diag('Expected "}"', this.current());
     }
     return { kind: NodeKind.DynamicArray, temporaries, elements, ...this.span(startTok) };
+  }
+
+  /** `#{ Namespace::Class }` binding constant. */
+  private parseBindingConstant(): Node {
+    const startTok = this.current();
+    this.advance(); // '#{'
+    const parts: string[] = [];
+    while (!this.atEnd() && !this.at(TokenKind.RBrace)) {
+      const t = this.current();
+      if (t.kind === TokenKind.Identifier || t.kind === TokenKind.Scope || t.kind === TokenKind.Period) {
+        parts.push(t.text);
+      }
+      this.advance();
+    }
+    if (this.at(TokenKind.RBrace)) {
+      this.advance();
+    } else {
+      this.diag('Expected "}" to close binding constant', this.current());
+    }
+    return { kind: NodeKind.BindingConstant, path: parts.join(''), ...this.span(startTok) };
+  }
+
+  /** `##( … )` compile-time constant — a temporaries + statement sequence. */
+  private parseCompileTimeConstant(): Node {
+    const startTok = this.current();
+    this.advance(); // '#'
+    this.advance(); // '#('
+    const { temporaries, statements } = this.parseSequenceBody(TokenKind.RParen);
+    if (this.at(TokenKind.RParen)) {
+      this.advance();
+    } else {
+      this.diag('Expected ")" to close compile-time constant', this.current());
+    }
+    return { kind: NodeKind.CompileTimeConstant, temporaries, statements, ...this.span(startTok) };
   }
 
   /** `[ (':' id)* '|'? '| temps |'? statements ]`. */

--- a/server/test/__snapshots__/14_gst_specific_binding_compile_time_constants.ast.txt
+++ b/server/test/__snapshots__/14_gst_specific_binding_compile_time_constants.ast.txt
@@ -1,0 +1,103 @@
+Program temps=[bindingToTranscript, bindingToArray, bindingToNamespacedClass, compileTimeNow, compileTimeCalculation, emptyCompileTime, tempsOnlyCompileTime, message] @286..1988
+  Assignment target='bindingToTranscript' @325..361
+    BindingConstant 'Transcript' @348..361
+  Assignment target='bindingToArray' @363..389
+    BindingConstant 'Array' @381..389
+  Cascade @392..485
+    Message unary 'value' @392..417
+      Variable 'bindingToTranscript' @392..411
+    ;
+      Message keyword 'show:' @392..448
+        CascadeReceiver @417..417
+        Literal string "'Accessed via binding: '" @424..448
+    ;
+      Message keyword 'show:' @417..481
+        CascadeReceiver @417..417
+        Message unary 'name' @456..481
+          Message unary 'value' @456..476
+            Variable 'bindingToArray' @456..470
+    ;
+      Message unary 'cr' @417..485
+        CascadeReceiver @417..417
+  Definition namespace name='TestBindings' @522..596
+    Message keyword 'current:' @522..554
+      Variable 'Namespace' @522..531
+      Literal symbol "#TestBindings" @541..554
+    Definition subclass name='MyBoundClass' @561..594
+      Message keyword 'subclass:' @561..591
+        Variable 'Object' @561..567
+        Literal symbol "#MyBoundClass" @578..591
+  Assignment target='bindingToNamespacedClass' @628..685
+    BindingConstant 'TestBindings::MyBoundClass' @656..685
+  Message unary 'printNl' @687..729
+    Message unary 'new' @687..721
+      Message unary 'value' @687..717
+        Variable 'bindingToNamespacedClass' @687..711
+  Assignment target='compileTimeNow' @884..916
+    CompileTimeConstant temps=[] @902..916
+      Message unary 'now' @906..914
+        Variable 'Time' @906..910
+  Message unary 'print' @918..944
+    Literal string "'Compile time was: '" @918..938
+  Message unary 'printNl' @946..968
+    Variable 'compileTimeNow' @946..960
+  Assignment target='compileTimeCalculation' @1085..1261
+    CompileTimeConstant temps=[a, b, product] @1111..1261
+      Assignment target='a' @1139..1145
+        Literal integer "5" @1144..1145
+      Assignment target='b' @1151..1158
+        Literal integer "10" @1156..1158
+      Assignment target='product' @1164..1180
+        Message binary '*' @1175..1180
+          Variable 'a' @1175..1176
+          Variable 'b' @1179..1180
+      Message binary '+' @1186..1216
+        Variable 'product' @1186..1193
+        Message unary 'dayOfYear' @1196..1216
+          Message unary 'today' @1196..1206
+            Variable 'Date' @1196..1200
+  Message unary 'print' @1263..1304
+    Literal string "'Compile-time calculation result: '" @1263..1298
+  Message unary 'printNl' @1306..1336
+    Variable 'compileTimeCalculation' @1306..1328
+  Assignment target='emptyCompileTime' @1421..1445
+    CompileTimeConstant temps=[] @1441..1445
+  Message keyword 'ifTrue:' @1447..1527
+    Message unary 'isNil' @1447..1469
+      Variable 'emptyCompileTime' @1447..1463
+    Block params=[] temps=[] @1478..1527
+      Message unary 'printNl' @1480..1525
+        Literal string "'Empty compile-time constant is nil.'" @1480..1517
+  Assignment target='tempsOnlyCompileTime' @1619..1656
+    CompileTimeConstant temps=[x, y] @1643..1656
+  Message keyword 'ifTrue:' @1658..1747
+    Message unary 'isNil' @1658..1684
+      Variable 'tempsOnlyCompileTime' @1658..1678
+    Block params=[] temps=[] @1693..1747
+      Message unary 'printNl' @1695..1745
+        Literal string "'Temps-only compile-time constant is nil.'" @1695..1737
+  Assignment target='message' @1811..1915
+    Message binary ',' @1822..1915
+      Literal string "'Program started at: '" @1822..1844
+      CompileTimeConstant temps=[] @1846..1915
+        Message keyword 'printFormat:' @1850..1913
+          Message unary 'today' @1850..1860
+            Variable 'Date' @1850..1854
+          LiteralArray @1874..1913
+            Literal integer "1" @1876..1877
+            Literal integer "2" @1878..1879
+            Literal integer "3" @1880..1881
+            Literal character "$ " @1882..1884
+            Literal character "$-" @1885..1887
+            Literal integer "1900" @1888..1892
+            Literal integer "1" @1893..1894
+            Literal integer "1" @1895..1896
+            Literal character "$m" @1897..1899
+            Literal character "$-" @1900..1902
+            Literal character "$d" @1903..1905
+            Literal character "$-" @1906..1908
+            Literal character "$Y" @1909..1911
+  Message unary 'printNl' @1917..1932
+    Variable 'message' @1917..1924
+
+--- diagnostics ---

--- a/server/test/astDump.ts
+++ b/server/test/astDump.ts
@@ -70,6 +70,13 @@ export function dump(node: Node, indent: string, out: string[]): void {
     case NodeKind.Variable:
       out.push(`${indent}Variable '${node.name}' ${at}`);
       break;
+    case NodeKind.BindingConstant:
+      out.push(`${indent}BindingConstant '${node.path}' ${at}`);
+      break;
+    case NodeKind.CompileTimeConstant:
+      out.push(`${indent}CompileTimeConstant temps=[${names(node.temporaries)}] ${at}`);
+      node.statements.forEach((s) => dump(s, child, out));
+      break;
     case NodeKind.Literal:
       out.push(`${indent}Literal ${node.literalKind} ${JSON.stringify(node.value)} ${at}`);
       break;

--- a/server/test/chunk.test.ts
+++ b/server/test/chunk.test.ts
@@ -1,0 +1,113 @@
+// Unit + snapshot tests for the GST chunk method format and GST primaries
+// (US-411, slice 3b). Runs in Node via tsx.
+//
+//   npm run test:parser                # run
+//   npm run test:parser -- --update    # regenerate snapshots
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '../src/parser/parser.ts';
+import {
+  NodeKind,
+  type BindingConstantNode,
+  type CompileTimeConstantNode,
+  type DefinitionNode,
+  type MethodDefinitionNode,
+  type Node,
+} from '../src/parser/ast.ts';
+import { serializeAst } from './astDump.ts';
+
+const UPDATE = process.argv.includes('--update');
+const ROOT = process.cwd();
+const FIXTURE_DIR = path.join(ROOT, 'docs/research/gst-syntax/test-cases');
+const SNAPSHOT_DIR = path.join(ROOT, 'server/test/__snapshots__');
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+const stmts = (src: string): Node[] => parse(src).ast.statements;
+const firstStmt = (src: string): Node => stmts(src)[0] as Node;
+
+// --- GST primaries (binding / compile-time) ---------------------------------
+test('binding constant #{...}', () => {
+  const b = firstStmt('#{Transcript}') as BindingConstantNode;
+  assert.equal(b.kind, NodeKind.BindingConstant);
+  assert.equal(b.path, 'Transcript');
+  const scoped = firstStmt('#{TestBindings::MyBoundClass}') as BindingConstantNode;
+  assert.equal(scoped.path, 'TestBindings::MyBoundClass');
+});
+
+test('compile-time constant ##(...)', () => {
+  const c = firstStmt('##( 1 + 2 )') as CompileTimeConstantNode;
+  assert.equal(c.kind, NodeKind.CompileTimeConstant);
+  assert.equal(c.statements.length, 1);
+  const withTemps = firstStmt('##( | a b | a := 5. a + b )') as CompileTimeConstantNode;
+  assert.deepEqual(withTemps.temporaries.map((t) => t.name), ['a', 'b']);
+  assert.equal(withTemps.statements.length, 2);
+  const empty = firstStmt('##( )') as CompileTimeConstantNode;
+  assert.equal(empty.statements.length, 0);
+});
+
+// --- Chunk method format (AC3) ----------------------------------------------
+test('methodsFor: chunk section yields method definitions', () => {
+  const d = firstStmt("Foo methodsFor: 'cat'! bar ^1 ! baz: x ^x ! !") as DefinitionNode;
+  assert.equal(d.kind, NodeKind.Definition);
+  assert.equal(d.definitionKind, 'methodsFor');
+  const methods = d.body.map((m) => m as MethodDefinitionNode);
+  assert.deepEqual(methods.map((m) => m.selector), ['bar', 'baz:']);
+  assert.deepEqual(methods.map((m) => m.messageType), ['unary', 'keyword']);
+  assert.equal((methods[0]?.target as { name?: string }).name, 'Foo');
+});
+
+test('class-side chunk section', () => {
+  const d = firstStmt("Foo class methodsFor: 'cat'! make ^self new ! !") as DefinitionNode;
+  const m = d.body[0] as MethodDefinitionNode;
+  assert.equal(m.classSide, true);
+  assert.equal((m.target as { name?: string }).name, 'Foo');
+});
+
+test('section ends at the first doit chunk, not a method pattern', () => {
+  const s = stmts("Foo methodsFor: 'cat'! bar ^1 ! Other subclass: #X [ ] ");
+  const section = s[0] as DefinitionNode;
+  assert.equal(section.definitionKind, 'methodsFor');
+  assert.equal(section.body.length, 1); // only `bar`, not the subclass doit
+  // The subclass doit is a separate top-level definition.
+  assert.ok(
+    s.some((n) => n.kind === NodeKind.Definition && (n as DefinitionNode).definitionKind === 'subclass'),
+    'expected the subclass doit as a separate definition',
+  );
+});
+
+// --- Robustness --------------------------------------------------------------
+test('fixtures 05/10/14 never throw and return a Program', () => {
+  for (const file of ['05_core_identifiers_pseudo_vars', '10_gst_specific_chunks_eval',
+    '14_gst_specific_binding_compile_time_constants']) {
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, `${file}.st`), 'utf8');
+    assert.equal(parse(src).ast.kind, NodeKind.Program, `${file} should parse to a Program`);
+  }
+});
+
+// --- Snapshot over the binding/compile-time fixture (AC3 remainder) ----------
+for (const name of ['14_gst_specific_binding_compile_time_constants']) {
+  test(`chunk/primitives snapshot: ${name}`, () => {
+    const src = fs.readFileSync(path.join(FIXTURE_DIR, `${name}.st`), 'utf8');
+    const actual = serializeAst(src);
+    const snapPath = path.join(SNAPSHOT_DIR, `${name}.ast.txt`);
+    if (UPDATE) {
+      fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
+      fs.writeFileSync(snapPath, actual);
+      console.log(`    (updated ${path.relative(ROOT, snapPath)})`);
+      return;
+    }
+    if (!fs.existsSync(snapPath)) {
+      throw new Error(`Missing snapshot ${path.relative(ROOT, snapPath)}; run: npm run test:parser -- --update`);
+    }
+    assert.equal(actual, fs.readFileSync(snapPath, 'utf8'), `AST snapshot drift for ${name}; review, then: npm run test:parser -- --update`);
+  });
+}
+
+console.log(`chunk: ${passed} tests passed.`);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -3,3 +3,4 @@
 import './lexer.test.ts';
 import './parser.test.ts';
 import './container.test.ts';
+import './chunk.test.ts';

--- a/specs/US-411-Parser-And-Symbol-Table/plan.md
+++ b/specs/US-411-Parser-And-Symbol-Table/plan.md
@@ -186,3 +186,20 @@ The container layer is **layered over the slice-2 core** (the expression parser 
   `11,12,13`. Shared `astDump.ts` serializer.
 - Slice exit: fixtures `12,13` snapshot with **zero diagnostics**; fixture `11`'s brace core is
   clean — its only diagnostics are in the slice-3b tail (implicit-receiver `definition:` blocks).
+
+## Slice 3b — chunk container + GST primaries (completes AC3's named formats)
+- **Chunk method format** (`parser.ts`): a top-level statement whose selector includes `methodsFor:`,
+  immediately followed by `!`, starts a `Definition` (`definitionKind: 'methodsFor'`) whose body is
+  `MethodDefinition`s — one per `!`-delimited chunk (pattern + body up to the next `!`). The section
+  ends on the empty `! !` chunk **or** the first chunk that reads as a doit rather than a method
+  pattern (`chunkLooksLikeMethod`: a doit is `Identifier Keyword…`; a pattern is a lone `Keyword`,
+  `BinarySelector Identifier`, or `Identifier` not followed by a keyword). Validated on fixture 05's
+  loose (no `! !`) style: both `methodsFor:` sections resolve to the right methods.
+- **GST primaries** (`parsePrimary`): `#{ … }` → `BindingConstant` (`path`, incl. `A::B`); `##( … )`
+  (lexed as `Hash` + `HashParen`) → `CompileTimeConstant` (temporaries + statements). Fixture 14 now
+  parses with **zero diagnostics**.
+- **Documented limitation** (not an AC requirement): the fixture-11 tail's implicit-receiver
+  `definition: [ name: … ]` blocks and dotted-namespace `A.B` paths remain unsupported.
+- Verification: `server/test/chunk.test.ts` (chunk sections, class-side, section-termination,
+  bindings, compile-time) + no-throw sweep over `05/10/14` + AST snapshot `14`. `check-types`/`lint`
+  clean; `test:parser` runs lexer + parser + container + chunk suites (69 checks).

--- a/specs/US-411-Parser-And-Symbol-Table/tasks.md
+++ b/specs/US-411-Parser-And-Symbol-Table/tasks.md
@@ -54,10 +54,12 @@ S3 GST containers (AC3) → S4 symbol table + recovery (AC4, AC5).
 - [x] T065 `server/test/container.test.ts` + shared `astDump.ts` — unit tests + no-throw sweep over `10–14` + AST snapshots `11,12,13`.
 - [x] T066 `check-types`, `lint`, `test:parser` green; open slice-3a PR (links #23).
 
-## Phase 7 — Slice 3b: GST chunk container + GST primaries (AC3, remainder)
-- [ ] S3b-1 Chunk method format `!Class methodsFor: '…'! … ! !` (mode switch over `!` chunks).
-- [ ] S3b-2 GST primaries: `#{…}` binding constants, `##(…)` compile-time constants (fixture 14).
-- [ ] S3b-3 Esoteric tail: implicit-receiver `definition: [ name: … ]` blocks, dotted-namespace `A.B` paths (fixture 11 tail).
+## Phase 7 — Slice 3b: GST chunk container + GST primaries (AC3, remainder) — branch `feature/US-411-gst-chunk-primaries`
+- [x] T070 Chunk method format `Class [class] methodsFor: '…'! method ! … ! !` → `Definition` (`methodsFor`) with `MethodDefinition` bodies; section ends on the empty `! !` chunk or the first doit chunk (`chunkLooksLikeMethod` heuristic, validated on fixture 05's loose style). *(AC3)*
+- [x] T071 GST primaries: `#{…}` binding constants (`BindingConstant`), `##(…)` compile-time constants (`CompileTimeConstant`); fixture 14 now parses with **zero diagnostics**. *(AC3)*
+- [x] T072 `server/test/chunk.test.ts` — unit tests + no-throw sweep over `05/10/14` + AST snapshot `14`.
+- [x] T073 `check-types`, `lint`, `test:parser` green; open slice-3b PR (links #23).
+- [ ] S3b-NOTE (documented limitation, not blocking AC3): implicit-receiver `definition: [ name: … ]` blocks and dotted-namespace `A.B` paths (fixture 11 tail) remain unsupported — not named by any AC; revisit if a feature needs them.
 
 ## Later slices (tracked here, planned per-slice when started)
 - [ ] S4 Symbol table + recovery (AC4, AC5): `symbolTable.ts`, synchronization, kernel smoke test.


### PR DESCRIPTION
## Summary

Completes **AC3's two named container formats** — the GST **chunk** method format (brace landed in #33) — and adds the GST literal primaries, layered over the core parser. Still never throws.

**Closes:** _n/a — slice 3b; does not close the story_ &nbsp;|&nbsp; **Story:** US-411 (#23) &nbsp;|&nbsp; **ADR (if any):** ADR-0001

### What's here
- **Chunk method format**: a top-level `Class [class] methodsFor: '…'!` header followed by `!`-delimited chunks becomes a `Definition` (`definitionKind: 'methodsFor'`) whose body is `MethodDefinition`s (one per chunk — pattern + body up to the next `!`). The section ends on the empty `! !` chunk **or** the first chunk that reads as a doit rather than a method pattern (`chunkLooksLikeMethod`). Validated on fixture 05's loose, no-`! !` style — both sections resolve to the right methods (`getValue`/`printSelf`, `printSuperclass`/`getValue`).
- **GST primaries**: `#{ … }` → `BindingConstant` (`path`, incl. `A::B`); `##( … )` (lexed as `Hash` + `HashParen`) → `CompileTimeConstant` (temporaries + statements). **Fixture 14 now parses with zero diagnostics.**
- `ast.ts`: `BindingConstant`, `CompileTimeConstant`; `DefinitionKind` gains `'methodsFor'`. `server/test/chunk.test.ts` + `astDump.ts` updates; `run.ts` adds the chunk suite.

### Documented limitation (no AC requires it)
Fixture 11's tail implicit-receiver `definition: [ name: … ]` blocks and dotted-namespace `A.B` paths remain unsupported. With brace (#33) + chunk (this PR), **AC3's named formats are complete**.

## Output Eval — *is the artifact right?*

- [x] AC met — **AC3 complete** (brace + chunk); GST primaries added.
- [x] Output eval added — AST snapshot `14` (zero diagnostics) + chunk/primitive unit tests under `npm run test:parser` (69 checks: lexer 26 + parser 19 + container 10 + chunk 7 + ... ). Grammar `npm run eval` unaffected.
- [ ] CI green on Linux, macOS, Windows — _pending the Actions run._
- [ ] Manual QA in an Extension Development Host — **N/A**: parser is internal.
- [ ] [Output rubric](evals/rubrics/output-eval.md) — for reviewer.

Local: `check-types` ✓ · `lint` ✓ · `test:parser` 69/69 ✓ · `test:client` 6/6 ✓ · `test:server` ✓.

## Trajectory Eval — *was it produced the right way?*

- [x] Traces to US-411/#23; slice-3b plan/tasks updated; the unsupported fixture-11 tail is called out as a documented limitation, not hidden.
- [x] Tests written with the change; chunk-termination heuristic validated against the loose fixture-05 style; no drift left behind.
- [x] Conventional scoped commit; outcomes reported faithfully (CI box left unchecked until it runs).
- [ ] [Trajectory rubric](evals/rubrics/trajectory-eval.md): ☐ Sound ☐ Sound w/ notes ☐ Unsound — for reviewer.

## Human sign-off

- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice (story DoD completes after slice 4).