### PR TITLE
docs: capture US-417 — navigation polish (folding + document highlight)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,10 @@ A snapshot of the milestone plan. Detail lives in `docs/product/` (epics, user s
 | ⬜ Planned | **0.9.0** | Hardening, performance, beta polish | No P1 bugs for 2+ weeks |
 | ⬜ Planned | **1.0.0** | Product polish; remove `preview`; publish to Open VSX | Marketing-grade README + demos |
 
-_Last updated: 2026-06-20 — 0.4.0 shipped (navigation: outline, workspace symbols, go-to-definition); M3 parser/symbol-table done. Next focus: 0.5.0 / US-413 (completion)._
+**0.4.x (point release):** navigation polish — **US-417** (semantic `foldingRange` + `documentHighlight`),
+a near-free follow-up to 0.4.0 that reuses the US-411 AST. Independent of 0.5.0.
+
+_Last updated: 2026-06-20 — 0.4.0 shipped (navigation: outline, workspace symbols, go-to-definition); M3 parser/symbol-table done. Next focus: 0.5.0 / US-413 (completion); 0.4.x polish (US-417) queued._
 
 **Dialect scope:** GNU Smalltalk now; the parser is layered (core ANSI + pluggable GST
 container formats) so other dialects (e.g. Pharo/Tonel) can be added later without a

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -960,3 +960,36 @@ Scenario: User follows Quick Start guide
 
 **Notes / Questions / Assumptions:**
 * If it slips, it ships in v1.1 and must not block v1.0.
+
+---
+
+## US-417: Navigation Polish — Semantic Folding + Document Highlight
+
+* **ID:** US-417
+* **Status:** Planned (target **0.4.x** — small follow-up to US-412)
+* **Epic:** EPIC-004
+* **Priority:** Low
+* **Estimate:** S
+* **Date Proposed:** 2026-06-20
+* **Owner:** Leonardo Nascimento
+
+**User Story:**
+> As a **Smalltalk developer**, I want **semantic code folding and highlighting of a symbol's other occurrences**, so that **navigating and reading a file feels as polished as the outline and go-to-definition already do.**
+
+**Acceptance Criteria (AC):**
+* AC1: `textDocument/foldingRange` returns ranges for class bodies, method bodies, blocks, and multi-line comments, walked from the US-411 AST (in addition to VS Code's default indentation/marker folding).
+* AC2: `textDocument/documentHighlight` highlights the occurrences of the symbol under the cursor within the current file — **scope-aware** (the same variable/parameter, or the same selector for message sends), not a naive same-text match.
+
+**Definition of Ready (DoR) Checklist:**
+* [X] Depends on US-411 (ranged AST) and US-412 (provider plumbing) — both shipped.
+* [X] Scoped as a bonus/polish item; explicitly droppable.
+* [X] Estimated/sized (S).
+
+**Definition of Done (DoD) Checklist:**
+* [ ] foldingRange + documentHighlight providers implemented over the parse cache.
+* [ ] **Language Server:** unit tests (folding ranges per construct; scoped highlight resolution) + a real-server/e2e check.
+* [ ] Works with no `gst`.
+* [ ] PO accepts the story.
+
+**Notes / Questions / Assumptions:**
+* Captured from the US-412 spec's "near-free bonuses" note. `foldingRange` is the truly near-free half (pure AST walk, reuses `parseCache`); `documentHighlight` needs the scope-aware resolution, hence its own AC. Ships as a 0.4.x point release, before/independently of 0.5.0 (US-413 completion).


### PR DESCRIPTION
## Summary

Captures the **navigation-polish follow-up** flagged during the 0.4.0 wrap — the "near-free bonuses" from the US-412 spec — so they're tracked before we start 0.5.0. Targeted at a **0.4.x** point release.

**Story:** US-417 (new backlog entry) · follow-up to US-412

- `docs/product/user-stories.md` — **US-417** (Planned, 0.4.x, Low/S):
  - **AC1** `textDocument/foldingRange` — class/method/block/comment ranges from the US-411 AST (the truly near-free half; pure AST walk over `parseCache`).
  - **AC2** `textDocument/documentHighlight` — **scope-aware** highlighting of the symbol under the cursor (its own AC, so we build the correct version, not a naive same-text match).
- `docs/ROADMAP.md` — 0.4.x point-release note.

No code — backlog capture only. The spec package is created when the story is picked up (per CONTRIBUTING). Tracked as issue (linked).