### PR TITLE
fix(US-412): activate when the workspace contains Smalltalk files

### DIFF
--- a/client/test-e2e/navigation.test.js
+++ b/client/test-e2e/navigation.test.js
@@ -20,8 +20,25 @@ async function waitFor(fn, ok, tries = 60) {
 
 suite('US-412 navigation (e2e)', () => {
   suiteSetup(async () => {
+    // The extension must activate from `workspaceContains:**/*.{st,gst}` — i.e. before
+    // any Smalltalk file is opened — so workspace symbol search works on a fresh window.
+    const ext = vscode.extensions.getExtension('leocamello.vscode-smalltalk');
+    assert.ok(ext, 'extension should be present');
+    await waitFor(() => Promise.resolve(ext.isActive), (active) => active === true);
+    assert.ok(ext.isActive, 'extension must activate from workspaceContains, not only onLanguage');
+
     const doc = await vscode.workspace.openTextDocument(sampleUri);
     await vscode.window.showTextDocument(doc);
+  });
+
+  test('AC2 workspace/symbol works before any document is opened (fresh window)', async () => {
+    // Activation already happened in suiteSetup without opening a file (the assertion above),
+    // so the server is indexing on startup; a query resolves from the indexed fixtures.
+    const results = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeWorkspaceSymbolProvider', 'Sample'),
+      (r) => Array.isArray(r) && r.some((s) => s.name === 'Sample'),
+    );
+    assert.ok((results || []).some((s) => s.name === 'Sample'));
   });
 
   test('AC1 documentSymbol outline lists the class and its methods', async () => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
         "Programming Languages",
         "Snippets"
     ],
+    "activationEvents": [
+        "workspaceContains:**/*.{st,gst}"
+    ],
     "contributes": {
         "languages": [
             {

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
@@ -41,7 +41,7 @@ Developer Tools) and confirm **no errors/exceptions** throughout.
 | M3 | **Brace-format outline detail** | Open `test-cases/11`/`12`/`13`; check Outline. | Namespaces → classes → instance/class methods + ivars/cvars; class-side methods marked. | ☐ | |
 | M4 | **Workspace symbol — class** | `Ctrl/Cmd+T`, type a class name (e.g. `Array`). | Class appears (possibly several files); selecting opens the definition site. | ☐ | |
 | M5 | **Workspace symbol — selector** | `Ctrl/Cmd+T`, type a common selector (e.g. `printOn:`). | Multiple implementors across files; each opens correctly. | ☐ | |
-| M6 | **`files.exclude` honored** | Add a folder to `files.exclude`; repeat M4/M5. | Excluded files do not appear in results. | ☐ | |
+| M6 | **`files.exclude` honored** | Add a pattern (e.g. `**/Array.st`) to `files.exclude`; repeat M4/M5. | Excluded files do not appear in results. | ☐ re-test | **FAIL on first pass** — exclude was applied only at startup; changing it at runtime had no effect. **Fixed** (#39: server now registers for `didChangeConfiguration` and re-indexes; regression e2e added). Re-test after reloading the Ext Dev Host. |
 | M7 | **Go-to-def — class ref** | In a kernel file, put the cursor on a superclass/class name; `F12` and `Ctrl/Cmd+Click`. | Jumps to the class definition; if multiple, a peek list. | ☐ | |
 | M8 | **Go-to-def — message send** | Cursor on a unary and a keyword message send; `F12`. | All implementor candidates listed (peek when >1); same-file first. | ☐ | |
 | M9 | **Live editing / debounce** | Add a new method to an open class; wait ~½s; re-open Outline / re-query `Ctrl+T`. | New symbol appears within ~300 ms; rapid typing does not spike CPU or flash errors. | ☐ | |


### PR DESCRIPTION
## Summary

**Found during the 0.4.0 manual-QA gate.** On a fresh window, `Ctrl/Cmd+T` (workspace symbols) returned *"No matching workspace symbols"* until a `.st` file was opened — because the extension only activated via the auto-generated `onLanguage:smalltalk` event, so the language server (and its index) wasn't running yet.

**Story:** US-412 (manual-QA finding)

### Fix
- `package.json` — add `activationEvents: ["workspaceContains:**/*.{st,gst}"]`, so the extension activates (and the server starts indexing) whenever a workspace folder **contains** Smalltalk files — no open file required, no overhead in unrelated workspaces.
- `client/test-e2e/navigation.test.js` — assert the extension `isActive` **before any document is opened** (this fails under `onLanguage`-only activation) + a test that `workspace/symbol` resolves on a fresh window. e2e now **5/5**.
- `verification.md` — records the earlier M6 `files.exclude` finding + its fix.

## Output Eval
- [x] Reproduces + fixes the reported behavior; e2e guard added (would fail without the fix).
- [x] `check-types` ✓ · `lint` ✓ · `test:parser` ✓ · `test:server` ✓ · `test:e2e` 5/5 ✓ · package smoke ✓.
- [ ] CI green on Linux/macOS/Windows — _pending._

## Trajectory
- [x] Surfaced by the manual-QA matrix (its purpose); fixed with a regression e2e; honest commit.
- [ ] Reviewer sign-off.