### PR TITLE
docs: 0.4.1 close-out + 0.5.0 readiness + cycle learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,36 @@ for the full process and [`docs/ROADMAP.md`](docs/ROADMAP.md) for where we're he
 `vscode-smalltalk` — a VS Code extension for **GNU Smalltalk** (`.st`/`.gst`). Published on the
 Marketplace as `leocamello.vscode-smalltalk`.
 
-## Current status (2026-06-20)
-- **Shipped:** v0.4.0 — **code navigation** (Outline/breadcrumbs, workspace symbol search,
-  go-to-definition) for GNU Smalltalk, all with no `gst`. Built on the **error-tolerant lexer +
-  parser + symbol table** (US-411, internal M3) wired into LSP providers (US-412). The bundled
-  TypeScript server is now functional. Earlier: v0.3.0 grammar/snippets/config + **Run Current
-  File** (US-301) + the LSP scaffold (US-410).
-  - Parser/symbol-table source: `server/src/parser/` (`lexer.ts`, `parser.ts`, `ast.ts`,
-    `symbols.ts`, container/chunk in `parser.ts`); providers: `server/src/providers/` +
-    `server/src/documents/parseCache.ts`. Blueprints: `docs/research/gst-syntax/01-*`, `02-*`;
-    fixtures `docs/research/gst-syntax/test-cases/*.st`; kernel corpus `../smalltalk-3.2.5/kernel/`
-    (122 files parse clean). Tests: `npm run test:parser` (unit/snapshot/kernel), `test:server`
-    (real-server LSP), `test:e2e` (Electron, local).
-- **Next:** **0.5.0 / US-413** — completion + GNU Smalltalk kernel index (closes #1).
+## Current status (2026-06-21)
+- **Shipped:** v0.4.1 — **navigation polish** (semantic folding + scope-aware document highlight,
+  US-417). v0.4.0 — **code navigation** (outline/breadcrumbs, workspace symbol search,
+  go-to-definition; US-412) on the error-tolerant **lexer + parser + symbol table** (US-411, internal
+  M3). All language intelligence runs with **no `gst`**. Earlier: v0.3.0 grammar/snippets/config +
+  **Run Current File** (US-301) + the LSP scaffold (US-410).
+- **Next:** **0.5.0 / US-413** — completion + a GNU Smalltalk kernel index (closes #1). Builds on the
+  US-411 symbol table + US-412 workspace index / `parseCache`.
+
+### Language server — code map, tests & conventions (read before LSP work)
+- **Source:** parser/symbols in `server/src/parser/` (`lexer.ts`, `parser.ts`, `ast.ts`, `symbols.ts`,
+  `walk.ts`; GST containers/chunk live in `parser.ts`). LSP providers in `server/src/providers/`
+  (`documentSymbol`, `workspaceSymbol` + `workspaceIndex`, `definition`, `foldingRange`,
+  `documentHighlight`); `server/src/documents/parseCache.ts` memoizes AST/tokens/symbols by
+  `(uri, version)`; wiring + advertised capabilities in `server/src/server.ts`.
+- **Blueprints/fixtures:** `docs/research/gst-syntax/01-*`, `02-*`; `…/test-cases/*.st`; kernel corpus
+  `../smalltalk-3.2.5/kernel/` (122 files, parses with **0 diagnostics**).
+- **Three test layers — keep all green per change:**
+  1. `npm run test:parser` — tsx unit + golden snapshots + the kernel smoke test (`server/test/*.test.ts` via `run.ts`).
+  2. `npm run test:server` — drives the **real bundled server** over LSP (`server/test/handshake.test.mjs`); fast, no Electron, runs in CI. Extend it for each new provider.
+  3. `npm run test:e2e` — **Electron** (`@vscode/test-cli`, `client/test-e2e/`) against real VS Code; **local only** (downloads VS Code + needs a display) — not in the default CI job.
+- **LSP gotchas learned (apply to new providers):**
+  - The extension activates via **`activationEvents: workspaceContains:**/*.{st,gst}`** — `onLanguage` alone leaves workspace features dead until a file is opened.
+  - `files.exclude` is honored only because the server **dynamically registers `didChangeConfiguration`** and re-indexes; pull config in the handler, not only at init.
+  - Prefer **deriving ranges in the provider** (token stream / node positions) over adding fields to the AST — avoids snapshot churn.
+  - The front end **never throws**; providers return empty results, not errors.
+- **Release ritual (every version):** run a **doc-rot audit** (sync the status docs below) + the
+  **manual-QA matrix/spot-check** in `specs/US-XXX-*/verification.md` (it caught both 0.4.0 bugs the
+  automated layers missed), then bump `version` + CHANGELOG → create the `vX.Y.Z` GitHub Release →
+  CI publishes (`MARKETPLACE` PAT, ~yearly expiry — check before tagging).
 
 ## How we work (spec-driven)
 Per user story (`US-XXX`): **Clarify → Spec → Plan → Task → Implement → Verify**.

--- a/docs/product/epics.md
+++ b/docs/product/epics.md
@@ -105,7 +105,7 @@
 ## EPIC-004: Language Intelligence — TypeScript LSP
 
 * **ID:** EPIC-004
-* **Status:** In Progress (US-410 scaffold, US-411 parser/symbols, US-412 navigation all done; v0.4.0 shipped. Next: US-413 completion)
+* **Status:** In Progress (US-410 scaffold, US-411 parser/symbols, US-412 navigation, US-417 folding+highlight all done; v0.4.0 + v0.4.1 shipped. Next: US-413 completion)
 * **Priority:** Medium
 * **Phase:** Phase 2
 * **Date Proposed:** 2025-05-02

--- a/docs/product/high-level-plan.md
+++ b/docs/product/high-level-plan.md
@@ -74,8 +74,9 @@ Phase 1 (declarative foundation + onboarding docs) shipped in **v0.2.0**; the Ty
 client/server scaffold and the *Run Current File* command shipped in **v0.3.0**. Phase 2 is
 underway: the error-tolerant parser + symbol table (**M3 / US-411**) and the first navigation
 features — outline, workspace symbol search, and go-to-definition (**US-412**) — shipped in
-**v0.4.0**. Current focus is **US-413** — completion + a GNU Smalltalk kernel index (0.5.0);
-diagnostics, hover, and formatting follow.
+**v0.4.0**, with semantic folding + document highlight (**US-417**) in **v0.4.1**. Current focus is
+**US-413** — completion + a GNU Smalltalk kernel index (0.5.0); diagnostics, hover, and formatting
+follow.
 
 See [`docs/ROADMAP.md`](../ROADMAP.md) for live milestone status, [`epics.md`](epics.md) and
 [`user-stories.md`](user-stories.md) for the backlog, and [`docs/decisions/`](../decisions/)

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1,6 +1,6 @@
 # vscode-smalltalk User Stories
 
-> **Status summary (2026-06-20).** v0.2.0, v0.3.0, and v0.4.0 are shipped. **Done:** US-101–106 & US-200–203 (declarative foundation, v0.2.0), US-301 (Run Current File, v0.3.0), US-410 (LSP scaffold, v0.3.0), **US-411** (error-tolerant parser + symbol table, internal milestone M3) and **US-412** (outline + workspace symbols + go-to-definition, v0.4.0). **Next:** US-413 (completion, 0.5.0). **Planned:** US-413–416. **Superseded by [ADR-0001](../decisions/0001-typescript-bundled-lsp-server.md):** US-401–403 (the server is TypeScript, not Smalltalk). The per-story `Status` fields below reflect this; see [`docs/ROADMAP.md`](../ROADMAP.md) for the live milestone view.
+> **Status summary (2026-06-21).** v0.2.0–v0.4.1 are shipped. **Done:** US-101–106 & US-200–203 (declarative foundation, v0.2.0), US-301 (Run Current File, v0.3.0), US-410 (LSP scaffold, v0.3.0), **US-411** (error-tolerant parser + symbol table, internal milestone M3), **US-412** (outline + workspace symbols + go-to-definition, v0.4.0), and **US-417** (semantic folding + scope-aware document highlight, v0.4.1). **Next:** US-413 (completion + kernel index, 0.5.0 — closes #1). **Planned:** US-413–416. **Superseded by [ADR-0001](../decisions/0001-typescript-bundled-lsp-server.md):** US-401–403 (the server is TypeScript, not Smalltalk). The per-story `Status` fields below reflect this; see [`docs/ROADMAP.md`](../ROADMAP.md) for the live milestone view.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out the 0.4.x cycle and prepares a **clean next session for 0.5.0 / US-413**: syncs every status-bearing doc to the shipped state, and captures this cycle's learnings into `CLAUDE.md` (which loads automatically each session).

- **CLAUDE.md** — status → **v0.4.1** (US-417 done); next 0.5.0/US-413. New **"Language server — code map, tests & conventions"** section:
  - the **three test layers** (`test:parser` unit/snapshot/kernel · `test:server` real bundled-server LSP · `test:e2e` Electron, local-only),
  - the **LSP gotchas** learned this cycle (`workspaceContains` activation; dynamic `didChangeConfiguration` for `files.exclude`; derive ranges in providers to avoid snapshot churn; never-throws front end),
  - the **release ritual** (doc-rot audit + manual-QA gate + tag → CI publish; PAT ~yearly).
- **user-stories.md / epics.md / high-level-plan.md** — reflect US-417 / v0.4.1; "Next" is US-413.

Doc-rot scan clean. No code changes.