### PR TITLE
fix(US-412): honor files.exclude changes at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 # Other entries
 syntaxes/gnu-smalltalk.tmLanguage.json
 .vscode-test/
+
+# e2e fixture workspace settings written by VS Code during tests
+client/test-e2e/fixtures/.vscode/

--- a/client/test-e2e/navigation.test.js
+++ b/client/test-e2e/navigation.test.js
@@ -44,6 +44,31 @@ suite('US-412 navigation (e2e)', () => {
     assert.ok((results || []).some((s) => s.name === 'Sample'), 'expected Sample in workspace symbols');
   });
 
+  test('AC2 files.exclude removes a file from workspace symbols after a settings change', async () => {
+    const filesConfig = () => vscode.workspace.getConfiguration('files');
+    const original = filesConfig().get('exclude') || {};
+    // Sanity: Sample is present before excluding it.
+    const before = await vscode.commands.executeCommand('vscode.executeWorkspaceSymbolProvider', 'Sample');
+    assert.ok((before || []).some((s) => s.name === 'Sample'), 'Sample should be present before exclusion');
+    try {
+      await filesConfig().update(
+        'exclude',
+        { ...original, '**/sample.st': true },
+        vscode.ConfigurationTarget.Workspace,
+      );
+      const after = await waitFor(
+        () => vscode.commands.executeCommand('vscode.executeWorkspaceSymbolProvider', 'Sample'),
+        (r) => Array.isArray(r) && !r.some((s) => s.name === 'Sample'),
+      );
+      assert.ok(
+        !(after || []).some((s) => s.name === 'Sample'),
+        'Sample must disappear from workspace symbols once files.exclude is updated at runtime',
+      );
+    } finally {
+      await filesConfig().update('exclude', original, vscode.ConfigurationTarget.Workspace);
+    }
+  });
+
   test('AC3 definition resolves the greet message send', async () => {
     const text = (await vscode.workspace.openTextDocument(sampleUri)).getText();
     const lines = text.split('\n');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,10 @@
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
+import path from 'node:path';
 import {
   createConnection,
   ProposedFeatures,
+  DidChangeConfigurationNotification,
   TextDocuments,
   TextDocumentSyncKind,
   type DefinitionParams,
@@ -28,6 +30,9 @@ const index = new WorkspaceIndex();
 const INDEX_DEBOUNCE_MS = 250;
 const indexTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let workspaceFolders: string[] = [];
+// The exclude predicate in force; refreshed from `files.exclude` on init and on
+// configuration change so the index honors it consistently.
+let currentExclude: ExcludePredicate = defaultExclude;
 
 connection.onInitialize((params: InitializeParams): InitializeResult => {
   // Language-intelligence providers are built on the US-411 front end and run
@@ -48,19 +53,19 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 
 connection.onInitialized(async () => {
   connection.console.log('Smalltalk language server initialized.');
-  let exclude: ExcludePredicate = defaultExclude;
+  // Ask the client to push `workspace/didChangeConfiguration` so edits to
+  // `files.exclude` re-trigger indexing (the client does not send these by default).
   try {
-    const files = (await connection.workspace.getConfiguration('files')) as
-      | { exclude?: Record<string, boolean> }
-      | undefined;
-    exclude = excludeFromConfig(files?.exclude);
+    await connection.client.register(DidChangeConfigurationNotification.type, undefined);
   } catch {
-    // Client without configuration support — fall back to the default exclude.
+    // Client without dynamic registration — the initial index still applies files.exclude.
   }
-  for (const folder of workspaceFolders) {
-    index.indexFolder(folder, exclude);
-  }
-  connection.console.log(`Indexed ${index.size} Smalltalk file(s).`);
+  await rebuildIndex();
+});
+
+// Re-scan when settings change so edits to `files.exclude` take effect.
+connection.onDidChangeConfiguration(() => {
+  void rebuildIndex();
 });
 
 connection.onDocumentSymbol((params: DocumentSymbolParams): DocumentSymbol[] => {
@@ -97,7 +102,7 @@ documents.onDidClose((e) => {
   const fsPath = uriToPath(e.document.uri);
   if (fsPath !== undefined && fs.existsSync(fsPath)) {
     try {
-      index.setFile(e.document.uri, fs.readFileSync(fsPath, 'utf8'));
+      indexDoc(e.document.uri, fs.readFileSync(fsPath, 'utf8'));
       return;
     } catch {
       // fall through to removal
@@ -105,6 +110,26 @@ documents.onDidClose((e) => {
   }
   index.removeFile(e.document.uri);
 });
+
+/** Re-pull `files.exclude`, re-scan the folders, then re-apply non-excluded open docs. */
+async function rebuildIndex(): Promise<void> {
+  try {
+    const files = (await connection.workspace.getConfiguration('files')) as
+      | { exclude?: Record<string, boolean> }
+      | undefined;
+    currentExclude = excludeFromConfig(files?.exclude);
+  } catch {
+    currentExclude = defaultExclude;
+  }
+  index.clear();
+  for (const folder of workspaceFolders) {
+    index.indexFolder(folder, currentExclude);
+  }
+  for (const doc of documents.all()) {
+    indexDoc(doc.uri, doc.getText());
+  }
+  connection.console.log(`Indexed ${index.size} Smalltalk file(s).`);
+}
 
 function scheduleIndex(uri: string, text: string): void {
   const existing = indexTimers.get(uri);
@@ -115,9 +140,19 @@ function scheduleIndex(uri: string, text: string): void {
     uri,
     setTimeout(() => {
       indexTimers.delete(uri);
-      index.setFile(uri, text);
+      indexDoc(uri, text);
     }, INDEX_DEBOUNCE_MS),
   );
+}
+
+/** Index a document unless `files.exclude` excludes it. */
+function indexDoc(uri: string, text: string): void {
+  const fsPath = uriToPath(uri);
+  if (fsPath !== undefined && currentExclude(fsPath, path.basename(fsPath), false)) {
+    index.removeFile(uri);
+    return;
+  }
+  index.setFile(uri, text);
 }
 
 function uriToPath(uri: string): string | undefined {


### PR DESCRIPTION
## Summary

**Found during the 0.4.0 manual-QA gate (row M6).** Adding a `files.exclude` pattern had no effect on `workspace/symbol` results — the server fetched `files.exclude` **once at startup** and never re-scanned, and the client doesn't push configuration changes by default.

**Story:** US-412 (manual-QA finding) &nbsp;|&nbsp; **Closes:** _n/a (fix)_

### Fix
- `server/src/server.ts`:
  - **Dynamically register** for `workspace/didChangeConfiguration` (the client doesn't send these otherwise), and **rebuild the index on change** — re-pull `files.exclude`, re-scan the folders, and re-apply open documents *through the exclude filter* (so an excluded file is dropped even when it's open).
  - The exclude predicate is now cached (`currentExclude`) and applied **consistently** on open/change/close, not just the initial scan.
- `client/test-e2e/navigation.test.js` — e2e reproducing M6: `Sample` is found, **disappears** from workspace symbols once `files.exclude` is updated at runtime, then restored. Without the fix this failed; now it passes.
- gitignore the e2e fixture `.vscode/` that VS Code writes during the test.

## Output Eval
- [x] Reproduces + fixes the reported M6 behavior; e2e locks it in (`test:e2e` 4/4).
- [x] `check-types` ✓ · `lint` ✓ · `test:parser` ✓ · `test:server` ✓.
- [ ] CI green on Linux/macOS/Windows — _pending._

## Trajectory
- [x] Bug surfaced by the manual-QA matrix (exactly its purpose); fixed with a regression e2e; honest commit.
- [ ] Reviewer sign-off.