### PR TITLE
feat(US-417): semantic folding ranges (slice A)

### DIFF
--- a/client/test-e2e/fixtures/sample.st
+++ b/client/test-e2e/fixtures/sample.st
@@ -2,7 +2,9 @@
 Object subclass: Sample [
     | value |
 
-    greet [ ^'hi' ]
+    greet [
+        ^'hi'
+    ]
 
     value [ ^value ]
 

--- a/client/test-e2e/navigation.test.js
+++ b/client/test-e2e/navigation.test.js
@@ -86,6 +86,16 @@ suite('US-412 navigation (e2e)', () => {
     }
   });
 
+  test('US-417 AC1 foldingRange folds the class and method bodies', async () => {
+    const ranges = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeFoldingRangeProvider', sampleUri),
+      (r) => Array.isArray(r) && r.length > 0,
+    );
+    // sample.st: `Object subclass: Sample [` on line 1 ... `]` near the end.
+    assert.ok((ranges || []).some((r) => r.start === 1), 'expected a fold starting at the class body (line 1)');
+    assert.ok((ranges || []).length >= 2, 'expected folds for the class and at least one method');
+  });
+
   test('AC3 definition resolves the greet message send', async () => {
     const text = (await vscode.workspace.openTextDocument(sampleUri)).getText();
     const lines = text.split('\n');

--- a/server/src/documents/parseCache.ts
+++ b/server/src/documents/parseCache.ts
@@ -1,12 +1,16 @@
-// Version-keyed symbol cache (US-412, slice A).
+// Version-keyed parse cache (US-412, extended in US-417).
 //
-// Parsing + symbol-table building is cheap (the whole GST kernel parses in a
-// blink), but the providers can be hit repeatedly for the same unchanged
-// document, so memoize by (uri, version). The TextDocuments manager bumps
-// `version` on every edit, which naturally invalidates a stale entry.
+// Parsing + symbol-table building is cheap, but the providers can be hit
+// repeatedly for the same unchanged document, so memoize by (uri, version).
+// One entry holds the AST, the full token stream (incl. comments), and the
+// lazily-built symbol table. The TextDocuments manager bumps `version` on every
+// edit, which naturally invalidates a stale entry.
 
 import { buildSymbolTable, type SymbolNode } from '../parser/symbols';
 import { parse } from '../parser/parser';
+import { tokenize } from '../parser/lexer';
+import type { ProgramNode } from '../parser/ast';
+import type { Token } from '../parser/token';
 
 interface TextLike {
   readonly uri: string;
@@ -16,20 +20,41 @@ interface TextLike {
 
 interface CacheEntry {
   readonly version: number;
-  readonly symbols: SymbolNode[];
+  readonly ast: ProgramNode;
+  readonly tokens: Token[];
+  symbols?: SymbolNode[];
 }
 
 const cache = new Map<string, CacheEntry>();
 
-/** The document's symbol table, parsed at most once per (uri, version). */
-export function getSymbols(doc: TextLike): SymbolNode[] {
+function entryFor(doc: TextLike): CacheEntry {
   const hit = cache.get(doc.uri);
   if (hit && hit.version === doc.version) {
-    return hit.symbols;
+    return hit;
   }
-  const symbols = buildSymbolTable(parse(doc.getText()).ast);
-  cache.set(doc.uri, { version: doc.version, symbols });
-  return symbols;
+  const text = doc.getText();
+  const entry: CacheEntry = { version: doc.version, ast: parse(text).ast, tokens: tokenize(text).tokens };
+  cache.set(doc.uri, entry);
+  return entry;
+}
+
+/** The document's AST, parsed at most once per (uri, version). */
+export function getAst(doc: TextLike): ProgramNode {
+  return entryFor(doc).ast;
+}
+
+/** The document's full token stream (including comment trivia). */
+export function getTokens(doc: TextLike): Token[] {
+  return entryFor(doc).tokens;
+}
+
+/** The document's symbol table (built once, then cached on the entry). */
+export function getSymbols(doc: TextLike): SymbolNode[] {
+  const entry = entryFor(doc);
+  if (!entry.symbols) {
+    entry.symbols = buildSymbolTable(entry.ast);
+  }
+  return entry.symbols;
 }
 
 /** Drop a document's cached entry (e.g. on close/delete). */

--- a/server/src/parser/walk.ts
+++ b/server/src/parser/walk.ts
@@ -1,0 +1,30 @@
+// Generic AST traversal (US-417). Visits every Node-valued property/array,
+// so providers don't enumerate node kinds. Pure.
+
+import type { Node } from './ast';
+
+export function isNode(value: unknown): value is Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { kind?: unknown }).kind === 'string' &&
+    typeof (value as { start?: unknown }).start === 'number'
+  );
+}
+
+/** Pre-order visit of `node` and every descendant Node. */
+export function visit(node: Node, fn: (n: Node) => void): void {
+  fn(node);
+  for (const key of Object.keys(node)) {
+    const value = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isNode(item)) {
+          visit(item, fn);
+        }
+      }
+    } else if (isNode(value)) {
+      visit(value, fn);
+    }
+  }
+}

