### PR TITLE
feat(US-412): document symbols / outline (slice A)

### DIFF
--- a/server/src/documents/parseCache.ts
+++ b/server/src/documents/parseCache.ts
@@ -1,0 +1,38 @@
+// Version-keyed symbol cache (US-412, slice A).
+//
+// Parsing + symbol-table building is cheap (the whole GST kernel parses in a
+// blink), but the providers can be hit repeatedly for the same unchanged
+// document, so memoize by (uri, version). The TextDocuments manager bumps
+// `version` on every edit, which naturally invalidates a stale entry.
+
+import { buildSymbolTable, type SymbolNode } from '../parser/symbols';
+import { parse } from '../parser/parser';
+
+interface TextLike {
+  readonly uri: string;
+  readonly version: number;
+  getText(): string;
+}
+
+interface CacheEntry {
+  readonly version: number;
+  readonly symbols: SymbolNode[];
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** The document's symbol table, parsed at most once per (uri, version). */
+export function getSymbols(doc: TextLike): SymbolNode[] {
+  const hit = cache.get(doc.uri);
+  if (hit && hit.version === doc.version) {
+    return hit.symbols;
+  }
+  const symbols = buildSymbolTable(parse(doc.getText()).ast);
+  cache.set(doc.uri, { version: doc.version, symbols });
+  return symbols;
+}
+
+/** Drop a document's cached entry (e.g. on close/delete). */
+export function invalidate(uri: string): void {
+  cache.delete(uri);
+}

--- a/server/src/providers/documentSymbol.ts
+++ b/server/src/providers/documentSymbol.ts
@@ -1,0 +1,44 @@
+// Document-symbol provider mapping (US-412, slice A / AC1).
+//
+// Maps the US-411 symbol tree to LSP `DocumentSymbol`s for the Outline view and
+// breadcrumbs. Pure — imports only `vscode-languageserver-types`, so it unit
+// tests under tsx without the server runtime.
+
+import { type DocumentSymbol, type Range, SymbolKind as LspSymbolKind } from 'vscode-languageserver-types';
+import { SymbolKind, type SymbolNode, type SymbolRange } from '../parser/symbols';
+
+const KIND_MAP: Record<SymbolKind, LspSymbolKind> = {
+  [SymbolKind.Namespace]: LspSymbolKind.Namespace,
+  [SymbolKind.Class]: LspSymbolKind.Class,
+  [SymbolKind.Method]: LspSymbolKind.Method,
+  [SymbolKind.InstanceVariable]: LspSymbolKind.Field,
+  [SymbolKind.ClassVariable]: LspSymbolKind.Field,
+  [SymbolKind.Temporary]: LspSymbolKind.Variable,
+};
+
+function toRange(r: SymbolRange): Range {
+  return { start: r.startPos, end: r.endPos };
+}
+
+/** Map the symbol tree to LSP document symbols. Method-local temporaries and
+ *  parameters are omitted — outlines list declarations, not locals. */
+export function toDocumentSymbols(nodes: SymbolNode[]): DocumentSymbol[] {
+  const out: DocumentSymbol[] = [];
+  for (const node of nodes) {
+    if (node.kind === SymbolKind.Temporary) {
+      continue;
+    }
+    const symbol: DocumentSymbol = {
+      name: node.name,
+      kind: KIND_MAP[node.kind],
+      range: toRange(node.range),
+      selectionRange: toRange(node.selectionRange),
+      children: toDocumentSymbols(node.children),
+    };
+    if (node.detail !== undefined) {
+      symbol.detail = node.detail;
+    }
+    out.push(symbol);
+  }
+  return out;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,21 +3,26 @@ import {
   ProposedFeatures,
   TextDocuments,
   TextDocumentSyncKind,
+  type DocumentSymbol,
+  type DocumentSymbolParams,
   type InitializeParams,
   type InitializeResult,
 } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { getSymbols, invalidate } from './documents/parseCache';
+import { toDocumentSymbols } from './providers/documentSymbol';
 
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 
 connection.onInitialize((_params: InitializeParams): InitializeResult => {
-  // No-op scaffold (US-410): advertise capabilities only. Feature providers
-  // (document symbols, definition, completion, diagnostics, hover, formatting)
-  // are added in US-412..416 once the parser (US-411) exists.
+  // Language-intelligence providers are built on the US-411 front end and run
+  // with no `gst`. US-412 adds document symbols (outline); workspace symbols and
+  // go-to-definition follow in the next slices.
   return {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
+      documentSymbolProvider: true,
     },
   };
 });
@@ -26,6 +31,16 @@ connection.onInitialized(() => {
   connection.console.log('Smalltalk language server initialized.');
 });
 
-// Track open documents (no handlers yet — wired up by later stories).
+connection.onDocumentSymbol((params: DocumentSymbolParams): DocumentSymbol[] => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return [];
+  }
+  return toDocumentSymbols(getSymbols(doc));
+});
+
+// Drop cached symbols when a document is closed.
+documents.onDidClose((e) => invalidate(e.document.uri));
+
 documents.listen(connection);
 connection.listen();

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -78,13 +78,40 @@ assert.equal(
   2,
   'expected incremental textDocumentSync (2)',
 );
+assert.equal(
+  initResult.result.capabilities.documentSymbolProvider,
+  true,
+  'expected documentSymbolProvider (US-412)',
+);
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
-send({ jsonrpc: '2.0', id: 2, method: 'shutdown' });
-await receiveId(2);
+
+// US-412: open a brace-format document and request its outline from the real server.
+const uri = 'file:///docsymbol-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: {
+    textDocument: { uri, languageId: 'smalltalk', version: 1, text: 'Object subclass: Foo [ | a | bar [ ^1 ] ]' },
+  },
+});
+send({ jsonrpc: '2.0', id: 2, method: 'textDocument/documentSymbol', params: { textDocument: { uri } } });
+const symResult = await receiveId(2);
+assert.ok(Array.isArray(symResult.result), 'documentSymbol must return an array');
+const foo = symResult.result.find((s) => s.name === 'Foo');
+assert.ok(foo, 'expected class Foo in the document symbols');
+assert.equal(foo.kind, 5, 'Foo must be a Class (SymbolKind 5)');
+assert.deepEqual(
+  (foo.children ?? []).map((s) => s.name).sort(),
+  ['a', 'bar'],
+  'Foo must contain field `a` and method `bar`',
+);
+
+send({ jsonrpc: '2.0', id: 3, method: 'shutdown' });
+await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server handshake OK: capabilities advertised, shutdown clean.');
+console.log('Server LSP OK: capabilities advertised, documentSymbol works, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/providers.test.ts
+++ b/server/test/providers.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for the LSP provider mappings (US-412). Runs in Node via tsx —
+// uses only vscode-languageserver-types (no server runtime, no VS Code).
+import assert from 'node:assert/strict';
+import { SymbolKind as LspSymbolKind, type DocumentSymbol } from 'vscode-languageserver-types';
+import { parse } from '../src/parser/parser.ts';
+import { buildSymbolTable } from '../src/parser/symbols.ts';
+import { toDocumentSymbols } from '../src/providers/documentSymbol.ts';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+const outline = (src: string): DocumentSymbol[] => toDocumentSymbols(buildSymbolTable(parse(src).ast));
+const find = (list: DocumentSymbol[], name: string): DocumentSymbol | undefined => list.find((s) => s.name === name);
+
+function assertContained(s: DocumentSymbol): void {
+  // LSP requires selectionRange ⊆ range.
+  const within =
+    (s.selectionRange.start.line > s.range.start.line ||
+      (s.selectionRange.start.line === s.range.start.line &&
+        s.selectionRange.start.character >= s.range.start.character)) &&
+    (s.selectionRange.end.line < s.range.end.line ||
+      (s.selectionRange.end.line === s.range.end.line &&
+        s.selectionRange.end.character <= s.range.end.character));
+  assert.ok(within, `selectionRange must be within range for ${s.name}`);
+  s.children?.forEach(assertContained);
+}
+
+test('brace class maps to a class symbol with field/method children', () => {
+  const top = outline('Object subclass: Foo [ | a b | bar [ ^1 ] Foo class >> make [ ^self ] ]');
+  const foo = find(top, 'Foo');
+  assert.ok(foo);
+  assert.equal(foo?.kind, LspSymbolKind.Class);
+  assert.equal(foo?.detail, 'Object');
+  const kids = foo?.children ?? [];
+  assert.deepEqual(kids.filter((c) => c.kind === LspSymbolKind.Field).map((c) => c.name), ['a', 'b']);
+  assert.deepEqual(
+    kids.filter((c) => c.kind === LspSymbolKind.Method).map((c) => c.name).sort(),
+    ['bar', 'make'],
+  );
+});
+
+test('method-local temporaries/parameters are not in the outline', () => {
+  const top = outline('Object subclass: Foo [ run: x [ | t | t := x. ^t ] ]');
+  const run = (find(top, 'Foo')?.children ?? []).find((c) => c.name === 'run:');
+  assert.equal(run?.kind, LspSymbolKind.Method);
+  assert.deepEqual(run?.children ?? [], []); // x and t are dropped
+});
+
+test('chunk-format methods appear under their class', () => {
+  const top = outline("Foo methodsFor: 'cat'! bar ^1 ! baz: x ^x ! !");
+  const foo = find(top, 'Foo');
+  assert.deepEqual((foo?.children ?? []).map((c) => c.name), ['bar', 'baz:']);
+});
+
+test('namespace maps to a Namespace symbol containing its classes', () => {
+  const top = outline('Namespace current: Kernel [ Object subclass: Bar [ go [ ^1 ] ] ]');
+  const ns = find(top, 'Kernel');
+  assert.equal(ns?.kind, LspSymbolKind.Namespace);
+  assert.equal(find(ns?.children ?? [], 'Bar')?.kind, LspSymbolKind.Class);
+});
+
+test('selectionRange is always within range', () => {
+  outline('Object subclass: Foo [ | a | bar [ ^1 ] ]').forEach(assertContained);
+});
+
+console.log(`providers: ${passed} tests passed.`);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -6,3 +6,4 @@ import './container.test.ts';
 import './chunk.test.ts';
 import './symbols.test.ts';
 import './kernel.test.ts';
+import './providers.test.ts';

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/plan.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Document/Workspace Symbols + Go-To-Definition
+
+**ID**: US-412 | **Date**: 2026-06-20 | **Spec**: ./spec.md | **Branch**: `feature/US-412-document-and-workspace-symbols-and-go-to-definition`
+
+## Summary
+Wire the US-411 front end (`parse` + `buildSymbolTable`) into three LSP providers — document symbols,
+workspace symbols, go-to-definition — over a version-keyed parse cache and a lazy workspace index.
+No new analysis; the work is the LSP boundary + indexing + tests. Delivered in **three slices** so
+each is reviewable and demoable: **A** documentSymbol (outline), **B** workspace/symbol, **C**
+definition + cache freshness. The §6 manual matrix (`verification.md`) is the 0.4.0 gate.
+
+## Approach
+Reuse existing patterns: the server is `vscode-languageserver/node` (US-410); the front end is pure
+and already emits LSP-shaped `{line,character}` ranges. New files live under `server/src/`:
+
+- **`documents/parseCache.ts`** — `getSymbols(uri, version, text) → SymbolNode[]`, memoized by
+  `(uri, version)`; the cache entry is invalidated when the `TextDocuments` version changes. A small
+  debounce window coalesces rapid edits (the providers read the latest committed version).
+- **`providers/documentSymbol.ts`** — `toDocumentSymbols(SymbolNode[]) → DocumentSymbol[]`: map our
+  `SymbolKind` → LSP `SymbolKind` (Class→Class, Method→Method, Instance/ClassVariable→Field,
+  Namespace→Namespace, Temporary→Variable), `detail` through, `range`/`selectionRange` through
+  (already positions), children recursed.
+- **`providers/workspaceIndex.ts`** — enumerate `**/*.{st,gst}` in the workspace folders (Node `fs`,
+  honoring `files.exclude` from client config), parse + flatten to a `{ name, kind, selector?,
+  classSide?, location }[]` index; rebuild incrementally on `didChange`/`didCreate`/`didDelete`.
+- **`providers/workspaceSymbol.ts`** — filter the index by the query (case-insensitive substring; LSP
+  client does the fuzzy ranking) → `WorkspaceSymbol[]`.
+- **`providers/definition.ts`** — resolve the identifier/selector under the cursor (re-tokenize the
+  line or reuse the token stream) → class refs match index Class entries; selectors match all Method
+  entries → `Location[]`, same-file first.
+- **`server.ts`** — advertise `documentSymbolProvider`, `workspaceSymbolProvider`,
+  `definitionProvider`; register the handlers; receive `workspaceFolders` + `files.exclude` on init.
+
+**Testing layers** (fastest first):
+1. **Unit (tsx)** — pure mappers/resolvers over fixture strings + `test-cases/*.st`. New
+   `server/test/providers.test.ts`, run under `test:parser`'s runner (rename concept: it is the
+   server unit runner).
+2. **LSP server test** — extend the `handshake.test.mjs` pattern: spawn the **bundled** server, run
+   `initialize` → `didOpen` → `documentSymbol`/`definition`/`workspaceSymbol`, assert real responses.
+   Fast, real, no Electron; runs in CI as `test:server`.
+3. **Integration (Electron)** — `@vscode/test-cli` config + a fixture workspace; assert
+   `vscode.executeDocumentSymbolProvider` / `executeDefinitionProvider` end-to-end (DoD requirement).
+4. **Manual** — the `verification.md` matrix (the release gate).
+
+## Steps (slices)
+**Slice A — documentSymbol / outline (AC1)** ← start here
+1. `documents/parseCache.ts` + unit test.
+2. `providers/documentSymbol.ts` (mapping) + unit test over brace + chunk fixtures.
+3. Wire `onDocumentSymbol` into `server.ts`; advertise the capability.
+4. Extend the LSP server test: `documentSymbol` request returns the class→methods hierarchy.
+5. `check-types`/`lint`/tests green → PR.
+
+**Slice B — workspace/symbol (AC2)**
+6. `providers/workspaceIndex.ts` (scan + flatten, `files.exclude`, incremental updates).
+7. `providers/workspaceSymbol.ts` (query filter) + `onWorkspaceSymbol`; advertise capability.
+8. Unit + LSP server tests (multi-file fixture dir).
+
+**Slice C — definition + freshness (AC3, AC4)**
+9. `providers/definition.ts` (position → class/selector → `Location[]`) + `onDefinition`.
+10. Cache-freshness on edit (debounce) + index invalidation; unit + LSP server tests.
+11. **Electron integration harness** (`.vscode-test.mjs` + fixture workspace + first e2e); wire into CI.
+
+**Release (0.4.0, after Slice C)**
+12. Run the `verification.md` manual matrix; bump version + CHANGELOG; confirm `MARKETPLACE` PAT;
+    cut `v0.4.0`.
+
+## Dependencies & Risks
+- **Dep**: US-411 (`parse`, `buildSymbolTable`) — merged. `vscode-languageserver` types (present).
+- **Workspace scan cost / `files.exclude` plumbing** — get the exclude globs from the client config;
+  guard very large trees; lazy + incremental. (Risk → Slice B.)
+- **Definition over-matching** (dynamic dispatch returns all implementors) — by design; order
+  same-file first; covered by manual M8.
+- **Electron e2e flakiness/cost** — keep it a thin smoke; the LSP server test carries the bulk of
+  automated end-to-end confidence; the manual matrix carries the rest.
+- **Position fidelity** — `selectionRange` must sit on the name for clean go-to-def selection.
+
+## Verification
+Per slice: `check-types` + `lint` + unit (tsx) + the LSP server test green; AST/symbol behavior
+unchanged (US-411 frozen). Story-level: Electron e2e + the **manual matrix** in `verification.md`
+(the 0.4.0 gate), then the release cut.

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/requirements-validation.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/requirements-validation.md
@@ -1,0 +1,34 @@
+# Requirements Validation Checklist
+
+**Purpose**: Validate spec quality BEFORE implementation begins
+**Type**: Requirements Quality Gate
+**Story**: US-412 — Document/workspace symbols + go-to-definition
+
+---
+
+## Section 1: Constitution Gates (Mandatory)
+- [x] **Native Look & Feel**: Uses standard VS Code surfaces — Outline, breadcrumbs, `Ctrl/Cmd+T`, `F12` — driven entirely by LSP `documentSymbol`/`workspace/symbol`/`definition`. No custom UI.
+- [x] **Zero Config**: No settings; the workspace scan and parse cache are automatic; works on first open.
+- [x] **Protocol First**: Pure LSP providers over the bundled server; the client is unchanged plumbing.
+- [x] **Robustness**: Built on the never-throws front end; a malformed file yields a partial outline (manual row 6). Definition returns all candidates rather than guessing.
+- [x] **Dialect Agnostic**: Consumes the dialect-neutral `buildSymbolTable`; brace + chunk formats both covered (AC1).
+
+## Section 2: Specification Completeness
+- [x] Goals and Non-Goals explicitly listed (§2/§3; completion/diagnostics/hover/formatting excluded).
+- [x] User stories in standard format (§4).
+- [x] Acceptance scenarios (Given/When/Then) defined (§4).
+- [x] Edge cases identified: chunk vs brace outline, multi-implementor definition, live edits/debounce, malformed file, large file, no `gst`, `files.exclude`, clean-install VSIX.
+- [x] Dependencies listed: US-411 (`parse`, `buildSymbolTable`) — merged; `vscode-languageserver` types; `@vscode/test-cli` for integration.
+
+## Section 3: Technical Design
+- [x] API/Command contracts defined: the three LSP requests + advertised server capabilities (§5).
+- [x] Data structures defined: `SymbolNode → DocumentSymbol`/`WorkspaceSymbol` mapping; the `(uri,version)` parse cache; the workspace index.
+- [x] Error handling strategy defined: never-throws front end; empty/partial results instead of failures; index guards for large trees.
+- [x] Testing strategy defined: unit (mapping + resolution) + integration (`@vscode/test-cli` on a fixture workspace) + a **manual verification matrix** (§6 / `verification.md`) gating 0.4.0.
+
+## Section 4: Validation Result
+- [x] PASS - Ready for implementation
+
+**Emphasis**: per PO direction, 0.4.0 does **not** ship on automated tests alone — the §6 manual
+verification matrix (real-corpus workspace, outline, search, go-to-def, live editing, robustness,
+no-`gst`, cross-platform, clean-install VSIX) is a hard gate, recorded in `verification.md`.

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/spec.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/spec.md
@@ -1,0 +1,135 @@
+# Specification: Document/Workspace Symbols + Go-To-Definition
+
+**ID**: US-412
+**Feature**: Navigation — outline, workspace symbol search, go-to-definition
+**Status**: Draft
+**Owner**: Leonardo Nascimento
+**Created**: 2026-06-20
+
+## 1. Overview
+The first **user-visible language-intelligence** feature, and the headline of **0.4.0**. It wires the
+US-411 front end (lexer → parser → `buildSymbolTable`) into three LSP providers — **document
+symbols** (outline/breadcrumbs), **workspace symbol search** (`Ctrl/Cmd+T`), and **go-to-definition**
+(`F12`) — so a developer can navigate a GNU Smalltalk codebase without an external tool and
+**without `gst`**. No new program analysis is invented: the symbol tree, with LSP-shaped ranges, is
+already produced by US-411; this story maps it to LSP types, indexes it across the workspace, and
+keeps it fresh with a debounced parse cache.
+
+Because this is the **first feature users actually see and click**, the verification bar is
+**manual QA in a real editor, on real code**, in addition to the automated unit/integration tests —
+see §6, which is the gate for shipping 0.4.0.
+
+## 2. Goals
+- `textDocument/documentSymbol`: a class → (instance/class methods, variables) hierarchy for both
+  brace- and chunk-format files, mapped from `buildSymbolTable`.
+- `workspace/symbol`: find classes and selectors across the workspace (`**/*.{st,gst}`, respecting
+  `files.exclude`).
+- `textDocument/definition`: from a class reference → its definition(s); from a message send → **all**
+  implementor candidates (Smalltalk is dynamically typed — return every match, ordered stably).
+- A **debounced, version-keyed parse cache** so results update as files change without reparsing on
+  every keystroke; a workspace index built lazily and updated incrementally.
+- Fully functional with **no `gst`**; zero configuration.
+- A **manual verification plan** (§6) executed before 0.4.0 ships.
+
+## 3. Non-Goals
+- No completion (US-413), diagnostics surfaced to the editor (US-414), hover (US-415), or formatting
+  (US-416).
+- No type inference or true sender/implementor *resolution* — definition returns candidate
+  implementors by selector, not a single resolved target.
+- No cross-file *semantic* linking beyond name/selector matching (no inheritance walk).
+- No changes to the parser/symbol table beyond additive helpers (US-411 behavior is frozen).
+- `foldingRange`/`documentHighlight` are out of scope unless trivially free (tracked as a stretch).
+
+## 4. User Stories & Acceptance Criteria
+**US-412**: As a Smalltalk developer, I want an outline, workspace symbol search, and
+go-to-definition, so that I can navigate a codebase quickly without an external tool.
+
+- **AC1**: `textDocument/documentSymbol` returns a hierarchy (class → methods/variables) for both
+  chunk- and brace-format files, with correct kinds and ranges.
+- **AC2**: `workspace/symbol` finds classes and selectors across the workspace (scans
+  `**/*.{st,gst}`, respects `files.exclude`), matching by substring/fuzzy query.
+- **AC3**: `textDocument/definition` jumps from a class reference to its definition(s) and from a
+  message send to implementor candidates — returning **all** matches as a `Location[]`.
+- **AC4**: Results update as files change, backed by a debounced, version-keyed parse cache (no
+  reparse storm while typing).
+
+**Acceptance scenarios**
+- *Given* a brace-format class file, *when* I open the Outline, *then* I see the class with its
+  instance and class-side methods (selector + arity) and instance/class variables nested under it.
+- *Given* a chunk-format file (`!Class methodsFor: '…'! … ! !`), *when* I open the Outline, *then*
+  the methods appear under their class.
+- *Given* the cursor on a class name, *when* I invoke Go to Definition, *then* the editor jumps to
+  the `subclass:` definition; if several files define/extend it, I get a candidate list.
+- *Given* the cursor on a unary/keyword message send, *when* I invoke Go to Definition, *then* I get
+  every method whose selector matches, across the workspace.
+- *Given* I edit a file, *when* I re-query within ~300 ms, *then* results reflect the edit; rapid
+  typing does not pin the CPU.
+- *Given* no `gst` on `PATH`, *when* I use any of the above, *then* they work unchanged.
+
+## 5. Technical Design
+**Reuse, don't rebuild.** All three providers consume `buildSymbolTable(parse(text).ast)` from
+US-411. New code is the LSP boundary + indexing.
+
+- **`server/src/documents/parseCache.ts`** — `getSymbols(doc)`: parse + `buildSymbolTable`, memoized
+  by `(uri, version)`; invalidated on change. A short **debounce** (~250–300 ms) coalesces edits.
+- **`server/src/providers/documentSymbol.ts`** — `SymbolNode → DocumentSymbol`: map our `SymbolKind`
+  to LSP `SymbolKind` (Class→Class, Method→Method, InstanceVariable/ClassVariable→Field,
+  Namespace→Namespace, Temporary→Variable), passing `range`/`selectionRange` straight through (already
+  `{line,character}`), preserving the child hierarchy.
+- **`server/src/providers/workspaceSymbol.ts`** — a lazily built **workspace index**: enumerate
+  `**/*.{st,gst}` under the workspace folders (Node `fs`/glob), parse each, flatten the symbol tree to
+  `WorkspaceSymbol` (class + selector entries with their `Location`), respect `files.exclude`. Updated
+  incrementally on `didChange`/`didCreate`/`didDelete`.
+- **`server/src/providers/definition.ts`** — at the request position, find the token/identifier:
+  a **class reference** → index entries of kind Class with that name; a **selector** (unary identifier
+  or keyword message) → all Method entries with that selector. Return `Location[]` (all candidates).
+- **`server/src/server.ts`** — advertise `documentSymbolProvider`, `workspaceSymbolProvider`,
+  `definitionProvider`; register `onDocumentSymbol`/`onWorkspaceSymbol`/`onDefinition`; keep
+  incremental `textDocumentSync`.
+- **Client** (`client/`) — already starts the server for `language: smalltalk`; no new UI. The Outline
+  view, breadcrumbs, `Ctrl/Cmd+T`, and `F12` are standard VS Code surfaces that light up once the
+  server advertises the capabilities.
+
+**Testing strategy.** (a) **Unit**: symbol→LSP mapping and definition/selector resolution over fixture
+strings + the `test-cases/*.st` files (extends the `test:parser`-style suites). (b) **Integration**:
+`@vscode/test-cli`/`@vscode/test-electron` against a small fixture workspace, asserting real
+`documentSymbol`/`workspace/symbol`/`definition` results end-to-end. (c) **Manual**: §6.
+
+## 6. Manual Verification Plan (gate for 0.4.0)
+Automated tests prove the providers return the right data; **manual QA proves the feature feels right
+in the editor, on real code.** This runs in the **Extension Development Host** (F5) and must pass
+before 0.4.0 is tagged. The full matrix lives in `verification.md`; the dimensions:
+
+1. **Real-corpus workspace** — open `../smalltalk-3.2.5/kernel/` (122 real files) as the test
+   workspace. Outline, `Ctrl/Cmd+T`, and `F12` are exercised against genuine GNU Smalltalk, not just
+   fixtures. The single strongest manual test.
+2. **Outline / breadcrumbs** — brace file *and* chunk file: classes, instance vs class-side methods,
+   variables; selectors show arity; nesting is correct; clicking an entry navigates.
+3. **Workspace symbol search** — query a class name and a selector; results span multiple files;
+   selecting one opens the right location; `files.exclude` honored.
+4. **Go-to-definition** — class reference jumps to the definition; a message send offers all
+   implementors (peek list when >1); `Ctrl/Cmd+Click` and `F12` both work.
+5. **Live editing** — type a new method/class; within ~300 ms the outline/search reflect it; rapid
+   typing doesn't spike CPU or flash errors.
+6. **Robustness in the editor** — a half-typed/malformed file still yields a usable (partial) outline
+   and never throws; a large file responds promptly.
+7. **No-`gst` & zero-config** — with `gst` absent and no settings, everything above works.
+8. **Cross-platform sanity** — exercise on the dev OS; CI covers Linux/macOS/Windows builds, but the
+   reviewer confirms no platform-specific path/URI glitches in navigation.
+9. **Clean-install smoke** — `npm run package` → install the VSIX in a clean VS Code → repeat the
+   headline checks (outline + go-to-def) to confirm the shipped artifact behaves like the dev build.
+
+Each row is recorded with a short note (and screenshot where useful) in `verification.md`. The
+`verify`/`run` skills may be used to drive the Extension Host.
+
+## 7. Risks & Limitations
+- **Workspace scan cost** on large trees — mitigate with lazy/incremental indexing, `files.exclude`,
+  and a file-count/size guard; parsing is fast (kernel: 122 files instantly in tests).
+- **Definition over-matching** — by design (dynamic dispatch) we return all selector implementors;
+  the risk is noise. Mitigate with stable ordering (same-file first) and the peek UI; document the
+  semantics so it reads as a feature, not a surprise.
+- **Cache/index staleness** — version-keyed cache + `didChange`/`didCreate`/`didDelete` handlers;
+  covered by the live-editing manual row.
+- **Manual-QA drift** — the matrix lives in `verification.md` and is gated by the PR template; the
+  real-corpus workspace keeps it honest.
+- **Scope creep** — completion/diagnostics/hover stay out (US-413+).

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/tasks.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Document/Workspace Symbols + Go-To-Definition
+
+**ID**: US-412 | **Spec**: ./spec.md | **Plan**: ./plan.md
+
+Mark each task `[x]` as it lands. Map tasks to acceptance criteria where possible.
+Delivered in three slices (each its own PR): **A** documentSymbol → **B** workspace/symbol →
+**C** definition + freshness + Electron e2e. The `verification.md` manual matrix gates 0.4.0.
+
+## Phase 1 — Spec & Setup
+- [x] T001 Spec authored; `requirements-validation.md` gate passed (PASS).
+- [x] T002 `plan.md` + `tasks.md` written; manual-QA matrix in `verification.md`.
+
+## Phase 2 — Slice A: documentSymbol / outline (AC1) — start here
+- [x] T010 `server/src/documents/parseCache.ts` — `getSymbols(doc)` memoized by `(uri, version)`; `invalidate(uri)` on close.
+- [x] T011 `server/src/providers/documentSymbol.ts` — `toDocumentSymbols(SymbolNode[])`: SymbolKind→LSP map; detail/ranges/children through; method-local temps/params omitted from the outline.
+- [x] T012 Wire `onDocumentSymbol` in `server.ts`; advertise `documentSymbolProvider`; keep incremental sync; drop cache on close.
+- [x] T013 `server/test/providers.test.ts` (tsx) — mapping unit tests over brace + chunk + namespace fixtures (hierarchy, kinds, selectionRange ⊆ range, temps dropped).
+- [x] T014 Extended the LSP server test (`handshake.test.mjs`): `initialize`→`didOpen`→`documentSymbol` returns the class→field/method hierarchy from the bundled server, and asserts the advertised capability.
+- [x] T015 `check-types`/`lint`/`test:parser`/`test:server` green + `npm run package` smoke; open Slice A PR (links the story).
+
+## Phase 3 — Slice B: workspace/symbol (AC2)
+- [ ] T020 `server/src/providers/workspaceIndex.ts` — scan `**/*.{st,gst}` in workspace folders, parse + flatten; honor `files.exclude`; incremental on `didChange`/`didCreate`/`didDelete`.
+- [ ] T021 `server/src/providers/workspaceSymbol.ts` — query filter → `WorkspaceSymbol[]`; `onWorkspaceSymbol`; advertise capability.
+- [ ] T022 Unit + LSP server tests over a multi-file fixture dir; `files.exclude` respected.
+- [ ] T023 Slice B PR.
+
+## Phase 4 — Slice C: definition + freshness (AC3, AC4)
+- [ ] T030 `server/src/providers/definition.ts` — position → identifier/selector → class defs / all implementors → `Location[]` (same-file first); `onDefinition`; advertise capability.
+- [ ] T031 Cache freshness on edit (debounce ~250–300 ms) + index invalidation; tests.
+- [ ] T032 Electron integration harness: `.vscode-test.mjs` + fixture workspace + first e2e (`executeDocumentSymbolProvider`/`executeDefinitionProvider`); wire into CI.
+- [ ] T033 Slice C PR.
+
+## Phase 5 — Verify & Release (0.4.0)
+- [ ] T900 Automated: unit + LSP server + Electron e2e green; `npm run eval` (grammar) unaffected.
+- [ ] T901 **Manual matrix in `verification.md` executed and passed** (real-corpus workspace, outline, search, go-to-def, live editing, robustness, no-`gst`, cross-platform, clean-install VSIX). *(release gate)*
+- [ ] T902 CI green on Linux/macOS/Windows.
+- [ ] T903 Bump `version` + CHANGELOG; confirm `MARKETPLACE` PAT valid; cut `v0.4.0` (CI publishes).

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
@@ -1,0 +1,64 @@
+# Implementation Verification Checklist
+
+**Purpose**: Verify implementation correctness AFTER coding
+**Type**: Implementation Verification
+**Story**: US-412 — Document/workspace symbols + go-to-definition
+**Tester**: _________________  **Date**: __________  **OS / VS Code ver**: __________
+
+> US-412 is the **first user-visible feature**, so this gate is weighted toward **manual QA in the
+> Extension Development Host on real code** (Section 4). Automated tests are necessary but not
+> sufficient to ship 0.4.0.
+
+---
+
+## Section 1: Acceptance Criteria
+- [ ] AC1 documentSymbol (brace + chunk) — automated unit + integration test passing.
+- [ ] AC2 workspace/symbol (scan, `files.exclude`) — automated test passing.
+- [ ] AC3 definition (class ref + all selector implementors) — automated test passing.
+- [ ] AC4 debounced version-keyed parse cache — automated test passing.
+
+## Section 2: Code Quality
+- [ ] `npm run check-types` clean (strict).
+- [ ] `npm run lint` passes.
+- [ ] `npm run test:parser` + new provider unit tests + `npm test` (integration) pass.
+- [ ] No unjustified `any`; TSDoc on the provider/cache public surface.
+
+## Section 3: Constitutional Compliance
+- [ ] **Native**: standard Outline/breadcrumbs/`Ctrl+T`/`F12`; no bespoke UI.
+- [ ] **Zero Config**: works on first open, no settings.
+- [ ] **Robustness**: malformed file → partial outline, never throws.
+- [ ] **TDD**: provider unit + integration tests authored with the change.
+
+## Section 4: Manual Verification — Extension Host matrix (the 0.4.0 gate)
+Launch with **F5** (Extension Development Host). Record **Pass/Fail + a note** per row; attach a
+screenshot for the headline rows (M1, M2, M4). Keep the Developer Tools console open (Help → Toggle
+Developer Tools) and confirm **no errors/exceptions** throughout.
+
+| ID | Area | Steps | Expected | Result | Notes |
+|----|------|-------|----------|--------|-------|
+| M1 | **Real-corpus outline** | Open `../smalltalk-3.2.5/kernel/` as the workspace; open `Array.st`, then open the Outline view. | Class `Array` with its methods nested (selectors + arity); instance variables shown; entries clickable → cursor jumps. | ☐ | |
+| M2 | **Chunk-format outline** | Open a chunk file (`test-cases/05_*` or `09_*`); open Outline. | Methods grouped under their class; no errors. | ☐ | |
+| M3 | **Brace-format outline detail** | Open `test-cases/11`/`12`/`13`; check Outline. | Namespaces → classes → instance/class methods + ivars/cvars; class-side methods marked. | ☐ | |
+| M4 | **Workspace symbol — class** | `Ctrl/Cmd+T`, type a class name (e.g. `Array`). | Class appears (possibly several files); selecting opens the definition site. | ☐ | |
+| M5 | **Workspace symbol — selector** | `Ctrl/Cmd+T`, type a common selector (e.g. `printOn:`). | Multiple implementors across files; each opens correctly. | ☐ | |
+| M6 | **`files.exclude` honored** | Add a folder to `files.exclude`; repeat M4/M5. | Excluded files do not appear in results. | ☐ | |
+| M7 | **Go-to-def — class ref** | In a kernel file, put the cursor on a superclass/class name; `F12` and `Ctrl/Cmd+Click`. | Jumps to the class definition; if multiple, a peek list. | ☐ | |
+| M8 | **Go-to-def — message send** | Cursor on a unary and a keyword message send; `F12`. | All implementor candidates listed (peek when >1); same-file first. | ☐ | |
+| M9 | **Live editing / debounce** | Add a new method to an open class; wait ~½s; re-open Outline / re-query `Ctrl+T`. | New symbol appears within ~300 ms; rapid typing does not spike CPU or flash errors. | ☐ | |
+| M10 | **Robustness — malformed** | Delete a `]`/`!`, leave the file half-typed. | Outline still shows a usable partial result; no crash; console clean. | ☐ | |
+| M11 | **Large file responsiveness** | Open the largest kernel file; scroll, query, go-to-def. | Outline/results appear promptly (sub-second); editor stays responsive. | ☐ | |
+| M12 | **No `gst` / zero-config** | Ensure `gst` is not on `PATH` and no settings set; repeat M1, M4, M7. | Everything works unchanged; no error notifications. | ☐ | |
+| M13 | **Cross-platform sanity** | On the dev OS, confirm navigation uses correct file URIs (no `\\`/`/` glitches). | Locations open the right file:line on this OS. | ☐ | |
+| M14 | **Clean-install VSIX smoke** | `npm run package`; install the `.vsix` in a clean VS Code (no dev host); repeat M1 + M7. | Shipped artifact behaves like the dev build. | ☐ | |
+
+- [ ] Developer Tools console shows **no errors/exceptions** across the matrix.
+- [ ] All headline rows (M1, M2, M4, M5, M7, M8) **Pass**; any failing row is fixed or explicitly waived with a reason below.
+
+**Waivers / follow-ups:**
+- …
+
+## Section 5: Sign-Off
+- [ ] Automated gates green (Sections 1–3) **and** the manual matrix (Section 4) complete.
+- [ ] Ready for Merge.
+- [ ] **0.4.0 release readiness:** with US-412 merged, the manual matrix passed on a clean VSIX, and
+  the `MARKETPLACE` PAT confirmed valid, the release can be cut (version + CHANGELOG → `v0.4.0` tag).


