### PR TITLE
feat(US-417): scope-aware document highlight (slice B)

### DIFF
--- a/client/test-e2e/fixtures/sample.st
+++ b/client/test-e2e/fixtures/sample.st
@@ -11,5 +11,6 @@ Object subclass: Sample [
     Sample class >> make [ ^self new ]
 ]
 
-"A reference + a message send, for go-to-definition."
+"A reference + two message sends, for go-to-definition and document highlight."
+Sample new greet.
 Sample new greet

--- a/client/test-e2e/navigation.test.js
+++ b/client/test-e2e/navigation.test.js
@@ -96,6 +96,23 @@ suite('US-412 navigation (e2e)', () => {
     assert.ok((ranges || []).length >= 2, 'expected folds for the class and at least one method');
   });
 
+  test('US-417 AC2 documentHighlight marks every send of the selector', async () => {
+    const text = (await vscode.workspace.openTextDocument(sampleUri)).getText();
+    const lines = text.split('\n');
+    const line = lines.findIndex((l) => l.includes('Sample new greet'));
+    const character = lines[line].indexOf('greet') + 2;
+    const highlights = await waitFor(
+      () =>
+        vscode.commands.executeCommand(
+          'vscode.executeDocumentHighlights',
+          sampleUri,
+          new vscode.Position(line, character),
+        ),
+      (r) => Array.isArray(r) && r.length >= 2,
+    );
+    assert.ok((highlights || []).length >= 2, 'expected both `greet` sends highlighted');
+  });
+
   test('AC3 definition resolves the greet message send', async () => {
     const text = (await vscode.workspace.openTextDocument(sampleUri)).getText();
     const lines = text.split('\n');

--- a/server/src/parser/walk.ts
+++ b/server/src/parser/walk.ts
@@ -15,16 +15,25 @@ export function isNode(value: unknown): value is Node {
 /** Pre-order visit of `node` and every descendant Node. */
 export function visit(node: Node, fn: (n: Node) => void): void {
   fn(node);
+  for (const child of childNodes(node)) {
+    visit(child, fn);
+  }
+}
+
+/** The immediate child Nodes of `node` (any Node-valued property or array element). */
+export function childNodes(node: Node): Node[] {
+  const out: Node[] = [];
   for (const key of Object.keys(node)) {
     const value = (node as unknown as Record<string, unknown>)[key];
     if (Array.isArray(value)) {
       for (const item of value) {
         if (isNode(item)) {
-          visit(item, fn);
+          out.push(item);
         }
       }
     } else if (isNode(value)) {
-      visit(value, fn);
+      out.push(value);
     }
   }
+  return out;
 }

--- a/server/src/providers/definition.ts
+++ b/server/src/providers/definition.ts
@@ -7,7 +7,7 @@
 // (vscode-languageserver-types only).
 
 import { type Location } from 'vscode-languageserver-types';
-import { NodeKind } from '../parser/ast';
+import { NodeKind, type ProgramNode } from '../parser/ast';
 import { parse } from '../parser/parser';
 import { SymbolKind } from '../parser/symbols';
 import { visit } from '../parser/walk';
@@ -21,7 +21,11 @@ export interface DefinitionQuery {
 
 /** What does the cursor (byte `offset`) point at — a selector send or a name reference? */
 export function resolveDefinitionQuery(text: string, offset: number): DefinitionQuery | undefined {
-  const { ast } = parse(text);
+  return resolveQueryInAst(parse(text).ast, offset);
+}
+
+/** Same as {@link resolveDefinitionQuery} but over an already-parsed AST (no re-parse). */
+export function resolveQueryInAst(ast: ProgramNode, offset: number): DefinitionQuery | undefined {
   let best: { query: DefinitionQuery; start: number; end: number } | undefined;
   const consider = (query: DefinitionQuery, start: number, end: number): void => {
     // Prefer the most specific (deepest) node: latest start, then earliest end.

--- a/server/src/providers/documentHighlight.ts
+++ b/server/src/providers/documentHighlight.ts
@@ -1,0 +1,142 @@
+// Document-highlight provider (US-417, slice B / AC2).
+//
+// Highlights the other occurrences of the symbol under the cursor within the
+// file — scope-aware, not a naive same-text match:
+//   - a message selector -> its sends (the selector token spans),
+//   - a variable -> its same-name references within the nearest binding scope
+//     (block/method params + temporaries), or file-wide if unbound (class/global).
+// Pure (vscode-languageserver-types only); derives selector spans from the token
+// stream so the parser/AST are untouched.
+
+import { type DocumentHighlight, DocumentHighlightKind, type Range } from 'vscode-languageserver-types';
+import { NodeKind, type MessageNode, type Node, type ProgramNode } from '../parser/ast';
+import type { Position, Token } from '../parser/token';
+import { childNodes, visit } from '../parser/walk';
+import { resolveQueryInAst } from './definition';
+
+interface Ranged {
+  readonly start: number;
+  readonly end: number;
+  readonly startPos: Position;
+  readonly endPos: Position;
+}
+
+function toRange(r: Ranged): Range {
+  return { start: r.startPos, end: r.endPos };
+}
+
+/** The first token within [from, to) byte offsets matching `pred`. */
+function tokenIn(tokens: Token[], from: number, to: number, pred: (t: Token) => boolean): Token | undefined {
+  for (const t of tokens) {
+    if (t.start >= from && t.end <= to && pred(t)) {
+      return t;
+    }
+  }
+  return undefined;
+}
+
+/** The source range(s) of a message's selector token(s), derived from the gaps
+ *  between the receiver and the arguments (so nested sends aren't included). */
+function selectorRangesOf(message: MessageNode, tokens: Token[]): Range[] {
+  const out: Range[] = [];
+  if (message.messageType === 'keyword') {
+    const parts = message.selector.match(/[^:]+:/g) ?? [];
+    let from = message.receiver.end;
+    for (let i = 0; i < parts.length; i++) {
+      const arg = message.arguments[i];
+      const to = arg ? arg.start : message.end;
+      const tok = tokenIn(tokens, from, to, (t) => t.text === parts[i]);
+      if (tok) {
+        out.push(toRange(tok));
+      }
+      from = arg ? arg.end : to;
+    }
+  } else {
+    const arg = message.arguments[0];
+    const to = message.messageType === 'binary' && arg ? arg.start : message.end;
+    const tok = tokenIn(tokens, message.receiver.end, to, (t) => t.text === message.selector);
+    if (tok) {
+      out.push(toRange(tok));
+    }
+  }
+  return out;
+}
+
+/** Root → deepest chain of nodes whose range contains `offset`. */
+function pathToOffset(root: Node, offset: number): Node[] {
+  const path: Node[] = [];
+  let node: Node | undefined = root;
+  while (node) {
+    path.push(node);
+    node = childNodes(node).find((c) => c.start <= offset && offset <= c.end);
+  }
+  return path;
+}
+
+/** The nearest enclosing scope (block/method/program) that binds `name`, else the program. */
+function bindingScope(path: Node[], name: string): Node {
+  for (let i = path.length - 1; i >= 0; i--) {
+    const node = path[i] as Node;
+    if (node.kind === NodeKind.Block || node.kind === NodeKind.MethodDefinition) {
+      const declares =
+        node.parameters.some((p) => p.name === name) || node.temporaries.some((t) => t.name === name);
+      if (declares) {
+        return node;
+      }
+    } else if (node.kind === NodeKind.Program && node.temporaries.some((t) => t.name === name)) {
+      return node;
+    }
+  }
+  return path[0] as Node;
+}
+
+export function documentHighlightsAt(ast: ProgramNode, tokens: Token[], offset: number): DocumentHighlight[] {
+  const query = resolveQueryInAst(ast, offset);
+  if (!query) {
+    return [];
+  }
+
+  if (query.target === 'selector') {
+    const out: DocumentHighlight[] = [];
+    visit(ast, (node) => {
+      if (node.kind === NodeKind.Message && node.selector === query.name) {
+        for (const range of selectorRangesOf(node, tokens)) {
+          out.push({ range, kind: DocumentHighlightKind.Read });
+        }
+      }
+    });
+    return out;
+  }
+
+  // Variable / name reference: scope to the nearest binding, else file-wide.
+  const scope = bindingScope(pathToOffset(ast, offset), query.name);
+  const out: DocumentHighlight[] = [];
+  const seen = new Set<string>();
+  const push = (r: Ranged, kind: DocumentHighlightKind): void => {
+    const key = `${r.start}:${r.end}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push({ range: toRange(r), kind });
+    }
+  };
+  // The declaration(s) in the binding scope.
+  if (scope.kind === NodeKind.Block || scope.kind === NodeKind.MethodDefinition) {
+    for (const p of scope.parameters) {
+      if (p.name === query.name) push(p, DocumentHighlightKind.Write);
+    }
+  }
+  if (scope.kind === NodeKind.Block || scope.kind === NodeKind.MethodDefinition || scope.kind === NodeKind.Program) {
+    for (const t of scope.temporaries) {
+      if (t.name === query.name) push(t, DocumentHighlightKind.Write);
+    }
+  }
+  // References within the scope subtree (assignment targets are writes).
+  visit(scope, (node) => {
+    if (node.kind === NodeKind.Assignment && node.target.name === query.name) {
+      push(node.target, DocumentHighlightKind.Write);
+    } else if (node.kind === NodeKind.Variable && node.name === query.name) {
+      push(node, DocumentHighlightKind.Read);
+    }
+  });
+  return out;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,6 +8,8 @@ import {
   TextDocuments,
   TextDocumentSyncKind,
   type DefinitionParams,
+  type DocumentHighlight,
+  type DocumentHighlightParams,
   type DocumentSymbol,
   type DocumentSymbolParams,
   type FoldingRange,
@@ -22,6 +24,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getAst, getSymbols, getTokens, invalidate } from './documents/parseCache';
 import { toDocumentSymbols } from './providers/documentSymbol';
 import { toFoldingRanges } from './providers/foldingRange';
+import { documentHighlightsAt } from './providers/documentHighlight';
 import { WorkspaceIndex, defaultExclude, excludeFromConfig, type ExcludePredicate } from './providers/workspaceIndex';
 import { toWorkspaceSymbols } from './providers/workspaceSymbol';
 import { findDefinitions, resolveDefinitionQuery } from './providers/definition';
@@ -51,6 +54,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       workspaceSymbolProvider: true,
       definitionProvider: true,
       foldingRangeProvider: true,
+      documentHighlightProvider: true,
     },
   };
 });
@@ -93,6 +97,11 @@ connection.onDefinition((params: DefinitionParams): Location[] => {
 connection.onFoldingRanges((params: FoldingRangeParams): FoldingRange[] => {
   const doc = documents.get(params.textDocument.uri);
   return doc ? toFoldingRanges(getAst(doc), getTokens(doc)) : [];
+});
+
+connection.onDocumentHighlight((params: DocumentHighlightParams): DocumentHighlight[] => {
+  const doc = documents.get(params.textDocument.uri);
+  return doc ? documentHighlightsAt(getAst(doc), getTokens(doc), doc.offsetAt(params.position)) : [];
 });
 
 // Keep the workspace index fresh, debounced so rapid typing does not reparse on

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -99,6 +99,7 @@ assert.equal(caps.documentSymbolProvider, true, 'expected documentSymbolProvider
 assert.equal(caps.workspaceSymbolProvider, true, 'expected workspaceSymbolProvider (US-412)');
 assert.equal(caps.definitionProvider, true, 'expected definitionProvider (US-412)');
 assert.equal(caps.foldingRangeProvider, true, 'expected foldingRangeProvider (US-417)');
+assert.equal(caps.documentHighlightProvider, true, 'expected documentHighlightProvider (US-417)');
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
@@ -190,11 +191,28 @@ assert.ok(
   'method body should fold lines 1..3',
 );
 
+// --- textDocument/documentHighlight (US-417 slice B) ---
+const hlUri = 'file:///highlight-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri: hlUri, languageId: 'smalltalk', version: 1, text: 'a foo. b foo' } },
+});
+// Cursor on the first `foo` send (char 3); both sends should highlight.
+send({
+  jsonrpc: '2.0',
+  id: 5,
+  method: 'textDocument/documentHighlight',
+  params: { textDocument: { uri: hlUri }, position: { line: 0, character: 3 } },
+});
+const hlResult = (await receiveId(5)).result ?? [];
+assert.equal(hlResult.length, 2, 'both `foo` sends should be highlighted');
+
 send({ jsonrpc: '2.0', id: 3, method: 'shutdown' });
 await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, documentHighlight, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/providers.test.ts
+++ b/server/test/providers.test.ts
@@ -12,6 +12,7 @@ import { toWorkspaceSymbols } from '../src/providers/workspaceSymbol.ts';
 import { findDefinitions, resolveDefinitionQuery } from '../src/providers/definition.ts';
 import { tokenize } from '../src/parser/lexer.ts';
 import { toFoldingRanges } from '../src/providers/foldingRange.ts';
+import { documentHighlightsAt } from '../src/providers/documentHighlight.ts';
 
 const FIXTURE_DIR = path.join(process.cwd(), 'docs/research/gst-syntax/test-cases');
 
@@ -178,6 +179,39 @@ test('folds multi-line comments as comment ranges', () => {
   assert.ok(hasFold(folds(src), 0, 3, 'comment'), 'comment folds 0..3 with comment kind');
   // A single-line comment does not fold.
   assert.equal(folds('"one line" 1 + 1').length, 0);
+});
+
+// --- Document highlight (AC2) -----------------------------------------------
+const highlightsAt = (src: string, sub: string, occurrence = 0) => {
+  let idx = -1;
+  for (let i = 0; i <= occurrence; i++) {
+    idx = src.indexOf(sub, idx + 1);
+  }
+  return documentHighlightsAt(parse(src).ast, tokenize(src).tokens, idx + 1);
+};
+
+test('highlight on a unary selector marks every send of it', () => {
+  const hs = highlightsAt('obj printNl. zed printNl', 'printNl');
+  assert.equal(hs.length, 2);
+});
+
+test('highlight on a keyword selector marks each part of every matching send', () => {
+  const hs = highlightsAt('a at: 1 put: 2. b at: 3 put: 4', 'at:');
+  assert.equal(hs.length, 4); // 2 sends × (at: + put:)
+});
+
+test('highlight on a variable is scoped to its method — no cross-scope bleed', () => {
+  // method m and method n both declare `x`; highlighting m's x must not touch n's.
+  const src = 'Object subclass: C [ m [ | x | ^x ] n [ | x | ^x ] ]';
+  const hs = highlightsAt(src, '^x'); // the use in method m
+  assert.equal(hs.length, 2); // the declaration + the `^x` use, in m only
+});
+
+test('highlight on a variable includes its declaration and assignment writes', () => {
+  const src = 'Object subclass: C [ m [ | x y | x := 1. ^x + y ] ]';
+  const hs = highlightsAt(src, '^x'); // a use of x
+  // declaration x, assignment target x, and ^x — but not y.
+  assert.equal(hs.length, 3);
 });
 
 console.log(`providers: ${passed} tests passed.`);

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/tasks.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/tasks.md
@@ -18,11 +18,11 @@ Mark each task `[x]` as it lands. Two slices: **A** foldingRange → **B** docum
 - [x] T015 `check-types`/`lint`/`test:parser`/`test:server`/`test:e2e` + package smoke green; open Slice A PR.
 
 ## Phase 3 — Slice B: documentHighlight (AC2)
-- [ ] T020 Parser: add the selector token range to `MessageNode` (additive); refresh AST snapshots.
-- [ ] T021 `providers/documentHighlight.ts` — selector match + scope-aware variable (nearest binding scope; file-wide if unbound).
-- [ ] T022 Wire `onDocumentHighlight`; advertise `documentHighlightProvider`.
-- [ ] T023 Unit tests (selector occurrences; scoped variable; no cross-scope bleed) + real-server LSP + e2e.
-- [ ] T024 `check-types`/`lint`/tests green; Slice B PR.
+- [x] T020 No AST change needed: selector token ranges are **derived in the provider** from the receiver/arg gaps + token stream (`tokenIn`), so nested sends aren't included and the parser/snapshots are untouched. `definition.ts` exposes `resolveQueryInAst` (no re-parse).
+- [x] T021 `providers/documentHighlight.ts` — selector match (all sends, each selector part) + scope-aware variable (`pathToOffset` + `bindingScope`: nearest block/method binding, else file-wide); writes for declarations/assignment targets. Shared `childNodes` added to `walk.ts`.
+- [x] T022 Wire `onDocumentHighlight`; advertise `documentHighlightProvider`.
+- [x] T023 Unit tests (unary + keyword selector occurrences; scoped variable; no cross-scope bleed; decl + assignment writes) + real-server LSP + Electron e2e (`executeDocumentHighlights`).
+- [x] T024 `check-types`/`lint`/`test:parser`/`test:server`/`test:e2e` (7/7) + package smoke green; open Slice B PR.
 
 ## Phase 4 — Verify & Release (0.4.1)
 - [ ] T900 Automated green (unit + LSP server + e2e); `npm run eval` unaffected.


### PR DESCRIPTION
## Summary

Second slice of **US-417** — a **`documentHighlight`** provider that marks the other occurrences of the symbol under the cursor, **scope-aware** (not a naive same-text match). Completes US-417 (AC1 folding + AC2 highlight). No `gst`; **no parser/AST change**.

**Closes:** _n/a — completes the story; ships in 0.4.1_ &nbsp;|&nbsp; **Story:** US-417 (#43) &nbsp;|&nbsp; Builds on slice A (#45).

### What's here
- `server/src/providers/documentHighlight.ts`:
  - **Selector** under the cursor → every send of that selector. Selector token spans are **derived from the receiver/argument gaps + token stream** (`tokenIn`), so nested sends are excluded — no need to store ranges on the AST.
  - **Variable** under the cursor → same-name references within the **nearest binding scope** (`pathToOffset` + `bindingScope`: block/method params + temporaries), or file-wide when unbound (class/global). Declarations and assignment targets are `Write`, reads `Read`.
- `server/src/providers/definition.ts` — exposes `resolveQueryInAst` (classify over an existing AST, no re-parse), reused here.
- `server/src/parser/walk.ts` — `childNodes` (shared).
- `server/src/server.ts` — advertises `documentHighlightProvider`.
- Tests at three layers: unit (unary + keyword selector; **no cross-scope bleed**; decl + assignment writes), real-server LSP, and **Electron e2e** (`executeDocumentHighlights`). e2e **7/7**.

### Next
- **0.4.1 release** — version bump + CHANGELOG + manual spot-check + `v0.4.1` tag.

## Output Eval
- [x] AC met — **AC2** (scope-aware `documentHighlight`); US-417 now complete (AC1+AC2).
- [x] Unit + real-server LSP + Electron e2e (7/7) green.
- [ ] CI green on Linux/macOS/Windows — _pending._
- [x] `check-types` ✓ · `lint` ✓ · `test:parser` 71 ✓ · `test:server` ✓ · `test:e2e` 7/7 ✓ · package smoke ✓.

## Trajectory
- [x] Traces to US-417 (#43); slice B in `plan.md`/`tasks.md`; chose the no-AST-change derivation (cleaner, snapshot-safe).
- [x] Tests with the change at all layers; conventional scoped commit.
- [ ] Reviewer sign-off.