--- a/server/src/providers/definition.ts
+++ b/server/src/providers/definition.ts
@@ -7,41 +7,16 @@
 // (vscode-languageserver-types only).
 
 import { type Location } from 'vscode-languageserver-types';
-import { NodeKind, type Node } from '../parser/ast';
+import { NodeKind } from '../parser/ast';
 import { parse } from '../parser/parser';
 import { SymbolKind } from '../parser/symbols';
+import { visit } from '../parser/walk';
 import type { IndexEntry, WorkspaceIndex } from './workspaceIndex';
 
 export interface DefinitionQuery {
   /** `class` → a class/namespace reference; `selector` → a message send. */
   readonly target: 'class' | 'selector';
   readonly name: string;
-}
-
-function isNode(value: unknown): value is Node {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { kind?: unknown }).kind === 'string' &&
-    typeof (value as { start?: unknown }).start === 'number'
-  );
-}
-
-/** Visit every AST node (generic — walks any Node-valued property/array). */
-function visit(node: Node, fn: (n: Node) => void): void {
-  fn(node);
-  for (const key of Object.keys(node)) {
-    const value = (node as unknown as Record<string, unknown>)[key];
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (isNode(item)) {
-          visit(item, fn);
-        }
-      }
-    } else if (isNode(value)) {
-      visit(value, fn);
-    }
-  }
 }
 
 /** What does the cursor (byte `offset`) point at — a selector send or a name reference? */

--- a/server/src/providers/foldingRange.ts
+++ b/server/src/providers/foldingRange.ts
@@ -1,0 +1,33 @@
+// Folding-range provider (US-417, slice A / AC1).
+//
+// Semantic folds from the US-411 AST + token stream: class/namespace bodies,
+// method bodies, blocks, and multi-line comments. Pure
+// (vscode-languageserver-types only); reuses the shared AST walker.
+
+import { type FoldingRange, FoldingRangeKind } from 'vscode-languageserver-types';
+import { NodeKind, type Node } from '../parser/ast';
+import { TokenKind, type Token } from '../parser/token';
+import { visit } from '../parser/walk';
+
+const FOLDABLE = new Set<NodeKind>([NodeKind.Definition, NodeKind.MethodDefinition, NodeKind.Block]);
+
+/** Fold ranges for definitions, method bodies, blocks, and multi-line comments.
+ *  Only constructs spanning >= 2 lines fold. `endLine` is the construct's last
+ *  line; the editor keeps the start line visible. */
+export function toFoldingRanges(ast: Node, tokens: Token[]): FoldingRange[] {
+  const ranges: FoldingRange[] = [];
+
+  visit(ast, (node) => {
+    if (FOLDABLE.has(node.kind) && node.startPos.line < node.endPos.line) {
+      ranges.push({ startLine: node.startPos.line, endLine: node.endPos.line });
+    }
+  });
+
+  for (const token of tokens) {
+    if (token.kind === TokenKind.Comment && token.startPos.line < token.endPos.line) {
+      ranges.push({ startLine: token.startPos.line, endLine: token.endPos.line, kind: FoldingRangeKind.Comment });
+    }
+  }
+
+  return ranges;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,6 +10,8 @@ import {
   type DefinitionParams,
   type DocumentSymbol,
   type DocumentSymbolParams,
+  type FoldingRange,
+  type FoldingRangeParams,
   type InitializeParams,
   type InitializeResult,
   type Location,
@@ -17,8 +19,9 @@ import {
   type WorkspaceSymbolParams,
 } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { getSymbols, invalidate } from './documents/parseCache';
+import { getAst, getSymbols, getTokens, invalidate } from './documents/parseCache';
 import { toDocumentSymbols } from './providers/documentSymbol';
+import { toFoldingRanges } from './providers/foldingRange';
 import { WorkspaceIndex, defaultExclude, excludeFromConfig, type ExcludePredicate } from './providers/workspaceIndex';
 import { toWorkspaceSymbols } from './providers/workspaceSymbol';
 import { findDefinitions, resolveDefinitionQuery } from './providers/definition';
@@ -47,6 +50,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       documentSymbolProvider: true,
       workspaceSymbolProvider: true,
       definitionProvider: true,
+      foldingRangeProvider: true,
     },
   };
 });
