### PR TITLE
docs(US-417): self-contained manual spot-check fixture

### DIFF
--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/spot-check.st
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/spot-check.st
@@ -1,0 +1,64 @@
+"=============================================================================
+  US-417 manual spot-check — open THIS file in the Extension Development Host
+  (F5 -> [Extension Development Host] -> open this file).
+  Follow the S1/S2/S3 instructions inline. Every construct here is valid
+  GNU Smalltalk and parses with zero diagnostics, so any odd behaviour is the
+  feature under test, not a parse error.
+============================================================================="
+
+"-----------------------------------------------------------------------------
+  S1 - CODE FOLDING
+  Hover the LEFT GUTTER (between line numbers and code) next to each marked
+  construct; click the chevron to fold, click again to expand.
+  Quick way to see ALL fold points: Ctrl+K Ctrl+0 (fold all) then
+  Ctrl+K Ctrl+J (unfold all).
+  Expect a fold for: (a) this multi-line comment, (b) the class body,
+  (c) the multi-line method `sum:`, (d) the inner block `[ :each | ... ]`.
+-----------------------------------------------------------------------------"
+
+Object subclass: SpotCheck [
+    | total |
+
+    "S1(c)+(d): fold this whole method, and the inner block separately."
+    sum: aCollection [
+        | running |
+        running := 0.
+        aCollection do: [ :each |
+            running := running + each
+        ].
+        ^running
+    ]
+
+    "-------------------------------------------------------------------------
+      S2 - HIGHLIGHT A SELECTOR
+      Click on the word `printNl` below -> BOTH sends highlight.
+      Click on `at:` (or `put:`) -> BOTH `at:put:` sends highlight, each part.
+      (Note: a method *definition* of a selector is not highlighted, only sends.)
+    -------------------------------------------------------------------------"
+    demo [
+        1 printNl.
+        2 printNl.
+        Smalltalk at: #A put: 1.
+        Smalltalk at: #B put: 2
+    ]
+
+    "-------------------------------------------------------------------------
+      S3 - HIGHLIGHT A SCOPED VARIABLE
+      Click on `x` inside `methodA` -> ONLY methodA's x highlights
+        (its declaration and both uses).
+      Click on `x` inside `methodB` -> ONLY methodB's x highlights.
+      The two `x` are independent locals: highlighting one must NOT light up
+      the other method's x. (This is the scope-aware behaviour, not text match.)
+    -------------------------------------------------------------------------"
+    methodA [
+        | x |
+        x := 1.
+        ^x + x
+    ]
+
+    methodB [
+        | x |
+        x := 99.
+        ^x
+    ]
+]

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
@@ -22,7 +22,11 @@
 - [x] **TDD**: tests authored with the change at all three layers; no parser/AST change (snapshots untouched).
 
 ## Section 4: Manual Verification — Extension Host spot-check (0.4.1 gate)
-Launch with **F5**, open a kernel file. Lightweight, since the behavior is automated-tested end-to-end.
+Launch with **F5**, then open **[`spot-check.st`](./spot-check.st)** (in this folder) — a single
+self-contained file with the exact S1/S2/S3 examples and inline instructions. It parses with **0
+diagnostics**, so any odd behaviour is the feature under test, not a parse error.
+Tip: to see *only* this extension's output in the console, launch with installed extensions disabled:
+`code --extensionDevelopmentPath="$PWD" --disable-extensions <folder>`.
 
 | ID | Check | Expected | Result |
 |----|-------|----------|--------|


### PR DESCRIPTION
## Summary

Adds **`specs/US-417-*/spot-check.st`** — one valid GNU Smalltalk file with the **exact** S1/S2/S3 examples and inline instructions, so the 0.4.1 manual gate is concrete and repeatable (per the request to generate a single validation file).

- **S1 (folding)** — a multi-line comment, the class body, a multi-line method (`sum:`), and an inner `[ :each | … ]` block.
- **S2 (selector highlight)** — `printNl` (unary, 2 sends) and `at:put:` (keyword, 2 sends).
- **S3 (scope-aware variable)** — `methodA` and `methodB` each have a local `x`; highlighting one must not light up the other.

Verified with our engine: **0 diagnostics**, 4 methods extracted, folds at the class / `sum:` / inner block / `demo` / `methodA` / `methodB` plus 4 comment folds. `verification.md` §4 links it and notes the `--disable-extensions` launch for a clean console.