### PR DESCRIPTION
## Summary

First slice of **US-412 navigation** (the headline of **0.4.0**): the LSP **document-symbol provider**, wiring the US-411 symbol table into the **Outline view + breadcrumbs** for GNU Smalltalk — with **no `gst`**. The hard part (parser + symbol table) is done; this is the LSP boundary.

**Closes:** _n/a — slice A of 3; does not close the story_ &nbsp;|&nbsp; **Story:** US-412 &nbsp;|&nbsp; **ADR:** ADR-0001

### What's here
- `server/src/documents/parseCache.ts` — `getSymbols(doc)`: `parse` + `buildSymbolTable` memoized by `(uri, version)`; `invalidate(uri)` on close.
- `server/src/providers/documentSymbol.ts` — `toDocumentSymbols()` maps the symbol tree to LSP `DocumentSymbol` (Class/Method/Field/Namespace), `detail`/`range`/`selectionRange` through; **method-local temporaries/parameters are omitted** from the outline (declarations, not locals). Pure (`vscode-languageserver-types` only).
- `server/src/server.ts` — advertises `documentSymbolProvider`; `onDocumentSymbol` over the cache; drops the cache on close.
- Tests: `providers.test.ts` (tsx unit — brace/chunk/namespace hierarchy, kinds, `selectionRange ⊆ range`, temps dropped) + `handshake.test.mjs` extended to drive a **real `documentSymbol` request against the bundled server**.
- Spec package authored, including the **manual-QA matrix** in `verification.md` (the 0.4.0 release gate).