@@ -84,6 +88,11 @@ connection.onDefinition((params: DefinitionParams): Location[] => {
   }
   const query = resolveDefinitionQuery(doc.getText(), doc.offsetAt(params.position));
   return query ? findDefinitions(index, query, doc.uri) : [];
+});
+
+connection.onFoldingRanges((params: FoldingRangeParams): FoldingRange[] => {
+  const doc = documents.get(params.textDocument.uri);
+  return doc ? toFoldingRanges(getAst(doc), getTokens(doc)) : [];
 });
 
 // Keep the workspace index fresh, debounced so rapid typing does not reparse on

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -98,6 +98,7 @@ assert.equal(caps.textDocumentSync, 2, 'expected incremental textDocumentSync (2
 assert.equal(caps.documentSymbolProvider, true, 'expected documentSymbolProvider (US-412)');
 assert.equal(caps.workspaceSymbolProvider, true, 'expected workspaceSymbolProvider (US-412)');
 assert.equal(caps.definitionProvider, true, 'expected definitionProvider (US-412)');
+assert.equal(caps.foldingRangeProvider, true, 'expected foldingRangeProvider (US-417)');
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
@@ -164,11 +165,36 @@ assert.ok(defResult.length >= 1, 'definition must resolve the `greet` send');
 assert.equal(defResult[0].uri, defUri, 'definition resolves within the same file');
 assert.equal(defResult[0].range.start.line, 0, '`greet` is defined on line 0');
 
+// --- textDocument/foldingRange (US-417 slice A) ---
+const foldUri = 'file:///folding-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: {
+    textDocument: {
+      uri: foldUri,
+      languageId: 'smalltalk',
+      version: 1,
+      text: 'Object subclass: Folder [\n    items [\n        ^1\n    ]\n]',
+    },
+  },
+});
+send({ jsonrpc: '2.0', id: 4, method: 'textDocument/foldingRange', params: { textDocument: { uri: foldUri } } });
+const foldResult = (await receiveId(4)).result ?? [];
+assert.ok(
+  foldResult.some((r) => r.startLine === 0 && r.endLine === 4),
+  'class body should fold lines 0..4',
+);
+assert.ok(
+  foldResult.some((r) => r.startLine === 1 && r.endLine === 3),
+  'method body should fold lines 1..3',
+);
+
 send({ jsonrpc: '2.0', id: 3, method: 'shutdown' });
 await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/providers.test.ts
+++ b/server/test/providers.test.ts
@@ -10,6 +10,8 @@ import { toDocumentSymbols } from '../src/providers/documentSymbol.ts';
 import { WorkspaceIndex, defaultExclude, excludeFromConfig } from '../src/providers/workspaceIndex.ts';
 import { toWorkspaceSymbols } from '../src/providers/workspaceSymbol.ts';
 import { findDefinitions, resolveDefinitionQuery } from '../src/providers/definition.ts';
+import { tokenize } from '../src/parser/lexer.ts';
+import { toFoldingRanges } from '../src/providers/foldingRange.ts';
 
 const FIXTURE_DIR = path.join(process.cwd(), 'docs/research/gst-syntax/test-cases');
 
@@ -146,6 +148,36 @@ test('findDefinitions returns class definitions and all selector implementors', 
   assert.deepEqual(selLocs.map((l) => l.uri).sort(), ['file:///a.st', 'file:///b.st']);
   // Same-file first: querying from b.st puts b.st's implementor first.
   assert.equal(selLocs[0]?.uri, 'file:///b.st');
+});
+
+// --- Folding ranges (AC1) ---------------------------------------------------
+const folds = (src: string) => toFoldingRanges(parse(src).ast, tokenize(src).tokens);
+const hasFold = (
+  ranges: ReturnType<typeof folds>,
+  startLine: number,
+  endLine: number,
+  kind?: string,
+) => ranges.some((r) => r.startLine === startLine && r.endLine === endLine && (kind === undefined || r.kind === kind));
+
+test('folds class bodies and method bodies with correct line ranges', () => {
+  const src = ['Object subclass: Foo [', '    greet [', '        ^1', '    ]', ']'].join('\n');
+  const ranges = folds(src);
+  assert.ok(hasFold(ranges, 0, 4), 'class Foo folds lines 0..4');
+  assert.ok(hasFold(ranges, 1, 3), 'method greet folds lines 1..3');
+});
+
+test('folds a multi-line block and skips single-line constructs', () => {
+  const block = ['x do: [ :each |', '    each printNl', ']'].join('\n');
+  assert.ok(hasFold(folds(block), 0, 2), 'block folds 0..2');
+  // A whole one-line method produces no fold (nothing to collapse).
+  assert.equal(folds('Object subclass: Foo [ bar [ ^1 ] ]').length, 0);
+});
+
+test('folds multi-line comments as comment ranges', () => {
+  const src = ['"', 'multi', 'line', '"', '1 + 1'].join('\n');
+  assert.ok(hasFold(folds(src), 0, 3, 'comment'), 'comment folds 0..3 with comment kind');
+  // A single-line comment does not fold.
+  assert.equal(folds('"one line" 1 + 1').length, 0);
 });
 
 console.log(`providers: ${passed} tests passed.`);

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/plan.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: Navigation Polish — Folding + Document Highlight
+
+**ID**: US-417 | **Date**: 2026-06-20 | **Spec**: ./spec.md | **Branch**: `feature/US-417-navigation-polish-folding-and-document-highlight`
+
+## Summary
+Two more LSP providers over the US-411 front end, reusing `parseCache`: **A** `foldingRange`
+(class/method/block/comment folds — truly near-free) and **B** `documentHighlight` (scope-aware
+occurrence highlighting). Delivered as two reviewable slices. The retired-Marketplace-badge README
+fix shipped separately (PR #44) per the request.
+
+## Approach
+- **`documents/parseCache.ts`** — add `getAst(doc)` (and `getTokens(doc)` if needed) alongside
+  `getSymbols`, memoized by the same `(uri, version)` key, so both providers read the cached parse.
+- **Slice A — `providers/foldingRange.ts`**: `toFoldingRanges(ast, tokens)`:
+  - Generic AST walk (reuse the `visit` pattern from `definition.ts`); for `Definition`,
+    `MethodDefinition`, `Block` with `startPos.line < endPos.line`, push `{ startLine, endLine }`.
+  - Multi-line `Comment` tokens → `{ startLine, endLine, kind: 'comment' }`.
+  - LSP `endLine` = the line of the node's last line that still contains content (so the closing
+    `]`/`!` line stays visible per convention; pick `endPos.line` or `endPos.line - 1` — pin with
+    tests).
+- **Slice B — `providers/documentHighlight.ts`**: `documentHighlightsAt(ast, offset)`:
+  - Classify the cursor with the `definition.ts` resolver (selector vs variable).
+  - **Selector** → all `Message` nodes with that selector; highlight the selector range.
+  - **Variable** → walk up to the nearest `Block`/`MethodDefinition`/`Program` whose params/temps
+    bind the name; collect same-name `Variable` nodes within that subtree; no binding → file-wide.
+  - Small AST touch: add the selector token range to `MessageNode` (`selectorStart/End`/positions)
+    in the parser so the selector highlight is precise, not the whole send. One focused parser edit
+    + snapshot refresh; behavior otherwise unchanged.
+- **`server.ts`** — advertise `foldingRangeProvider` + `documentHighlightProvider`; register the
+  handlers reading the cache.
+
+## Steps (slices)
+**Slice A — foldingRange (AC1)** ← start here
+1. `parseCache.getAst` (+ token access).
+2. `providers/foldingRange.ts` + unit tests (per construct, multi-line comment, single-line skipped, exact line numbers).
+3. Wire `onFoldingRanges`; advertise capability.
+4. Real-server LSP test (`foldingRange` request) + Electron e2e row.
+5. Green → PR.
+
+**Slice B — documentHighlight (AC2)**
+6. Add selector range to `MessageNode` (parser) + refresh AST snapshots.
+7. `providers/documentHighlight.ts` (selector + scoped variable) + unit tests (selector match; scoped variable; no cross-scope bleed).
+8. Wire `onDocumentHighlight`; advertise capability; real-server + e2e.
+9. Green → PR.
+
+**Release (0.4.x)**
+10. Bump version (0.4.1) + CHANGELOG; manual spot-check; cut `v0.4.1`.
+
+## Dependencies & Risks
+- **Dep**: US-411 (AST/tokens), US-412 (`parseCache`, provider plumbing) — shipped.
+- **`endLine` off-by-one** — pin with exact-line unit tests.
+- **Selector range** — the one parser/AST touch; keep it additive (don't disturb existing ranges);
+  refresh AST snapshots and confirm no diff beyond the new field.
+- **Variable scoping** — v1 = nearest binding scope; document shadowing limits. If it balloons,
+  ship Slice A and split B (per spec §6).
+
+## Verification
+Per slice: `check-types` + `lint` + unit (tsx) + real-server LSP green; AST snapshots stable
+(except the additive selector-range field in Slice B). Story-level: Electron e2e rows + a manual
+spot-check in the Extension Host (fold a class/method/block/comment; highlight a selector and a
+scoped variable), then the 0.4.1 release.

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/requirements-validation.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/requirements-validation.md
@@ -1,0 +1,34 @@
+# Requirements Validation Checklist
+
+**Purpose**: Validate spec quality BEFORE implementation begins
+**Type**: Requirements Quality Gate
+**Story**: US-417 — Navigation polish (folding + document highlight)
+
+---
+
+## Section 1: Constitution Gates (Mandatory)
+- [x] **Native Look & Feel**: standard `foldingRange`/`documentHighlight` LSP surfaces (gutter folds, occurrence highlights); no bespoke UI.
+- [x] **Zero Config**: no settings; reuses the existing parse cache; works on first open.
+- [x] **Protocol First**: two pure LSP providers over the bundled server.
+- [x] **Robustness**: built on the never-throws front end; empty result on unresolved cursor; no throw on malformed input.
+- [x] **Dialect Agnostic**: consumes the dialect-neutral AST/token stream (US-411).
+
+## Section 2: Specification Completeness
+- [x] Goals/Non-Goals explicit (§2/§3; no rename/cross-file/type resolution).
+- [x] User story + ACs in standard form (§4).
+- [x] Acceptance scenarios (Given/When/Then) defined (§4).
+- [x] Edge cases identified: multi-line-only folds, `endLine` semantics, keyword-selector spans, variable scoping/shadowing, no-binding → file-wide.
+- [x] Dependencies listed: US-411 (AST/tokens) + US-412 (`parseCache`, provider plumbing) — both shipped.
+
+## Section 3: Technical Design
+- [x] API/Command contracts: `foldingRangeProvider`, `documentHighlightProvider`; `toFoldingRanges`, `documentHighlightsAt` (§5).
+- [x] Data structures: reuse AST nodes + token stream; one small AST touch (selector range) for highlight precision.
+- [x] Error handling: never-throws front end; empty results, not failures.
+- [x] Testing strategy: unit (tsx) + real-server LSP + Electron e2e + manual spot-check.
+
+## Section 4: Validation Result
+- [x] PASS - Ready for implementation
+
+**Scope note**: two slices — **A** `foldingRange` (truly near-free, ship-first) and **B**
+`documentHighlight` (scope-aware; carries the small selector-range AST touch). If B's scoping
+balloons, A ships alone and B becomes its own follow-up (§6).

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/spec.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/spec.md
@@ -1,0 +1,96 @@
+# Specification: Navigation Polish — Semantic Folding + Document Highlight
+
+**ID**: US-417
+**Feature**: `foldingRange` + `documentHighlight` LSP providers
+**Status**: Draft
+**Owner**: Leonardo Nascimento
+**Created**: 2026-06-20
+
+## 1. Overview
+A small **0.4.x** polish follow-up to US-412: two more LSP providers over the existing US-411 front
+end. **Semantic folding** (`textDocument/foldingRange`) lets the editor collapse exactly on class
+bodies, method bodies, blocks, and multi-line comments — more precise than VS Code's default
+indentation folding. **Document highlight** (`textDocument/documentHighlight`) highlights the other
+occurrences of the symbol under the cursor within the current file. Both reuse the cached AST/token
+stream (`parseCache`), need no `gst`, and are zero-config.
+
+## 2. Goals
+- `textDocument/foldingRange`: ranges for class/namespace bodies, method bodies, blocks, and
+  multi-line comments, derived from the AST + token stream.
+- `textDocument/documentHighlight`: occurrences of the symbol under the cursor in the file —
+  **scope-aware**: a message selector → its sends; a variable → its same-name references within the
+  nearest binding scope (block/method/program), or file-wide for a class/global reference.
+- Reuse `parseCache`; no new analysis beyond walking the existing AST/tokens.
+- Fully functional with no `gst`; no settings.
+
+## 3. Non-Goals
+- No rename/refactor (highlight is read-only occurrence marking, not edit).
+- No cross-file analysis (both are single-document providers).
+- No type-based resolution of *which* implementor a send targets (selector match only) — that stays
+  with go-to-definition's "all candidates" model.
+- No folding of import/region markers beyond what the language-configuration already provides.
+
+## 4. User Stories & Acceptance Criteria
+**US-417**: As a Smalltalk developer, I want semantic code folding and highlighting of a symbol's
+other occurrences, so that navigating and reading a file feels as polished as the outline and
+go-to-definition already do.
+
+- **AC1** (`foldingRange`): returns fold ranges for class/namespace bodies, method bodies, blocks,
+  and multi-line comments (only where they span ≥ 2 lines), from the US-411 AST + token stream — in
+  addition to VS Code's default indentation/marker folding. Never throws on malformed input.
+- **AC2** (`documentHighlight`): given a cursor position, returns the occurrences of that symbol in
+  the file — **scope-aware**, not a naive same-text match:
+  - On a **message selector** → all sends with the same selector (and arity shape).
+  - On a **variable** → its same-name references bounded by the nearest enclosing scope that binds
+    it (block params/temps, method params/temps); a reference with no local binding (class/global)
+    matches file-wide.
+  - The symbol under the cursor is included; ordering is stable.
+
+**Acceptance scenarios**
+- *Given* a brace-format class, *when* I collapse the class in the gutter, *then* the whole
+  `[ … ]` body folds; method bodies and inner blocks fold independently; a multi-line `"…"` comment
+  folds.
+- *Given* the cursor on a method send `printNl`, *when* highlight runs, *then* every `printNl` send
+  in the file is highlighted.
+- *Given* the cursor on a block parameter `:x`, *when* highlight runs, *then* only the uses of that
+  `x` inside its block are highlighted — not an unrelated `x` in another method.
+
+## 5. Technical Design
+Two pure providers under `server/src/providers/`, mapped at the server boundary; both read
+`getSymbols`/the AST via a small addition to `parseCache` (expose the parsed `ast`, or add
+`getAst(doc)` alongside `getSymbols`).
+
+- **`providers/foldingRange.ts`** — `toFoldingRanges(ast, comments): FoldingRange[]`:
+  - Walk the AST; for `Definition`, `MethodDefinition`, and `Block` nodes whose `startPos.line <
+    endPos.line`, emit `{ startLine, endLine }` (end clamped to the last content line, per LSP).
+  - From the token stream, emit `kind: 'comment'` ranges for multi-line `Comment` tokens.
+  - Generic AST walk (reuse the `visit` helper pattern from `definition.ts`).
+- **`providers/documentHighlight.ts`** — `documentHighlightsAt(ast, offset): DocumentHighlight[]`:
+  - Reuse the `definition.ts` cursor resolver to classify the target (selector vs variable name).
+  - **Selector** → collect every `Message` node with that selector; highlight the selector span.
+    (Needs a selector range; either store it on `Message` in slice 2, or recompute from tokens.)
+  - **Variable** → find the nearest enclosing scope (`Block`/`MethodDefinition`/`Program`) that
+    declares the name (params/temporaries); collect same-name `Variable` nodes within it; if no
+    binding is found, collect file-wide. Mark each `DocumentHighlightKind.Text` (Write on the
+    assignment target/declaration if cheap).
+- **`server.ts`** — advertise `foldingRangeProvider` + `documentHighlightProvider`; register
+  `onFoldingRanges` / `onDocumentHighlight` reading the cache.
+- **Note**: the `Message` node currently stores `selector` as a string but not the selector token's
+  range; slice 2 adds a `selectorStart/selectorEnd` (or recomputes from the token stream) so the
+  highlight lands on the selector, not the whole send. This is the one small parser/AST touch.
+
+**Testing**: unit (tsx) for `toFoldingRanges` (per construct + multi-line comment) and
+`documentHighlightsAt` (selector match; scoped variable; no cross-scope bleed) over fixture strings;
+extend the real-server LSP test (`handshake.test.mjs`) with a `foldingRange` + `documentHighlight`
+request; an Electron e2e row each. Manual spot-check in the Extension Host.
+
+## 6. Risks & Limitations
+- **Selector range fidelity** — keyword sends span multiple tokens (`at: … put: …`); the highlight
+  should cover the keyword parts. v1 may highlight the whole send range if per-part ranges are not
+  stored; refine if needed. (Risk → slice 2.)
+- **Scope resolution depth** — full ANSI scoping (shadowing, nested blocks) is more than "near-free".
+  v1 uses the nearest binding scope; document any shadowing edge cases as known limits.
+- **Folding `endLine` semantics** — LSP folds hide lines *after* `startLine` through `endLine`;
+  off-by-one on the closing `]`/`!` looks wrong. Covered by unit tests on exact line numbers.
+- **Scope creep** — this is polish; if `documentHighlight` scoping balloons, ship `foldingRange`
+  (slice 1) alone and split highlight to its own follow-up.

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/tasks.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Navigation Polish — Folding + Document Highlight
+
+**ID**: US-417 | **Spec**: ./spec.md | **Plan**: ./plan.md
+
+Mark each task `[x]` as it lands. Two slices: **A** foldingRange → **B** documentHighlight.
+
+## Phase 1 — Spec & Setup
+- [x] T001 Spec authored; `requirements-validation.md` gate passed (PASS).
+- [x] T002 `plan.md` + `tasks.md` written.
+- [x] T003 Pre-req fix: retired shields.io Marketplace badges replaced (PR #44, merged).
+
+## Phase 2 — Slice A: foldingRange (AC1)
+- [x] T010 `documents/parseCache.ts` — combined `(uri, version)` entry exposing `getAst`/`getTokens`/`getSymbols`; shared AST walker extracted to `parser/walk.ts`.
+- [x] T011 `providers/foldingRange.ts` — `toFoldingRanges(ast, tokens)`: Definition/MethodDefinition/Block (multi-line) + multi-line `Comment` tokens; `endLine` = construct's last line.
+- [x] T012 Wire `onFoldingRanges` in `server.ts`; advertise `foldingRangeProvider`.
+- [x] T013 Unit tests (class/method/block ranges, multi-line comment, single-line skipped, exact line numbers).
+- [x] T014 Real-server LSP test (`foldingRange`) + Electron e2e row (`executeFoldingRangeProvider`).
+- [x] T015 `check-types`/`lint`/`test:parser`/`test:server`/`test:e2e` + package smoke green; open Slice A PR.
+
+## Phase 3 — Slice B: documentHighlight (AC2)
+- [ ] T020 Parser: add the selector token range to `MessageNode` (additive); refresh AST snapshots.
+- [ ] T021 `providers/documentHighlight.ts` — selector match + scope-aware variable (nearest binding scope; file-wide if unbound).
+- [ ] T022 Wire `onDocumentHighlight`; advertise `documentHighlightProvider`.
+- [ ] T023 Unit tests (selector occurrences; scoped variable; no cross-scope bleed) + real-server LSP + e2e.
+- [ ] T024 `check-types`/`lint`/tests green; Slice B PR.
+
+## Phase 4 — Verify & Release (0.4.1)
+- [ ] T900 Automated green (unit + LSP server + e2e); `npm run eval` unaffected.
+- [ ] T901 Manual spot-check in the Extension Host (fold class/method/block/comment; highlight a selector and a scoped variable).
+- [ ] T902 CI green on Linux/macOS/Windows.
+- [ ] T903 Bump version (0.4.1) + CHANGELOG; cut `v0.4.1` (CI publishes).

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
@@ -1,0 +1,29 @@
+# Implementation Verification Checklist
+
+**Purpose**: Verify implementation correctness AFTER coding  
+**Type**: Implementation Verification  
+
+---
+
+## Section 1: Acceptance Criteria
+- [ ] All ACs in `tasks.md` are checked?
+- [ ] Each AC has a passing test?
+
+## Section 2: Code Quality
+- [ ] `npm run lint` passes?
+- [ ] `npm test` passes?
+- [ ] No `any` types in TypeScript (unless justified)?
+- [ ] JSDoc provided for public APIs?
+
+## Section 3: Constitutional Compliance
+- [ ] **Native**: Follows VS Code guidelines?
+- [ ] **Zero Config**: Works without manual setup?
+- [ ] **Robustness**: Handles errors gracefully?
+- [ ] **TDD**: Tests were written/exist?
+
+## Section 4: Manual Verification
+- [ ] Feature works in Extension Host?
+- [ ] No errors in Developer Tools console?
+
+## Section 5: Sign-Off
+- [ ] Ready for Merge?


### PR DESCRIPTION
## Summary

First slice of **US-417 navigation polish**: a **`foldingRange`** provider over the US-411 AST + token stream — the editor now folds exactly on **class/namespace bodies, method bodies, blocks, and multi-line comments**, beyond VS Code's default indentation folding. No `gst`.

**Closes:** _n/a — slice A of 2_ &nbsp;|&nbsp; **Story:** US-417 (#43) &nbsp;|&nbsp; **ADR:** ADR-0001 &nbsp;|&nbsp; target **0.4.1**

### What's here
- `server/src/parser/walk.ts` — extracts the generic AST walker (`visit`/`isNode`), now shared by `definition.ts` and the folding provider.
- `server/src/documents/parseCache.ts` — one `(uri, version)` entry exposes `getAst` / `getTokens` / `getSymbols` (symbol table built lazily).
- `server/src/providers/foldingRange.ts` — `toFoldingRanges(ast, tokens)`: folds `Definition`/`MethodDefinition`/`Block` (≥2 lines) + multi-line `Comment` tokens (`FoldingRangeKind.Comment`).
- `server/src/server.ts` — advertises `foldingRangeProvider`; `onFoldingRanges` over the cache.
- Tests at three layers: unit (`providers.test.ts` — ranges, multi-line comment, single-line skipped, exact line numbers), real-server LSP (`handshake.test.mjs`), and **Electron e2e** (`executeFoldingRangeProvider`).

### Next
- **Slice B** — scope-aware `documentHighlight` (carries the small additive selector-range AST touch). Then the 0.4.1 release.

## Output Eval
- [x] AC met — **AC1** (`foldingRange`).
- [x] Unit + real-server LSP + **Electron e2e** (6/6) green.
- [ ] CI green on Linux/macOS/Windows — _pending._
- [x] `check-types` ✓ · `lint` ✓ · `test:parser` 67 ✓ · `test:server` ✓ · `test:e2e` 6/6 ✓ · package smoke ✓.

## Trajectory
- [x] Traces to US-417 (#43); spec/gate/plan/tasks authored before coding; reuses US-411/US-412 unchanged (AST walker extracted, not duplicated).
- [x] Tests with the change at all layers; conventional scoped commit.
- [ ] Reviewer sign-off.