### PR TITLE
feat(US-412): workspace symbol search (slice B)

### DIFF
--- a/server/src/providers/workspaceIndex.ts
+++ b/server/src/providers/workspaceIndex.ts
@@ -1,0 +1,150 @@
+// Workspace symbol index (US-412, slice B / AC2).
+//
+// Flattens each `.st`/`.gst` file's symbol tree into class/namespace/method
+// entries with a Location, keyed by file URI, so `workspace/symbol` can search
+// across the workspace. Open documents are updated from their live text; the
+// initial population reads from disk. Pure Node (fs) — no VS Code.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { parse } from '../parser/parser';
+import { buildSymbolTable, SymbolKind, type SymbolNode } from '../parser/symbols';
+import type { Position } from '../parser/token';
+
+export interface IndexRange {
+  readonly start: Position;
+  readonly end: Position;
+}
+
+export interface IndexEntry {
+  /** The class/namespace name, or the method selector. */
+  readonly name: string;
+  readonly kind: SymbolKind;
+  readonly classSide?: boolean;
+  /** The enclosing class/namespace name, when known. */
+  readonly containerName?: string;
+  readonly uri: string;
+  readonly range: IndexRange;
+  readonly selectionRange: IndexRange;
+}
+
+/** Returns true when a path should be skipped during the scan. */
+export type ExcludePredicate = (fullPath: string, basename: string, isDirectory: boolean) => boolean;
+
+const DEFAULT_EXCLUDED_DIRS = new Set(['node_modules', '.git', 'dist', 'out', '.vscode-test', 'bower_components']);
+const MAX_FILES = 5000; // guard against pathological trees
+const ST_FILE = /\.(st|gst)$/i;
+
+/** Skip well-known build/VCS directories and dot-directories. */
+export const defaultExclude: ExcludePredicate = (_full, name, isDirectory) =>
+  isDirectory && (DEFAULT_EXCLUDED_DIRS.has(name) || name.startsWith('.'));
+
+/** Build an exclude predicate from a VS Code `files.exclude` map (best-effort:
+ *  honors the common `**​/name`, `name`, and `name/**` directory globs). */
+export function excludeFromConfig(filesExclude: Record<string, boolean> | undefined): ExcludePredicate {
+  const names = new Set<string>();
+  for (const [pattern, enabled] of Object.entries(filesExclude ?? {})) {
+    if (!enabled) {
+      continue;
+    }
+    const base = pattern.replace(/^\*\*\//, '').replace(/\/\*\*$/, '').replace(/\/$/, '');
+    if (base && !base.includes('/') && !base.includes('*')) {
+      names.add(base);
+    }
+  }
+  return (full, name, isDirectory) => defaultExclude(full, name, isDirectory) || names.has(name);
+}
+
+function toRange(r: { startPos: Position; endPos: Position }): IndexRange {
+  return { start: r.startPos, end: r.endPos };
+}
+
+function flatten(uri: string, nodes: SymbolNode[], container: string | undefined, out: IndexEntry[]): void {
+  for (const node of nodes) {
+    if (node.kind === SymbolKind.Class || node.kind === SymbolKind.Namespace || node.kind === SymbolKind.Method) {
+      const entry: IndexEntry = {
+        name: node.name,
+        kind: node.kind,
+        uri,
+        range: toRange(node.range),
+        selectionRange: toRange(node.selectionRange),
+        ...(node.classSide !== undefined ? { classSide: node.classSide } : {}),
+        ...(container !== undefined ? { containerName: container } : {}),
+      };
+      out.push(entry);
+    }
+    const nextContainer =
+      node.kind === SymbolKind.Class || node.kind === SymbolKind.Namespace ? node.name : container;
+    flatten(uri, node.children, nextContainer, out);
+  }
+}
+
+export class WorkspaceIndex {
+  private readonly byUri = new Map<string, IndexEntry[]>();
+
+  /** (Re)index a single document from its text. */
+  setFile(uri: string, text: string): void {
+    const out: IndexEntry[] = [];
+    flatten(uri, buildSymbolTable(parse(text).ast), undefined, out);
+    this.byUri.set(uri, out);
+  }
+
+  removeFile(uri: string): void {
+    this.byUri.delete(uri);
+  }
+
+  clear(): void {
+    this.byUri.clear();
+  }
+
+  /** Recursively index `.st`/`.gst` files under `root`, skipping `exclude` paths. */
+  indexFolder(root: string, exclude: ExcludePredicate = defaultExclude): void {
+    let count = 0;
+    const walk = (dir: string): void => {
+      let dirents: fs.Dirent[];
+      try {
+        dirents = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const dirent of dirents) {
+        const full = path.join(dir, dirent.name);
+        if (dirent.isDirectory()) {
+          if (!exclude(full, dirent.name, true)) {
+            walk(full);
+          }
+        } else if (dirent.isFile() && ST_FILE.test(dirent.name) && count < MAX_FILES) {
+          if (exclude(full, dirent.name, false)) {
+            continue;
+          }
+          count += 1;
+          try {
+            this.setFile(pathToFileURL(full).href, fs.readFileSync(full, 'utf8'));
+          } catch {
+            // Unreadable file — skip it; never throw from indexing.
+          }
+        }
+      }
+    };
+    walk(root);
+  }
+
+  /** Entries whose name contains `query` (case-insensitive); empty query → all. */
+  query(query: string): IndexEntry[] {
+    const needle = query.toLowerCase();
+    const out: IndexEntry[] = [];
+    for (const entries of this.byUri.values()) {
+      for (const entry of entries) {
+        if (needle === '' || entry.name.toLowerCase().includes(needle)) {
+          out.push(entry);
+        }
+      }
+    }
+    return out;
+  }
+
+  get size(): number {
+    return this.byUri.size;
+  }
+}

--- a/server/src/providers/workspaceSymbol.ts
+++ b/server/src/providers/workspaceSymbol.ts
@@ -1,0 +1,33 @@
+// workspace/symbol provider mapping (US-412, slice B / AC2).
+// Maps workspace index entries to LSP WorkspaceSymbols. Pure
+// (vscode-languageserver-types only).
+
+import { SymbolKind as LspSymbolKind, type WorkspaceSymbol } from 'vscode-languageserver-types';
+import { SymbolKind } from '../parser/symbols';
+import type { IndexEntry } from './workspaceIndex';
+
+const KIND_MAP: Partial<Record<SymbolKind, LspSymbolKind>> = {
+  [SymbolKind.Namespace]: LspSymbolKind.Namespace,
+  [SymbolKind.Class]: LspSymbolKind.Class,
+  [SymbolKind.Method]: LspSymbolKind.Method,
+};
+
+export function toWorkspaceSymbols(entries: IndexEntry[]): WorkspaceSymbol[] {
+  const out: WorkspaceSymbol[] = [];
+  for (const entry of entries) {
+    const kind = KIND_MAP[entry.kind];
+    if (kind === undefined) {
+      continue;
+    }
+    const symbol: WorkspaceSymbol = {
+      name: entry.name,
+      kind,
+      location: { uri: entry.uri, range: entry.selectionRange },
+    };
+    if (entry.containerName !== undefined) {
+      symbol.containerName = entry.containerName;
+    }
+    out.push(symbol);
+  }
+  return out;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 import {
   createConnection,
   ProposedFeatures,
@@ -7,40 +9,88 @@ import {
   type DocumentSymbolParams,
   type InitializeParams,
   type InitializeResult,
+  type WorkspaceSymbol,
+  type WorkspaceSymbolParams,
 } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getSymbols, invalidate } from './documents/parseCache';
 import { toDocumentSymbols } from './providers/documentSymbol';
+import { WorkspaceIndex, defaultExclude, excludeFromConfig, type ExcludePredicate } from './providers/workspaceIndex';
+import { toWorkspaceSymbols } from './providers/workspaceSymbol';
 
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
+const index = new WorkspaceIndex();
 
-connection.onInitialize((_params: InitializeParams): InitializeResult => {
+let workspaceFolders: string[] = [];
+
+connection.onInitialize((params: InitializeParams): InitializeResult => {
   // Language-intelligence providers are built on the US-411 front end and run
-  // with no `gst`. US-412 adds document symbols (outline); workspace symbols and
-  // go-to-definition follow in the next slices.
+  // with no `gst`. US-412: document symbols (outline) + workspace symbol search;
+  // go-to-definition follows in the next slice.
+  workspaceFolders = (params.workspaceFolders ?? [])
+    .map((folder) => uriToPath(folder.uri))
+    .filter((p): p is string => p !== undefined);
   return {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       documentSymbolProvider: true,
+      workspaceSymbolProvider: true,
     },
   };
 });
 
-connection.onInitialized(() => {
+connection.onInitialized(async () => {
   connection.console.log('Smalltalk language server initialized.');
+  let exclude: ExcludePredicate = defaultExclude;
+  try {
+    const files = (await connection.workspace.getConfiguration('files')) as
+      | { exclude?: Record<string, boolean> }
+      | undefined;
+    exclude = excludeFromConfig(files?.exclude);
+  } catch {
+    // Client without configuration support — fall back to the default exclude.
+  }
+  for (const folder of workspaceFolders) {
+    index.indexFolder(folder, exclude);
+  }
+  connection.console.log(`Indexed ${index.size} Smalltalk file(s).`);
 });
 
 connection.onDocumentSymbol((params: DocumentSymbolParams): DocumentSymbol[] => {
   const doc = documents.get(params.textDocument.uri);
-  if (!doc) {
-    return [];
-  }
-  return toDocumentSymbols(getSymbols(doc));
+  return doc ? toDocumentSymbols(getSymbols(doc)) : [];
 });
 
-// Drop cached symbols when a document is closed.
-documents.onDidClose((e) => invalidate(e.document.uri));
+connection.onWorkspaceSymbol((params: WorkspaceSymbolParams): WorkspaceSymbol[] =>
+  toWorkspaceSymbols(index.query(params.query)),
+);
+
+// Keep the index fresh: open documents reflect their live text.
+documents.onDidChangeContent((e) => index.setFile(e.document.uri, e.document.getText()));
+
+documents.onDidClose((e) => {
+  invalidate(e.document.uri);
+  // Revert the index to the on-disk version of the closed file (drop unsaved edits).
+  const fsPath = uriToPath(e.document.uri);
+  if (fsPath !== undefined && fs.existsSync(fsPath)) {
+    try {
+      index.setFile(e.document.uri, fs.readFileSync(fsPath, 'utf8'));
+      return;
+    } catch {
+      // fall through to removal
+    }
+  }
+  index.removeFile(e.document.uri);
+});
+
+function uriToPath(uri: string): string | undefined {
+  try {
+    return fileURLToPath(uri);
+  } catch {
+    return undefined;
+  }
+}
 
 documents.listen(connection);
 connection.listen();

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -1,21 +1,28 @@
 // Verifies the bundled server (dist/server.js) speaks LSP: spawn it as a plain
-// Node process (no gst, no VS Code) and complete an initialize/shutdown handshake.
-// Covers US-410 AC4 (server advertises capabilities) and AC5 (no Smalltalk runtime).
+// Node process (no gst, no VS Code) and drive a real session.
+//   - initialize/shutdown handshake + advertised capabilities (US-410)
+//   - textDocument/documentSymbol returns an outline (US-412 slice A)
+//   - workspace/symbol searches an indexed folder (US-412 slice B)
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const serverPath = path.join(root, 'dist', 'server.js');
+const fixtureDir = path.join(root, 'docs', 'research', 'gst-syntax', 'test-cases');
 
 const child = spawn(process.execPath, [serverPath, '--stdio'], {
   stdio: ['pipe', 'pipe', 'inherit'],
 });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 function send(msg) {
   const json = JSON.stringify(msg);
   child.stdin.write(`Content-Length: ${Buffer.byteLength(json)}\r\n\r\n${json}`);
+}
+function respond(id, result) {
+  send({ jsonrpc: '2.0', id, result });
 }
 
 let buffer = Buffer.alloc(0);
@@ -35,6 +42,15 @@ child.stdout.on('data', (chunk) => {
     const body = buffer.subarray(bodyStart, bodyStart + len).toString('utf8');
     buffer = buffer.subarray(bodyStart + len);
     const msg = JSON.parse(body);
+    // Auto-answer server→client requests (e.g. workspace/configuration) so the
+    // server's initialization (and folder indexing) can proceed.
+    if (msg.method && msg.id !== undefined) {
+      const result = msg.method === 'workspace/configuration'
+        ? (msg.params?.items ?? [{}]).map(() => ({ exclude: {} }))
+        : null;
+      respond(msg.id, result);
+      continue;
+    }
     if (waiter) {
       const resolve = waiter;
       waiter = null;
@@ -48,45 +64,43 @@ child.stdout.on('data', (chunk) => {
 function receive() {
   return queue.length ? Promise.resolve(queue.shift()) : new Promise((r) => (waiter = r));
 }
-
 async function receiveId(id) {
   for (;;) {
     const msg = await receive();
     if (msg.id === id) return msg;
   }
 }
-
 function fail(message) {
-  console.error(`Server handshake FAILED: ${message}`);
+  console.error(`Server LSP test FAILED: ${message}`);
   child.kill();
   process.exit(1);
 }
 
-const timeout = setTimeout(() => fail('timed out waiting for the server'), 10000);
+const timeout = setTimeout(() => fail('timed out waiting for the server'), 15000);
 
+// --- initialize (with a workspace folder so the index can populate) ---
 send({
   jsonrpc: '2.0',
   id: 1,
   method: 'initialize',
-  params: { processId: process.pid, rootUri: null, capabilities: {} },
+  params: {
+    processId: process.pid,
+    rootUri: null,
+    workspaceFolders: [{ uri: pathToFileURL(fixtureDir).href, name: 'fixtures' }],
+    capabilities: { workspace: { configuration: true, workspaceFolders: true } },
+  },
 });
 
 const initResult = await receiveId(1);
 assert.ok(initResult.result?.capabilities, 'initialize must return capabilities');
-assert.equal(
-  initResult.result.capabilities.textDocumentSync,
-  2,
-  'expected incremental textDocumentSync (2)',
-);
-assert.equal(
-  initResult.result.capabilities.documentSymbolProvider,
-  true,
-  'expected documentSymbolProvider (US-412)',
-);
+const caps = initResult.result.capabilities;
+assert.equal(caps.textDocumentSync, 2, 'expected incremental textDocumentSync (2)');
+assert.equal(caps.documentSymbolProvider, true, 'expected documentSymbolProvider (US-412)');
+assert.equal(caps.workspaceSymbolProvider, true, 'expected workspaceSymbolProvider (US-412)');
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
-// US-412: open a brace-format document and request its outline from the real server.
+// --- documentSymbol (US-412 slice A) ---
 const uri = 'file:///docsymbol-test.st';
 send({
   jsonrpc: '2.0',
@@ -107,11 +121,23 @@ assert.deepEqual(
   'Foo must contain field `a` and method `bar`',
 );
 
+// --- workspace/symbol (US-412 slice B) — poll until the folder index is ready ---
+let wsResult = [];
+for (let i = 0; i < 25 && wsResult.length === 0; i++) {
+  send({ jsonrpc: '2.0', id: 100 + i, method: 'workspace/symbol', params: { query: 'MySimpleClass' } });
+  wsResult = (await receiveId(100 + i)).result ?? [];
+  if (wsResult.length === 0) await sleep(100);
+}
+const mySimple = wsResult.find((s) => s.name === 'MySimpleClass');
+assert.ok(mySimple, 'workspace/symbol must find MySimpleClass from the indexed fixtures');
+assert.equal(mySimple.kind, 5, 'MySimpleClass must be a Class (5)');
+assert.match(mySimple.location.uri, /11_/, 'MySimpleClass must resolve to fixture 11');
+
 send({ jsonrpc: '2.0', id: 3, method: 'shutdown' });
 await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities advertised, documentSymbol works, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/providers.test.ts
+++ b/server/test/providers.test.ts
@@ -1,10 +1,16 @@
 // Unit tests for the LSP provider mappings (US-412). Runs in Node via tsx —
 // uses only vscode-languageserver-types (no server runtime, no VS Code).
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 import { SymbolKind as LspSymbolKind, type DocumentSymbol } from 'vscode-languageserver-types';
 import { parse } from '../src/parser/parser.ts';
-import { buildSymbolTable } from '../src/parser/symbols.ts';
+import { buildSymbolTable, SymbolKind } from '../src/parser/symbols.ts';
 import { toDocumentSymbols } from '../src/providers/documentSymbol.ts';
+import { WorkspaceIndex, defaultExclude, excludeFromConfig } from '../src/providers/workspaceIndex.ts';
+import { toWorkspaceSymbols } from '../src/providers/workspaceSymbol.ts';
+
+const FIXTURE_DIR = path.join(process.cwd(), 'docs/research/gst-syntax/test-cases');
 
 let passed = 0;
 function test(name: string, fn: () => void): void {
@@ -65,6 +71,48 @@ test('namespace maps to a Namespace symbol containing its classes', () => {
 
 test('selectionRange is always within range', () => {
   outline('Object subclass: Foo [ | a | bar [ ^1 ] ]').forEach(assertContained);
+});
+
+// --- Workspace index + workspace/symbol (AC2) -------------------------------
+test('index.setFile + query finds classes and selectors', () => {
+  const idx = new WorkspaceIndex();
+  idx.setFile('file:///a.st', 'Object subclass: Foo [ bar [ ^1 ] at: k put: v [ ^k ] ]');
+  assert.deepEqual(idx.query('Foo').map((e) => e.name), ['Foo']);
+  const atput = idx.query('at:put:');
+  assert.equal(atput[0]?.kind, SymbolKind.Method);
+  assert.equal(atput[0]?.containerName, 'Foo'); // method's enclosing class
+  assert.equal(idx.query('').length, 3); // Foo + bar + at:put:
+});
+
+test('indexFolder scans real .st files and records locations', () => {
+  const idx = new WorkspaceIndex();
+  idx.indexFolder(FIXTURE_DIR);
+  assert.ok(idx.size >= 10, `expected the 15 fixtures indexed, got ${idx.size}`);
+  const simple = idx.query('MySimpleClass'); // defined in fixture 11
+  assert.ok(simple.length >= 1, 'expected MySimpleClass from fixture 11');
+  assert.match(simple[0]?.uri ?? '', /^file:\/\/.*11_/);
+  assert.ok((simple[0]?.range.start.line ?? -1) >= 0);
+});
+
+test('toWorkspaceSymbols maps kind, location, and container', () => {
+  const idx = new WorkspaceIndex();
+  idx.setFile('file:///a.st', 'Object subclass: Foo [ bar [ ^1 ] ]');
+  const syms = toWorkspaceSymbols(idx.query(''));
+  const foo = syms.find((s) => s.name === 'Foo');
+  assert.equal(foo?.kind, LspSymbolKind.Class);
+  const bar = syms.find((s) => s.name === 'bar');
+  assert.equal(bar?.kind, LspSymbolKind.Method);
+  assert.equal(bar?.containerName, 'Foo');
+  assert.equal(bar?.location.uri, 'file:///a.st');
+});
+
+test('exclude predicates skip build/VCS dirs and files.exclude entries', () => {
+  assert.equal(defaultExclude('/x/node_modules', 'node_modules', true), true);
+  assert.equal(defaultExclude('/x/.git', '.git', true), true);
+  assert.equal(defaultExclude('/x/src', 'src', true), false);
+  const fromCfg = excludeFromConfig({ '**/vendored': true, '**/keepme': false });
+  assert.equal(fromCfg('/x/vendored', 'vendored', true), true);
+  assert.equal(fromCfg('/x/keepme', 'keepme', true), false);
 });
 
 console.log(`providers: ${passed} tests passed.`);

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/tasks.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/tasks.md
@@ -19,10 +19,10 @@ Delivered in three slices (each its own PR): **A** documentSymbol → **B** work
 - [x] T015 `check-types`/`lint`/`test:parser`/`test:server` green + `npm run package` smoke; open Slice A PR (links the story).
 
 ## Phase 3 — Slice B: workspace/symbol (AC2)
-- [ ] T020 `server/src/providers/workspaceIndex.ts` — scan `**/*.{st,gst}` in workspace folders, parse + flatten; honor `files.exclude`; incremental on `didChange`/`didCreate`/`didDelete`.
-- [ ] T021 `server/src/providers/workspaceSymbol.ts` — query filter → `WorkspaceSymbol[]`; `onWorkspaceSymbol`; advertise capability.
-- [ ] T022 Unit + LSP server tests over a multi-file fixture dir; `files.exclude` respected.
-- [ ] T023 Slice B PR.
+- [x] T020 `server/src/providers/workspaceIndex.ts` — scan `**/*.{st,gst}` (sync fs walk, `MAX_FILES` guard), parse + flatten classes/namespaces/methods to located entries; `defaultExclude` + `excludeFromConfig(files.exclude)`; per-document refresh via `setFile`.
+- [x] T021 `server/src/providers/workspaceSymbol.ts` — substring query → `WorkspaceSymbol[]` (kind/location/containerName); `onWorkspaceSymbol` + `workspaceSymbolProvider` advertised; index built on `initialized` from `workspaceFolders` (+ `files.exclude` via configuration); kept fresh on `didChangeContent`, reverted from disk on `didClose`.
+- [x] T022 Unit tests (index query, real-folder scan over `test-cases/`, mapping, exclude predicates) + LSP server test driving `workspace/symbol` against the indexed fixture folder (answers `workspace/configuration`).
+- [x] T023 `check-types`/`lint`/`test:parser`/`test:server` green + package smoke; open Slice B PR.
 
 ## Phase 4 — Slice C: definition + freshness (AC3, AC4)
 - [ ] T030 `server/src/providers/definition.ts` — position → identifier/selector → class defs / all implementors → `Location[]` (same-file first); `onDefinition`; advertise capability.


### PR DESCRIPTION
## Summary

Second slice of **US-412 navigation**: **`workspace/symbol`** (`Ctrl/Cmd+T`) over an index of the workspace's Smalltalk files, built on the US-411 symbol table — with **no `gst`**.

**Closes:** _n/a — slice B of 3; does not close the story_ &nbsp;|&nbsp; **Story:** US-412 &nbsp;|&nbsp; **ADR:** ADR-0001 &nbsp;|&nbsp; Builds on slice A (#36, merged).

### What's here
- `server/src/providers/workspaceIndex.ts` — `WorkspaceIndex` flattens each `.st`/`.gst` file's symbol tree into located **class/namespace/method** entries keyed by URI. `indexFolder()` walks the workspace (sync `fs`, `MAX_FILES` guard, `defaultExclude` for `node_modules`/`.git`/`dist`/dot-dirs); `excludeFromConfig()` honors common `files.exclude` directory globs. `query()` is a case-insensitive substring match; `setFile`/`removeFile` keep it fresh.
- `server/src/providers/workspaceSymbol.ts` — maps entries to LSP `WorkspaceSymbol` (kind, location, `containerName`).
- `server/src/server.ts` — advertises `workspaceSymbolProvider`; builds the index on `initialized` from `workspaceFolders` (fetching `files.exclude` via configuration); refreshes on `didChangeContent`; reverts to the on-disk version on `didClose`.
- Tests: `providers.test.ts` adds index/query, a **real-folder scan over `test-cases/`**, mapping, and exclude-predicate tests; `handshake.test.mjs` now answers `workspace/configuration` and drives a **real `workspace/symbol` request against the indexed fixtures** (finds `MySimpleClass` → fixture 11).

### Next
- **Slice C** — `textDocument/definition` (`F12`), debounced freshness, and the Electron e2e harness. Then the manual-QA matrix → **v0.4.0**.

## Output Eval — *is the artifact right?*

- [x] AC met — **AC2** (`workspace/symbol`: scan `**/*.{st,gst}`, `files.exclude`, class + selector search).
- [x] Output eval — provider unit suite (now 9) + a real-server `workspace/symbol` assertion in `test:server`. Grammar `npm run eval` unaffected.
- [ ] CI green on Linux/macOS/Windows — _pending the Actions run._
- [ ] Manual QA — story-level matrix (`verification.md`); F5-checkable now (Ctrl/Cmd+T against a folder).
- [ ] [Output rubric](evals/rubrics/output-eval.md) — for reviewer.

Local: `check-types` ✓ · `lint` ✓ · `test:parser` 62 ✓ · `test:client` 6 ✓ · `test:server` ✓ (real workspace/symbol) · package smoke ✓.

## Trajectory Eval — *was it produced the right way?*

- [x] Traces to US-412 (slice B in `plan.md`/`tasks.md`); built on the merged slice A; reuses US-411 unchanged.
- [x] Tests written with the change (unit + real-server, incl. a real folder scan); no drift.
- [x] Conventional scoped commit; outcomes reported faithfully.
- [ ] [Trajectory rubric](evals/rubrics/trajectory-eval.md): ☐ Sound ☐ Sound w/ notes ☐ Unsound — for reviewer.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice.