### PR TITLE
docs(US-417): manual spot-check sign-off (S1–S4 pass)

### DIFF
--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
@@ -30,12 +30,14 @@ Tip: to see *only* this extension's output in the console, launch with installed
 
 | ID | Check | Expected | Result |
 |----|-------|----------|--------|
-| S1 | **Fold** a class, a method, a block, and a multi-line comment via the gutter chevrons. | Each collapses on its own range. | ☐ |
-| S2 | Cursor on a **message selector** (e.g. `printNl`, `at:`). | Every send of that selector is highlighted in the file. | ☐ |
-| S3 | Cursor on a **local variable / block param**. | Only its same-scope uses highlight — a same-named local in another method does not. | ☐ |
-| S4 | Developer Tools console. | No errors/exceptions. | ☐ |
+| S1 | **Fold** a class, a method, a block, and a multi-line comment via the gutter chevrons. | Each collapses on its own range. | ✅ Pass |
+| S2 | Cursor on a **message selector** (e.g. `printNl`, `at:`). | Every send of that selector is highlighted in the file. | ✅ Pass |
+| S3 | Cursor on a **local variable / block param**. | Only its same-scope uses highlight — a same-named local in another method does not. | ✅ Pass |
+| S4 | Developer Tools console. | No errors/exceptions. | ✅ Pass — our extension emits nothing; the only console noise is from other installed extensions (Mermaid/Pylance/Copilot/Claude Code) + VS Code. |
+
+_Spot-checked against `spot-check.st` in the Extension Host (Linux / VS Code 1.125.1), 2026-06-21._
 
 ## Section 5: Sign-Off
 - [x] Automated gates green (Sections 1–3); slices #45 + #46 merged.
-- [ ] Manual spot-check (Section 4) passed in the Extension Host.
-- [ ] Ready to cut **v0.4.1** (version + CHANGELOG done in the release PR → tag the Release → CI publishes).
+- [x] Manual spot-check (Section 4) passed in the Extension Host.
+- [x] Ready to cut **v0.4.1** — version + CHANGELOG done in the release PR (#47); tagging the Release → CI publishes.


### PR DESCRIPTION
Records the 0.4.1 manual gate: S1 folding / S2 selector highlight / S3 scope-aware variable / S4 clean console all pass against `spot-check.st`. US-417 verification complete; ready to tag v0.4.1.