### Next slices
- **B** — `workspace/symbol` (`Ctrl/Cmd+T`) + workspace index.
- **C** — `textDocument/definition` (`F12`) + cache freshness + Electron e2e harness.

## Output Eval — *is the artifact right?*

- [x] AC met for this slice — **AC1** (documentSymbol, brace + chunk).
- [x] Output eval — `providers.test.ts` unit suite + a real-server `documentSymbol` assertion in `test:server`. Grammar `npm run eval` unaffected.
- [ ] CI green on Linux/macOS/Windows — _pending the Actions run._
- [ ] Manual QA — deferred to the story-level matrix (`verification.md`); this slice is verified by the automated outline tests. (Outline is manually checkable now via F5 if desired.)
- [ ] [Output rubric](evals/rubrics/output-eval.md) — for reviewer.

Local: `check-types` ✓ · `lint` ✓ · `test:parser` 58/58 ✓ · `test:client` 6/6 ✓ · `test:server` ✓ (real documentSymbol) · `npm run package` smoke ✓.

## Trajectory Eval — *was it produced the right way?*

- [x] Traces to US-412; `spec.md`/`requirements-validation.md` (PASS)/`plan.md`/`tasks.md`/`verification.md` authored before coding; the manual-QA matrix is a first-class artifact per PO direction.
- [x] Tests written with the change (unit + real-server); reuses US-411 unchanged; no drift.
- [x] Conventional scoped commit; outcomes reported faithfully.
- [ ] [Trajectory rubric](evals/rubrics/trajectory-eval.md): ☐ Sound ☐ Sound w/ notes ☐ Unsound — for reviewer.

## Human sign-off

- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice.