### PR TITLE
feat(US-413): kernel-index model + bundled gst-3.2.5 index (slice A)

### DIFF
--- a/docs/decisions/0002-kernel-symbol-sourcing.md
+++ b/docs/decisions/0002-kernel-symbol-sourcing.md
@@ -1,0 +1,102 @@
+# ADR-0002: Kernel symbol sourcing — installed-first, bundled-fallback; neutral model + per-dialect source adapters
+
+* **Status:** Accepted
+* **Date:** 2026-06-21
+* **Deciders:** Leonardo Nascimento
+* **Relates to:** [ADR-0001](0001-typescript-bundled-lsp-server.md) (TypeScript bundled LSP),
+  Constitution Principle IV (*Dialect Agnostic*); realised by US-413.
+
+## Context
+
+US-413 adds completion for standard kernel-library selectors/classes, not just the user's
+workspace symbols. Those kernel symbols (`Object`, `Collection`, `String`, …) do not live in
+the user's `.st` files — they live in a Smalltalk *installation*. This forces a sourcing
+decision, complicated by two project realities:
+
+* **ADR-0001** mandates that language intelligence is **fully functional without `gst`** — a
+  deliberate differentiator. A "read the installed runtime" approach (how vscode-java/JDT and
+  vscode-csharp/Roslyn work — they index the configured JDK / .NET SDK metadata at runtime)
+  would give *nothing* to a user who just installed VS Code and our extension with no Smalltalk
+  yet. That first-run user is a primary use case.
+* **Constitution Principle IV** requires we stay dialect-agnostic so Pharo/Squeak/Tonel can be
+  added later. GST ships its kernel as readable `.st` source (e.g. `…/share/smalltalk/kernel`);
+  image-based dialects (Pharo/Squeak) keep their base library inside a serialized **image**, not
+  loose source — so "parse a source directory" does not generalise.
+
+A static, single-version bundled index alone risks **misleading the user** ("it completed, so it
+must be installed and runnable") and pins us to one GST version.
+
+## Decision
+
+Kernel symbols come from a **precedence chain**, exposed as a sourcing strategy, over a
+**dialect-neutral index model** fed by **per-dialect source adapters**.
+
+1. **Tiers (highest-confidence first):**
+   * **Workspace** (US-412) — always indexed; the user's own code.
+   * **Kernel tier** — exactly *one* active source, chosen by
+     `smalltalk.completion.kernelLibrary = auto | bundled | off`:
+     * `auto` (default): discover an installed GST kernel dir and index it **live**; else fall
+       back to the **bundled** index.
+     * `bundled`: force the shipped reference index.
+     * `off`: no kernel tier.
+   * Mixing installed + bundled is disallowed (would duplicate/confuse). The bundle only fills the
+     gap when nothing installed is found.
+
+2. **Neutral index model** (`vscode`-free, library-agnostic):
+   `{ dialect, library, version, source, classes: { name → { superclass?, instanceSelectors,
+   classSelectors } } }`, selector = `{ selector, arity }`. **Facts only** — names/arities/
+   superclasses, never method-comment prose (LGPL-2.1; see Licensing).
+
+3. **Source adapters** produce that model; the completion provider only ever consumes the model:
+   * **GST file adapter** (now): parse a kernel **directory** of `.st` with our existing parser.
+     The *same* indexer serves both the bundled corpus and a live installed dir. Its discovery
+     override is `smalltalk.completion.kernelPath` (a directory).
+   * **Image-based adapter** (future, Pharo/Squeak): no source dir — build the index by
+     **reflective export** (run the dialect VM headless against its image, dump
+     `allSubclasses`/`selectors`/arity to the same JSON), or ship that export as a `bundled`
+     index. Introduces its **own** config (`imagePath`/`vmPath`); does **not** overload
+     `kernelPath`. A richer "query a live image" mode is a possible later enhancement.
+
+4. **Honesty / anti-confusion (so a suggestion is never mistaken for guaranteed availability):**
+   * Completion items carry **provenance** (workspace / installed / bundled-reference).
+   * The resolved kernel identity is shown **ambiently** in a status-bar item
+     ("Smalltalk kernel: bundled (gst 3.2.5)" / "installed" / "off"); a one-time notice on first
+     fallback to the bundle. Identity lives in the index header, *not* in the enum literal — hence
+     `bundled` (a strategy) rather than `gst-3.2.5` (an artifact we will bump).
+
+5. **`smalltalk.dialect` axis** is deferred: when more than one bundle ships, a separate
+   (auto-detected) dialect selector chooses *which* library; `kernelLibrary` stays the orthogonal
+   *sourcing* axis. `bundled` is forward-compatible with this.
+
+## Engine boundary (build our own Roslyn/JDT? spin out?)
+
+We will **not** set out to build a Smalltalk "Roslyn/JDT," and **not** spin the engine into a
+separate project now. Rationale:
+
+* Smalltalk's compiler-as-a-service already exists — **the image** (self-hosting, reflective).
+  The long-term win is our lightweight, no-runtime TS engine **plus optional delegation to a live
+  image** when present, not reinventing a compiler.
+* There is exactly one consumer (this extension); a separate repo adds release/versioning cost for
+  no current benefit. Keep a **modular monolith**: `server/src/parser` + the new
+  `KernelIndex`/adapters stay a clean, `vscode`-free, dialect-pluggable core — **designed for
+  extraction** but not extracted. Trigger to extract: a real second consumer or partner dialect.
+
+## Consequences
+
+* **Positive:** first-run/no-`gst` users still get kernel completions (honours ADR-0001); users
+  with GST installed get version-correct completions from their *actual* kernel; the neutral model
+  + adapter seam makes new dialects an additive change (Principle IV); provenance/status keep the
+  experience honest; reusing our `.st` parser makes the installed path cheap (no binary-metadata
+  reader, unlike JDT/Roslyn).
+* **Negative:** US-413 grows (bundled generator **and** live installed indexing **and**
+  provenance/status UX), enlarging the 0.5.0 milestone (~4 PR slices vs 3).
+* **Follow-up:** US-413 ACs amended (AC5 → `auto|bundled|off`; new AC6 installed indexing, AC7
+  provenance/status). A future story covers an image-based dialect adapter (Pharo/Squeak) and the
+  `smalltalk.dialect` axis. Hover (US-415) revisits shipping kernel comment prose with attribution.
+
+## Licensing
+
+GNU Smalltalk kernel sources are LGPL-2.1. The index stores **facts** (class names, superclass
+links, selector names + arity) — not the creative method-comment prose. The generator/adapters
+must never copy comment text or method bodies into the index; a test asserts the index carries no
+free-text fields. Shipping comment prose (with attribution) is deferred to the hover story (US-415).

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -825,34 +825,40 @@ Scenario: User follows Quick Start guide
 * **Status:** Planned
 * **Epic:** EPIC-004
 * **Priority:** High *(directly answers issue #1)*
-* **Estimate:** L
+* **Estimate:** L *(grown to XL by [ADR-0002](../decisions/0002-kernel-symbol-sourcing.md): adds live installed-kernel indexing + provenance/status UX)*
 * **Date Proposed:** 2026-06-13
 * **Owner:** Leonardo Nascimento
 
 **User Story:**
 > As a **Smalltalk developer**, I want **auto-completion for selectors, class names, and local/instance variables, including standard kernel-library selectors**, so that **I can write code faster with fewer lookups.**
 
+**Architecture:** kernel symbols follow [ADR-0002](../decisions/0002-kernel-symbol-sourcing.md) — an *installed-first, bundled-fallback* precedence chain over a **dialect-neutral index model** fed by **per-dialect source adapters** (GST file adapter now; image-based adapters later, per Constitution Principle IV).
+
 **Acceptance Criteria (AC):**
-* AC1: A build-time generator parses `../smalltalk-3.2.5/kernel/*.st` with our own parser into `server/data/kernel-index.json` (classes, superclass chains, selectors + arity).
-* AC2: Completion offers keyword selectors after a receiver (workspace > kernel ranking, prefix + camel-hump matching).
+* AC1: A build-time generator parses a GNU Smalltalk kernel source directory (the bundled `../smalltalk-3.2.5/kernel/*.st`) with our own parser into `server/data/kernel-index.json` — dialect-neutral model (`dialect`, `library`, `version`, `source` header; classes, superclass chains, selectors + arity). Built on a **reusable `.st`-directory indexer** (the same one AC6 uses), **facts only** (no comment prose).
+* AC2: Completion offers keyword selectors after a receiver (workspace > installed-kernel > bundled-kernel ranking, prefix + camel-hump matching).
 * AC3: Completion offers class names in expression-head position and temp/instance variables from the symbol-table scopes.
 * AC4: Multi-part keyword selectors insert as snippets (e.g. `at:put:` → `at:${1} put:${2}`).
-* AC5: A setting `smalltalk.completion.kernelLibrary` (`gst-3.2.5` | `off`) controls the kernel index.
+* AC5: A setting `smalltalk.completion.kernelLibrary` (`auto` | `bundled` | `off`, default `auto`) selects the kernel sourcing strategy; `smalltalk.completion.kernelPath` overrides the GST kernel-directory discovery.
+* AC6: When a GST install is discoverable (via `kernelPath`, the `smalltalk.gnuSmalltalkPath` prefix, or common locations), the kernel tier indexes its **actual** kernel sources live via the same directory indexer; otherwise it falls back to the bundled index.
+* AC7: Completion items carry **provenance** (workspace / installed / bundled-reference); a status-bar item shows the resolved kernel identity (e.g. "bundled (gst 3.2.5)" / "installed" / "off"), with a one-time notice on first fallback to the bundle.
 
 **Definition of Ready (DoR) Checklist:**
 * [X] Depends on US-411 + US-412 indexes.
 * [X] Licensing reviewed (kernel selector names/arities are facts; method comment prose is LGPL 2.1 — names/signatures only in v0.5.0).
+* [X] Sourcing architecture decided ([ADR-0002](../decisions/0002-kernel-symbol-sourcing.md)).
 * [X] Estimated/sized.
 
 **Definition of Done (DoD) Checklist:**
-* [ ] Kernel-index generator + completion provider implemented.
-* [ ] **Language Server:** unit tests at cursor positions; index generator snapshot test.
+* [ ] Kernel-index model + bundled generator + live installed-kernel indexing + completion provider implemented (slices A–D).
+* [ ] **Language Server:** unit tests at cursor positions; index generator snapshot test; licensing (no-prose) test; resolution/discovery tests.
 * [ ] **End-to-End:** integration test asserting kernel + workspace completions.
 * [ ] GitHub issue #1 closed with a demo.
 * [ ] PO accepts the story.
 
 **Notes / Questions / Assumptions:**
 * Decide on shipping kernel method-comment text (with attribution) before hover (US-415).
+* Image-based dialect adapter (Pharo/Squeak, via reflective export) and a `smalltalk.dialect` axis are deferred follow-ups (ADR-0002).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
         "test:e2e": "npm run compile && vscode-test",
         "package": "vsce package --no-dependencies",
         "deploy": "vsce publish",
+        "gen:kernel-index": "tsx scripts/gen-kernel-index.ts",
         "build:grammar": "js-yaml syntaxes/gnu-smalltalk.YAML-tmLanguage > syntaxes/gnu-smalltalk.tmLanguage.json",
         "test:grammar": "node src/test/grammar-verification.js",
         "eval": "npm run build:grammar && npm run test:grammar",

--- a/scripts/gen-kernel-index.ts
+++ b/scripts/gen-kernel-index.ts
@@ -1,0 +1,37 @@
+// Build-time generator for the bundled GNU Smalltalk kernel index (US-413, AC1).
+//
+//   npm run gen:kernel-index [-- <kernel-dir>]
+//
+// Parses the bundled GST 3.2.5 kernel `.st` sources with our own parser and
+// writes the dialect-neutral, facts-only index to server/data/kernel-index.json.
+// The corpus lives OUTSIDE the repo and is absent in CI, so the JSON is a
+// COMMITTED artifact — regenerate locally whenever the indexer or corpus changes
+// (the kernelIndex.test.ts drift guard catches staleness when the corpus exists).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  BUNDLED_HEADER,
+  bundledIndexPath,
+  bundledKernelDir,
+  indexKernelDirectory,
+  serializeKernelIndex,
+} from '../server/src/kernel/indexer';
+
+const dir = process.argv[2] ?? bundledKernelDir();
+
+if (!fs.existsSync(dir)) {
+  console.error(`gen-kernel-index: kernel directory not found: ${dir}`);
+  console.error('Pass a kernel source directory, or place the corpus at ../smalltalk-3.2.5/kernel.');
+  process.exit(1);
+}
+
+const data = indexKernelDirectory(dir, BUNDLED_HEADER);
+const outPath = bundledIndexPath();
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, serializeKernelIndex(data), 'utf8');
+
+console.log(
+  `gen-kernel-index: wrote ${path.relative(process.cwd(), outPath)} ` +
+    `(${data.library}: ${data.classCount} classes, ${data.selectorCount} selectors) from ${dir}`,
+);

--- a/server/data/kernel-index.json
+++ b/server/data/kernel-index.json
@@ -1,0 +1,20562 @@
+{
+  "dialect": "gst",
+  "library": "gst-3.2.5",
+  "version": "3.2.5",
+  "source": "bundled",
+  "classCount": 250,
+  "selectorCount": 4723,
+  "classes": {
+    "AbstractNamespace": {
+      "superclass": "BindingDictionary",
+      "instanceSelectors": [
+        {
+          "selector": "addSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "addSubspace:",
+          "arity": 1
+        },
+        {
+          "selector": "allAssociations",
+          "arity": 0
+        },
+        {
+          "selector": "allBehaviorsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allClassObjectsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allClassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allMetaclassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSubassociationsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSubspaces",
+          "arity": 0
+        },
+        {
+          "selector": "allSubspacesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSuperspacesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "classAt:",
+          "arity": 1
+        },
+        {
+          "selector": "classAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "copyEmpty:",
+          "arity": 1
+        },
+        {
+          "selector": "import:",
+          "arity": 1
+        },
+        {
+          "selector": "includesClassNamed:",
+          "arity": 1
+        },
+        {
+          "selector": "includesGlobalNamed:",
+          "arity": 1
+        },
+        {
+          "selector": "inheritedKeys",
+          "arity": 0
+        },
+        {
+          "selector": "isNamespace",
+          "arity": 0
+        },
+        {
+          "selector": "isSmalltalk",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSubspace:",
+          "arity": 1
+        },
+        {
+          "selector": "selectSubspaces:",
+          "arity": 1
+        },
+        {
+          "selector": "selectSuperspaces:",
+          "arity": 1
+        },
+        {
+          "selector": "set:to:",
+          "arity": 2
+        },
+        {
+          "selector": "set:to:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "setSubspaces:",
+          "arity": 1
+        },
+        {
+          "selector": "setSuperspace:",
+          "arity": 1
+        },
+        {
+          "selector": "sharedPoolDictionaries",
+          "arity": 0
+        },
+        {
+          "selector": "siblings",
+          "arity": 0
+        },
+        {
+          "selector": "siblingsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "subspaces",
+          "arity": 0
+        },
+        {
+          "selector": "subspacesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "superspace",
+          "arity": 0
+        },
+        {
+          "selector": "superspace:",
+          "arity": 1
+        },
+        {
+          "selector": "values",
+          "arity": 0
+        },
+        {
+          "selector": "whileCurrentDo:",
+          "arity": 1
+        },
+        {
+          "selector": "withAllSubspaces",
+          "arity": 0
+        },
+        {
+          "selector": "withAllSubspacesDo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "primNew:name:",
+          "arity": 2
+        }
+      ]
+    },
+    "AlreadyDefined": {
+      "superclass": "InvalidArgument",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "AlternativeObjectProxy": {
+      "superclass": "DumperProxy",
+      "instanceSelectors": [
+        {
+          "selector": "object",
+          "arity": 0
+        },
+        {
+          "selector": "object:",
+          "arity": 1
+        },
+        {
+          "selector": "primObject",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "acceptUsageForClass:",
+          "arity": 1
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "ArchiveFile": {
+      "superclass": "FileWrapper",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "convertMode:",
+          "arity": 1
+        },
+        {
+          "selector": "convertModeString:",
+          "arity": 1
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "extractMember:",
+          "arity": 1
+        },
+        {
+          "selector": "extractMember:into:",
+          "arity": 2
+        },
+        {
+          "selector": "fillMember:",
+          "arity": 1
+        },
+        {
+          "selector": "findDirectory:into:",
+          "arity": 2
+        },
+        {
+          "selector": "isAccessible",
+          "arity": 0
+        },
+        {
+          "selector": "isDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "member:do:",
+          "arity": 2
+        },
+        {
+          "selector": "member:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "nameAt:",
+          "arity": 1
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "release",
+          "arity": 0
+        },
+        {
+          "selector": "removeMember:",
+          "arity": 1
+        },
+        {
+          "selector": "updateMember:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "ArchiveMember": {
+      "superclass": "FilePath",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "archive",
+          "arity": 0
+        },
+        {
+          "selector": "archive:",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "createDirectory:",
+          "arity": 1
+        },
+        {
+          "selector": "creationTime",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "exists",
+          "arity": 0
+        },
+        {
+          "selector": "fillFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "full",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isAccessible",
+          "arity": 0
+        },
+        {
+          "selector": "isDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "isExecutable",
+          "arity": 0
+        },
+        {
+          "selector": "isReadable",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbolicLink",
+          "arity": 0
+        },
+        {
+          "selector": "isWriteable",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastChangeTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastModifyTime",
+          "arity": 0
+        },
+        {
+          "selector": "mode",
+          "arity": 0
+        },
+        {
+          "selector": "mode:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "remove",
+          "arity": 0
+        },
+        {
+          "selector": "renameTo:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "size:stCtime:stMtime:stAtime:mode:",
+          "arity": 5
+        },
+        {
+          "selector": "size:stMtime:mode:",
+          "arity": 3
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "ArgumentOutOfRange": {
+      "superclass": "InvalidArgument",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "high",
+          "arity": 0
+        },
+        {
+          "selector": "high:",
+          "arity": 1
+        },
+        {
+          "selector": "low",
+          "arity": 0
+        },
+        {
+          "selector": "low:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:mustBeBetween:and:",
+          "arity": 3
+        }
+      ]
+    },
+    "ArithmeticError": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Array": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "isArray",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "multiBecome:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "replaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "from:",
+          "arity": 1
+        }
+      ]
+    },
+    "ArrayedCollection": {
+      "superclass": "SequenceableCollection",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "atAll:",
+          "arity": 1
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "copyGrowTo:",
+          "arity": 1
+        },
+        {
+          "selector": "copyReplaceAll:with:",
+          "arity": 2
+        },
+        {
+          "selector": "copyReplaceFrom:to:with:",
+          "arity": 3
+        },
+        {
+          "selector": "copyReplaceFrom:to:withObject:",
+          "arity": 3
+        },
+        {
+          "selector": "copyWith:",
+          "arity": 1
+        },
+        {
+          "selector": "copyWithout:",
+          "arity": 1
+        },
+        {
+          "selector": "grow",
+          "arity": 0
+        },
+        {
+          "selector": "growBy:",
+          "arity": 1
+        },
+        {
+          "selector": "growTo:",
+          "arity": 1
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "reverse",
+          "arity": 0
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "sorted",
+          "arity": 0
+        },
+        {
+          "selector": "sorted:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "with:collect:",
+          "arity": 2
+        },
+        {
+          "selector": "writeStream",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "join:",
+          "arity": 1
+        },
+        {
+          "selector": "join:separatedBy:",
+          "arity": 2
+        },
+        {
+          "selector": "new:withAll:",
+          "arity": 2
+        },
+        {
+          "selector": "streamContents:",
+          "arity": 1
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "with:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "with:with:with:with:with:",
+          "arity": 5
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "Association": {
+      "superclass": "LookupKey",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "environment:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "key:value:",
+          "arity": 2
+        },
+        {
+          "selector": "mourn",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "key:value:",
+          "arity": 2
+        }
+      ]
+    },
+    "Autoload": {
+      "superclass": "nil",
+      "instanceSelectors": [
+        {
+          "selector": "class",
+          "arity": 0
+        },
+        {
+          "selector": "doesNotUnderstand:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "class:from:",
+          "arity": 2
+        },
+        {
+          "selector": "class:in:from:",
+          "arity": 3
+        },
+        {
+          "selector": "class:in:loader:",
+          "arity": 3
+        },
+        {
+          "selector": "class:loader:",
+          "arity": 2
+        }
+      ]
+    },
+    "AutoloadClass": {
+      "superclass": "nil",
+      "instanceSelectors": [
+        {
+          "selector": "doesNotUnderstand:",
+          "arity": 1
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "loadedClass_",
+          "arity": 0
+        },
+        {
+          "selector": "loadedMetaclass_",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "class:in:loader:",
+          "arity": 3
+        }
+      ]
+    },
+    "BadReturn": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Bag": {
+      "superclass": "Collection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "add:withOccurrences:",
+          "arity": 2
+        },
+        {
+          "selector": "asRunArrayMap",
+          "arity": 0
+        },
+        {
+          "selector": "asSet",
+          "arity": 0
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "dictionaryClass",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "initContents:",
+          "arity": 1
+        },
+        {
+          "selector": "occurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "sortedByCount",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "valuesAndCounts",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "Behavior": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": ">>",
+          "arity": 1
+        },
+        {
+          "selector": "addInstVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "addSelector:withMethod:",
+          "arity": 2
+        },
+        {
+          "selector": "addSubclass:",
+          "arity": 1
+        },
+        {
+          "selector": "allClassVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "allInstVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "allInstances",
+          "arity": 0
+        },
+        {
+          "selector": "allInstancesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSelectors",
+          "arity": 0
+        },
+        {
+          "selector": "allSharedPoolDictionaries",
+          "arity": 0
+        },
+        {
+          "selector": "allSharedPoolDictionariesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSharedPools",
+          "arity": 0
+        },
+        {
+          "selector": "allSubclasses",
+          "arity": 0
+        },
+        {
+          "selector": "allSubclassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSubinstancesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSuperclasses",
+          "arity": 0
+        },
+        {
+          "selector": "allSuperclassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "article",
+          "arity": 0
+        },
+        {
+          "selector": "asClass",
+          "arity": 0
+        },
+        {
+          "selector": "basicNew",
+          "arity": 0
+        },
+        {
+          "selector": "basicNew:",
+          "arity": 1
+        },
+        {
+          "selector": "basicNewInFixedSpace",
+          "arity": 0
+        },
+        {
+          "selector": "basicNewInFixedSpace:",
+          "arity": 1
+        },
+        {
+          "selector": "canUnderstand:",
+          "arity": 1
+        },
+        {
+          "selector": "classPool",
+          "arity": 0
+        },
+        {
+          "selector": "classVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "compile:",
+          "arity": 1
+        },
+        {
+          "selector": "compile:ifError:",
+          "arity": 2
+        },
+        {
+          "selector": "compile:notifying:",
+          "arity": 2
+        },
+        {
+          "selector": "compileAll",
+          "arity": 0
+        },
+        {
+          "selector": "compileAll:",
+          "arity": 1
+        },
+        {
+          "selector": "compileAllSubclasses",
+          "arity": 0
+        },
+        {
+          "selector": "compileAllSubclasses:",
+          "arity": 1
+        },
+        {
+          "selector": "compiledMethodAt:",
+          "arity": 1
+        },
+        {
+          "selector": "compiledMethodAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "compilerClass",
+          "arity": 0
+        },
+        {
+          "selector": "createGetMethod:",
+          "arity": 1
+        },
+        {
+          "selector": "createGetMethod:default:",
+          "arity": 2
+        },
+        {
+          "selector": "createSetMethod:",
+          "arity": 1
+        },
+        {
+          "selector": "debuggerClass",
+          "arity": 0
+        },
+        {
+          "selector": "decompile:",
+          "arity": 1
+        },
+        {
+          "selector": "decompilerClass",
+          "arity": 0
+        },
+        {
+          "selector": "defineAsyncCFunc:withSelectorArgs:args:",
+          "arity": 3
+        },
+        {
+          "selector": "defineCFunc:withSelectorArgs:returning:args:",
+          "arity": 4
+        },
+        {
+          "selector": "edit:",
+          "arity": 1
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "evalString:to:",
+          "arity": 2
+        },
+        {
+          "selector": "evalString:to:ifError:",
+          "arity": 3
+        },
+        {
+          "selector": "evaluate:",
+          "arity": 1
+        },
+        {
+          "selector": "evaluate:ifError:",
+          "arity": 2
+        },
+        {
+          "selector": "evaluate:notifying:",
+          "arity": 2
+        },
+        {
+          "selector": "evaluate:to:",
+          "arity": 2
+        },
+        {
+          "selector": "evaluate:to:ifError:",
+          "arity": 3
+        },
+        {
+          "selector": "evaluatorClass",
+          "arity": 0
+        },
+        {
+          "selector": "extractEvalChunk:",
+          "arity": 1
+        },
+        {
+          "selector": "flushCache",
+          "arity": 0
+        },
+        {
+          "selector": "formattedSourceStringAt:",
+          "arity": 1
+        },
+        {
+          "selector": "formattedSourceStringAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "hasMethods",
+          "arity": 0
+        },
+        {
+          "selector": "hierarchyIndent",
+          "arity": 0
+        },
+        {
+          "selector": "includesBehavior:",
+          "arity": 1
+        },
+        {
+          "selector": "includesSelector:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOfInstVar:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOfInstVar:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "inheritsFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "instSize",
+          "arity": 0
+        },
+        {
+          "selector": "instVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "instanceCount",
+          "arity": 0
+        },
+        {
+          "selector": "instanceSpec",
+          "arity": 0
+        },
+        {
+          "selector": "instanceVariableNames:",
+          "arity": 1
+        },
+        {
+          "selector": "isBehavior",
+          "arity": 0
+        },
+        {
+          "selector": "isBits",
+          "arity": 0
+        },
+        {
+          "selector": "isFixed",
+          "arity": 0
+        },
+        {
+          "selector": "isIdentity",
+          "arity": 0
+        },
+        {
+          "selector": "isImmediate",
+          "arity": 0
+        },
+        {
+          "selector": "isPointers",
+          "arity": 0
+        },
+        {
+          "selector": "isVariable",
+          "arity": 0
+        },
+        {
+          "selector": "kindOfSubclass",
+          "arity": 0
+        },
+        {
+          "selector": "lookupAllSelectors:",
+          "arity": 1
+        },
+        {
+          "selector": "lookupSelector:",
+          "arity": 1
+        },
+        {
+          "selector": "methodDictionary",
+          "arity": 0
+        },
+        {
+          "selector": "methodDictionary:",
+          "arity": 1
+        },
+        {
+          "selector": "methods",
+          "arity": 0
+        },
+        {
+          "selector": "methodsFor",
+          "arity": 0
+        },
+        {
+          "selector": "methodsFor:ifFeatures:",
+          "arity": 2
+        },
+        {
+          "selector": "methodsFor:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "methodsFor:stamp:",
+          "arity": 2
+        },
+        {
+          "selector": "mutate:via:",
+          "arity": 2
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "newInFixedSpace",
+          "arity": 0
+        },
+        {
+          "selector": "newInFixedSpace:",
+          "arity": 1
+        },
+        {
+          "selector": "parseInstanceVariableString:",
+          "arity": 1
+        },
+        {
+          "selector": "parseTreeFor:",
+          "arity": 1
+        },
+        {
+          "selector": "parseVariableString:",
+          "arity": 1
+        },
+        {
+          "selector": "parserClass",
+          "arity": 0
+        },
+        {
+          "selector": "primCompile:",
+          "arity": 1
+        },
+        {
+          "selector": "primCompile:ifError:",
+          "arity": 2
+        },
+        {
+          "selector": "printFullHierarchy",
+          "arity": 0
+        },
+        {
+          "selector": "printHierarchy",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "printSubclasses:",
+          "arity": 1
+        },
+        {
+          "selector": "printSuperclasses:",
+          "arity": 1
+        },
+        {
+          "selector": "privateMethods",
+          "arity": 0
+        },
+        {
+          "selector": "publicMethods",
+          "arity": 0
+        },
+        {
+          "selector": "recompile:",
+          "arity": 1
+        },
+        {
+          "selector": "recompile:notifying:",
+          "arity": 2
+        },
+        {
+          "selector": "removeInstVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSelector:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSelector:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeSubclass:",
+          "arity": 1
+        },
+        {
+          "selector": "scopeDictionary",
+          "arity": 0
+        },
+        {
+          "selector": "scopeHas:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "securityPolicy",
+          "arity": 0
+        },
+        {
+          "selector": "securityPolicy:",
+          "arity": 1
+        },
+        {
+          "selector": "selectSubclasses:",
+          "arity": 1
+        },
+        {
+          "selector": "selectSuperclasses:",
+          "arity": 1
+        },
+        {
+          "selector": "selectorAt:",
+          "arity": 1
+        },
+        {
+          "selector": "selectors",
+          "arity": 0
+        },
+        {
+          "selector": "selectorsAndMethodsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "setInstanceSpec:instVars:",
+          "arity": 2
+        },
+        {
+          "selector": "setInstanceVariables:",
+          "arity": 1
+        },
+        {
+          "selector": "shape",
+          "arity": 0
+        },
+        {
+          "selector": "shape:",
+          "arity": 1
+        },
+        {
+          "selector": "shapes",
+          "arity": 0
+        },
+        {
+          "selector": "sharedPoolDictionaries",
+          "arity": 0
+        },
+        {
+          "selector": "sharedPools",
+          "arity": 0
+        },
+        {
+          "selector": "someInstance",
+          "arity": 0
+        },
+        {
+          "selector": "sourceCodeAt:",
+          "arity": 1
+        },
+        {
+          "selector": "sourceCodeAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "sourceMethodAt:",
+          "arity": 1
+        },
+        {
+          "selector": "subclassInstVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "subclasses",
+          "arity": 0
+        },
+        {
+          "selector": "subclassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "superclass",
+          "arity": 0
+        },
+        {
+          "selector": "superclass:",
+          "arity": 1
+        },
+        {
+          "selector": "updateInstanceVars:shape:",
+          "arity": 2
+        },
+        {
+          "selector": "updateInstanceVars:superclass:shape:",
+          "arity": 3
+        },
+        {
+          "selector": "validateIdentifier:",
+          "arity": 1
+        },
+        {
+          "selector": "whichClassIncludesSelector:",
+          "arity": 1
+        },
+        {
+          "selector": "whichSelectorsAccess:",
+          "arity": 1
+        },
+        {
+          "selector": "whichSelectorsAssign:",
+          "arity": 1
+        },
+        {
+          "selector": "whichSelectorsRead:",
+          "arity": 1
+        },
+        {
+          "selector": "whichSelectorsReferTo:",
+          "arity": 1
+        },
+        {
+          "selector": "whichSelectorsReferToByteCode:",
+          "arity": 1
+        },
+        {
+          "selector": "withAllSubclasses",
+          "arity": 0
+        },
+        {
+          "selector": "withAllSubclassesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "withAllSuperclasses",
+          "arity": 0
+        },
+        {
+          "selector": "withAllSuperclassesDo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "BindingDictionary": {
+      "superclass": "Dictionary",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "addWhileGrowing:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "copyEmpty:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmptyForCollect",
+          "arity": 0
+        },
+        {
+          "selector": "copyEmptyForCollect:",
+          "arity": 1
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "define:",
+          "arity": 1
+        },
+        {
+          "selector": "doesNotUnderstand:",
+          "arity": 1
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "environment:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "import:from:",
+          "arity": 2
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "BlockClosure": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "argumentCount",
+          "arity": 0
+        },
+        {
+          "selector": "asContext:",
+          "arity": 1
+        },
+        {
+          "selector": "block",
+          "arity": 0
+        },
+        {
+          "selector": "block:",
+          "arity": 1
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "cull:",
+          "arity": 1
+        },
+        {
+          "selector": "cull:cull:",
+          "arity": 2
+        },
+        {
+          "selector": "cull:cull:cull:",
+          "arity": 3
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "ensure:",
+          "arity": 1
+        },
+        {
+          "selector": "finalIP",
+          "arity": 0
+        },
+        {
+          "selector": "fixTemps",
+          "arity": 0
+        },
+        {
+          "selector": "fork",
+          "arity": 0
+        },
+        {
+          "selector": "forkAt:",
+          "arity": 1
+        },
+        {
+          "selector": "forkWithoutPreemption",
+          "arity": 0
+        },
+        {
+          "selector": "hasMethodReturn",
+          "arity": 0
+        },
+        {
+          "selector": "ifCurtailed:",
+          "arity": 1
+        },
+        {
+          "selector": "ifError:",
+          "arity": 1
+        },
+        {
+          "selector": "initialIP",
+          "arity": 0
+        },
+        {
+          "selector": "method",
+          "arity": 0
+        },
+        {
+          "selector": "newProcess",
+          "arity": 0
+        },
+        {
+          "selector": "newProcessWith:",
+          "arity": 1
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "numTemps",
+          "arity": 0
+        },
+        {
+          "selector": "on:do:",
+          "arity": 2
+        },
+        {
+          "selector": "on:do:on:do:",
+          "arity": 4
+        },
+        {
+          "selector": "on:do:on:do:on:do:",
+          "arity": 6
+        },
+        {
+          "selector": "on:do:on:do:on:do:on:do:",
+          "arity": 8
+        },
+        {
+          "selector": "on:do:on:do:on:do:on:do:on:do:",
+          "arity": 10
+        },
+        {
+          "selector": "outerContext",
+          "arity": 0
+        },
+        {
+          "selector": "outerContext:",
+          "arity": 1
+        },
+        {
+          "selector": "receiver",
+          "arity": 0
+        },
+        {
+          "selector": "receiver:",
+          "arity": 1
+        },
+        {
+          "selector": "repeat",
+          "arity": 0
+        },
+        {
+          "selector": "stackDepth",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        },
+        {
+          "selector": "value:value:",
+          "arity": 2
+        },
+        {
+          "selector": "value:value:value:",
+          "arity": 3
+        },
+        {
+          "selector": "valueAndResumeOnUnwind",
+          "arity": 0
+        },
+        {
+          "selector": "valueWithArguments:",
+          "arity": 1
+        },
+        {
+          "selector": "valueWithUnwind",
+          "arity": 0
+        },
+        {
+          "selector": "valueWithoutInterrupts",
+          "arity": 0
+        },
+        {
+          "selector": "valueWithoutPreemption",
+          "arity": 0
+        },
+        {
+          "selector": "whileFalse",
+          "arity": 0
+        },
+        {
+          "selector": "whileFalse:",
+          "arity": 1
+        },
+        {
+          "selector": "whileTrue",
+          "arity": 0
+        },
+        {
+          "selector": "whileTrue:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "block:",
+          "arity": 1
+        },
+        {
+          "selector": "block:receiver:",
+          "arity": 2
+        },
+        {
+          "selector": "block:receiver:outerContext:",
+          "arity": 3
+        },
+        {
+          "selector": "exceptionHandlerResetBlock",
+          "arity": 0
+        },
+        {
+          "selector": "exceptionHandlerSearchBlock",
+          "arity": 0
+        },
+        {
+          "selector": "isImmediate",
+          "arity": 0
+        },
+        {
+          "selector": "numArgs:numTemps:bytecodes:depth:literals:",
+          "arity": 5
+        }
+      ]
+    },
+    "BlockContext": {
+      "superclass": "ContextPart",
+      "instanceSelectors": [
+        {
+          "selector": "caller",
+          "arity": 0
+        },
+        {
+          "selector": "home",
+          "arity": 0
+        },
+        {
+          "selector": "isBlock",
+          "arity": 0
+        },
+        {
+          "selector": "isDisabled",
+          "arity": 0
+        },
+        {
+          "selector": "isEnvironment",
+          "arity": 0
+        },
+        {
+          "selector": "isInternalExceptionHandlingContext",
+          "arity": 0
+        },
+        {
+          "selector": "isUnwind",
+          "arity": 0
+        },
+        {
+          "selector": "nthOuterContext:",
+          "arity": 1
+        },
+        {
+          "selector": "outerContext",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromClosure:parent:",
+          "arity": 2
+        }
+      ]
+    },
+    "Boolean": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "&",
+          "arity": 1
+        },
+        {
+          "selector": "and:",
+          "arity": 1
+        },
+        {
+          "selector": "asCBooleanValue",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "eqv:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "ifTrue:",
+          "arity": 1
+        },
+        {
+          "selector": "ifTrue:ifFalse:",
+          "arity": 2
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "not",
+          "arity": 0
+        },
+        {
+          "selector": "or:",
+          "arity": 1
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "xor:",
+          "arity": 1
+        },
+        {
+          "selector": "|",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "isIdentity",
+          "arity": 0
+        },
+        {
+          "selector": "isImmediate",
+          "arity": 0
+        }
+      ]
+    },
+    "ByteArray": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asCData",
+          "arity": 0
+        },
+        {
+          "selector": "asCData:",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asUnicodeString",
+          "arity": 0
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "byteAt:",
+          "arity": 1
+        },
+        {
+          "selector": "byteAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "castTo:",
+          "arity": 1
+        },
+        {
+          "selector": "charAt:",
+          "arity": 1
+        },
+        {
+          "selector": "charAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "doubleAt:",
+          "arity": 1
+        },
+        {
+          "selector": "doubleAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "floatAt:",
+          "arity": 1
+        },
+        {
+          "selector": "floatAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "growSize",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "indexOf:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "intAt:",
+          "arity": 1
+        },
+        {
+          "selector": "intAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "longAt:",
+          "arity": 1
+        },
+        {
+          "selector": "longAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "longDoubleAt:",
+          "arity": 1
+        },
+        {
+          "selector": "longDoubleAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "objectAt:",
+          "arity": 1
+        },
+        {
+          "selector": "objectAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "replaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "replaceFrom:to:withString:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "shortAt:",
+          "arity": 1
+        },
+        {
+          "selector": "shortAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "stringAt:",
+          "arity": 1
+        },
+        {
+          "selector": "stringAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "type:at:",
+          "arity": 2
+        },
+        {
+          "selector": "type:at:put:",
+          "arity": 3
+        },
+        {
+          "selector": "ucharAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ucharAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "uintAt:",
+          "arity": 1
+        },
+        {
+          "selector": "uintAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "ulongAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ulongAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedCharAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedCharAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedIntAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedIntAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedLongAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedLongAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedShortAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedShortAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "ushortAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ushortAt:put:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromCData:size:",
+          "arity": 2
+        }
+      ]
+    },
+    "CAggregate": {
+      "superclass": "CObject",
+      "instanceSelectors": [
+        {
+          "selector": "elementType",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CArray": {
+      "superclass": "CAggregate",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredValue",
+          "arity": 0
+        },
+        {
+          "selector": "dereferencedType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "CArrayCType": {
+      "superclass": "CPtrCType",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "numberOfElements",
+          "arity": 0
+        },
+        {
+          "selector": "numberOfElements:",
+          "arity": 1
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "elementType:",
+          "arity": 1
+        },
+        {
+          "selector": "elementType:numberOfElements:",
+          "arity": 2
+        },
+        {
+          "selector": "from:",
+          "arity": 1
+        }
+      ]
+    },
+    "CBoolean": {
+      "superclass": "CByte",
+      "instanceSelectors": [
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "type",
+          "arity": 0
+        }
+      ]
+    },
+    "CByte": {
+      "superclass": "CUChar",
+      "instanceSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "type",
+          "arity": 0
+        }
+      ]
+    },
+    "CCallable": {
+      "superclass": "CObject",
+      "instanceSelectors": [
+        {
+          "selector": "argTypes:",
+          "arity": 1
+        },
+        {
+          "selector": "asyncCall",
+          "arity": 0
+        },
+        {
+          "selector": "asyncCallNoRetryFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "callInto:",
+          "arity": 1
+        },
+        {
+          "selector": "callNoRetryFrom:into:",
+          "arity": 2
+        },
+        {
+          "selector": "isValid",
+          "arity": 0
+        },
+        {
+          "selector": "link",
+          "arity": 0
+        },
+        {
+          "selector": "returnType",
+          "arity": 0
+        },
+        {
+          "selector": "returnType:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "for:returning:withArgs:",
+          "arity": 3
+        },
+        {
+          "selector": "mapType:",
+          "arity": 1
+        },
+        {
+          "selector": "typeMap",
+          "arity": 0
+        }
+      ]
+    },
+    "CCallbackDescriptor": {
+      "superclass": "CCallable",
+      "instanceSelectors": [
+        {
+          "selector": "block",
+          "arity": 0
+        },
+        {
+          "selector": "block:",
+          "arity": 1
+        },
+        {
+          "selector": "link",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "for:returning:withArgs:",
+          "arity": 3
+        }
+      ]
+    },
+    "CChar": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "asByteArray:",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asString:",
+          "arity": 1
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CCompound": {
+      "superclass": "CObject",
+      "instanceSelectors": [
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "fieldSelectorList",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "classPragmas",
+          "arity": 0
+        },
+        {
+          "selector": "compileSize:align:",
+          "arity": 2
+        },
+        {
+          "selector": "declaration",
+          "arity": 0
+        },
+        {
+          "selector": "declaration:",
+          "arity": 1
+        },
+        {
+          "selector": "declaration:inject:into:",
+          "arity": 3
+        },
+        {
+          "selector": "emitFieldNameTo:for:",
+          "arity": 2
+        },
+        {
+          "selector": "gcNew",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "newStruct:declaration:",
+          "arity": 2
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        },
+        {
+          "selector": "subclass:declaration:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        }
+      ]
+    },
+    "CDouble": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CFloat": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CFunctionDescriptor": {
+      "superclass": "CCallable",
+      "instanceSelectors": [
+        {
+          "selector": "addressOf:",
+          "arity": 1
+        },
+        {
+          "selector": "link",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "addressOf:",
+          "arity": 1
+        },
+        {
+          "selector": "for:returning:withArgs:",
+          "arity": 3
+        },
+        {
+          "selector": "isFunction:",
+          "arity": 1
+        }
+      ]
+    },
+    "CInt": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CInterfaceError": {
+      "superclass": "PrimitiveFailed",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "CLong": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CLongDouble": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CLongLong": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CObject": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "address",
+          "arity": 0
+        },
+        {
+          "selector": "address:",
+          "arity": 1
+        },
+        {
+          "selector": "addressAt:",
+          "arity": 1
+        },
+        {
+          "selector": "adjPtrBy:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:noCObjectsPut:type:",
+          "arity": 3
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "at:put:type:",
+          "arity": 3
+        },
+        {
+          "selector": "at:type:",
+          "arity": 2
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredValue",
+          "arity": 0
+        },
+        {
+          "selector": "castTo:",
+          "arity": 1
+        },
+        {
+          "selector": "decr",
+          "arity": 0
+        },
+        {
+          "selector": "decrBy:",
+          "arity": 1
+        },
+        {
+          "selector": "derefAt:type:",
+          "arity": 2
+        },
+        {
+          "selector": "dereferencedType",
+          "arity": 0
+        },
+        {
+          "selector": "finalize",
+          "arity": 0
+        },
+        {
+          "selector": "free",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "incr",
+          "arity": 0
+        },
+        {
+          "selector": "incrBy:",
+          "arity": 1
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isCObject",
+          "arity": 0
+        },
+        {
+          "selector": "isNull",
+          "arity": 0
+        },
+        {
+          "selector": "narrow",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storage",
+          "arity": 0
+        },
+        {
+          "selector": "storage:",
+          "arity": 1
+        },
+        {
+          "selector": "type",
+          "arity": 0
+        },
+        {
+          "selector": "type:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "address:",
+          "arity": 1
+        },
+        {
+          "selector": "alloc:",
+          "arity": 1
+        },
+        {
+          "selector": "alloc:type:",
+          "arity": 2
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "gcAlloc:",
+          "arity": 1
+        },
+        {
+          "selector": "gcAlloc:type:",
+          "arity": 2
+        },
+        {
+          "selector": "gcNew:",
+          "arity": 1
+        },
+        {
+          "selector": "inheritShape",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "type",
+          "arity": 0
+        }
+      ]
+    },
+    "CPtr": {
+      "superclass": "CAggregate",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "CPtrCType": {
+      "superclass": "CType",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "elementType",
+          "arity": 0
+        },
+        {
+          "selector": "elementType:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "elementType:",
+          "arity": 1
+        },
+        {
+          "selector": "from:",
+          "arity": 1
+        }
+      ]
+    },
+    "CScalar": {
+      "superclass": "CObject",
+      "instanceSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "gcValue:",
+          "arity": 1
+        },
+        {
+          "selector": "type",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ]
+    },
+    "CScalarCType": {
+      "superclass": "CType",
+      "instanceSelectors": [
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "valueType",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "CShort": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CSmalltalk": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CString": {
+      "superclass": "CPtr",
+      "instanceSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "type",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ]
+    },
+    "CStringCType": {
+      "superclass": "CScalarCType",
+      "instanceSelectors": [
+        {
+          "selector": "elementType",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "CStruct": {
+      "superclass": "CCompound",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "declaration:",
+          "arity": 1
+        }
+      ]
+    },
+    "CType": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "address:",
+          "arity": 1
+        },
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "arrayType:",
+          "arity": 1
+        },
+        {
+          "selector": "cObjectType",
+          "arity": 0
+        },
+        {
+          "selector": "gcNew",
+          "arity": 0
+        },
+        {
+          "selector": "gcNew:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "init:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "ptrType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "valueType",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "cObjectBinding:",
+          "arity": 1
+        },
+        {
+          "selector": "cObjectType:",
+          "arity": 1
+        },
+        {
+          "selector": "computeAggregateType:",
+          "arity": 1
+        },
+        {
+          "selector": "from:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        }
+      ]
+    },
+    "CUChar": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CUInt": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CULong": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CULongLong": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CUShort": {
+      "superclass": "CScalar",
+      "instanceSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "alignof",
+          "arity": 0
+        },
+        {
+          "selector": "cObjStoredType",
+          "arity": 0
+        },
+        {
+          "selector": "sizeof",
+          "arity": 0
+        }
+      ]
+    },
+    "CUnion": {
+      "superclass": "CCompound",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "declaration:",
+          "arity": 1
+        }
+      ]
+    },
+    "CallinProcess": {
+      "superclass": "Process",
+      "instanceSelectors": [
+        {
+          "selector": "detach",
+          "arity": 0
+        },
+        {
+          "selector": "returnContext",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Character": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "asCharacter",
+          "arity": 0
+        },
+        {
+          "selector": "asInteger",
+          "arity": 0
+        },
+        {
+          "selector": "asLowercase",
+          "arity": 0
+        },
+        {
+          "selector": "asLowercaseValue",
+          "arity": 0
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "asUnicodeString",
+          "arity": 0
+        },
+        {
+          "selector": "asUppercase",
+          "arity": 0
+        },
+        {
+          "selector": "asciiValue",
+          "arity": 0
+        },
+        {
+          "selector": "codePoint",
+          "arity": 0
+        },
+        {
+          "selector": "digitValue",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "isAlphaNumeric",
+          "arity": 0
+        },
+        {
+          "selector": "isCharacter",
+          "arity": 0
+        },
+        {
+          "selector": "isDigit",
+          "arity": 0
+        },
+        {
+          "selector": "isDigit:",
+          "arity": 1
+        },
+        {
+          "selector": "isLetter",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "isLowercase",
+          "arity": 0
+        },
+        {
+          "selector": "isPathSeparator",
+          "arity": 0
+        },
+        {
+          "selector": "isPunctuation",
+          "arity": 0
+        },
+        {
+          "selector": "isSeparator",
+          "arity": 0
+        },
+        {
+          "selector": "isUppercase",
+          "arity": 0
+        },
+        {
+          "selector": "isVowel",
+          "arity": 0
+        },
+        {
+          "selector": "printCodePointOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "asciiValue:",
+          "arity": 1
+        },
+        {
+          "selector": "backspace",
+          "arity": 0
+        },
+        {
+          "selector": "bell",
+          "arity": 0
+        },
+        {
+          "selector": "codePoint:",
+          "arity": 1
+        },
+        {
+          "selector": "cr",
+          "arity": 0
+        },
+        {
+          "selector": "digitValue:",
+          "arity": 1
+        },
+        {
+          "selector": "eof",
+          "arity": 0
+        },
+        {
+          "selector": "eot",
+          "arity": 0
+        },
+        {
+          "selector": "esc",
+          "arity": 0
+        },
+        {
+          "selector": "ff",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isImmediate",
+          "arity": 0
+        },
+        {
+          "selector": "lf",
+          "arity": 0
+        },
+        {
+          "selector": "newPage",
+          "arity": 0
+        },
+        {
+          "selector": "nl",
+          "arity": 0
+        },
+        {
+          "selector": "nul",
+          "arity": 0
+        },
+        {
+          "selector": "space",
+          "arity": 0
+        },
+        {
+          "selector": "tab",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ]
+    },
+    "CharacterArray": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "%",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "asByteArray",
+          "arity": 0
+        },
+        {
+          "selector": "asClassPoolKey",
+          "arity": 0
+        },
+        {
+          "selector": "asGlobalKey",
+          "arity": 0
+        },
+        {
+          "selector": "asInteger",
+          "arity": 0
+        },
+        {
+          "selector": "asLowercase",
+          "arity": 0
+        },
+        {
+          "selector": "asNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asPoolKey",
+          "arity": 0
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "asUnicodeString",
+          "arity": 0
+        },
+        {
+          "selector": "asUppercase",
+          "arity": 0
+        },
+        {
+          "selector": "bindWith:",
+          "arity": 1
+        },
+        {
+          "selector": "bindWith:with:",
+          "arity": 2
+        },
+        {
+          "selector": "bindWith:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "bindWith:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "bindWithArguments:",
+          "arity": 1
+        },
+        {
+          "selector": "caseInsensitiveCompareTo:",
+          "arity": 1
+        },
+        {
+          "selector": "contractTo:",
+          "arity": 1
+        },
+        {
+          "selector": "encoding",
+          "arity": 0
+        },
+        {
+          "selector": "fileName",
+          "arity": 0
+        },
+        {
+          "selector": "filePos",
+          "arity": 0
+        },
+        {
+          "selector": "indexOf:matchCase:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "isCharacterArray",
+          "arity": 0
+        },
+        {
+          "selector": "isNumeric",
+          "arity": 0
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        },
+        {
+          "selector": "lines",
+          "arity": 0
+        },
+        {
+          "selector": "linesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "match:",
+          "arity": 1
+        },
+        {
+          "selector": "match:ignoreCase:",
+          "arity": 2
+        },
+        {
+          "selector": "matchSubstring:in:at:",
+          "arity": 3
+        },
+        {
+          "selector": "numberOfCharacters",
+          "arity": 0
+        },
+        {
+          "selector": "sameAs:",
+          "arity": 1
+        },
+        {
+          "selector": "subStrings",
+          "arity": 0
+        },
+        {
+          "selector": "subStrings:",
+          "arity": 1
+        },
+        {
+          "selector": "subStringsChar:",
+          "arity": 1
+        },
+        {
+          "selector": "substrings",
+          "arity": 0
+        },
+        {
+          "selector": "substrings:",
+          "arity": 1
+        },
+        {
+          "selector": "trimSeparators",
+          "arity": 0
+        },
+        {
+          "selector": "valueAt:",
+          "arity": 1
+        },
+        {
+          "selector": "valueAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "valueAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "withShellEscapes",
+          "arity": 0
+        },
+        {
+          "selector": "withUnixShellEscapes",
+          "arity": 0
+        },
+        {
+          "selector": "withWindowsShellEscapes",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromString:",
+          "arity": 1
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        },
+        {
+          "selector": "lineDelimiter",
+          "arity": 0
+        }
+      ]
+    },
+    "Class": {
+      "superclass": "ClassDescription",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "addClassVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "addClassVarName:value:",
+          "arity": 2
+        },
+        {
+          "selector": "addSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "allClassVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "allLocalSharedPoolDictionariesExcept:do:",
+          "arity": 2
+        },
+        {
+          "selector": "allSharedPoolDictionariesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "article",
+          "arity": 0
+        },
+        {
+          "selector": "asClass",
+          "arity": 0
+        },
+        {
+          "selector": "binaryRepresentationVersion",
+          "arity": 0
+        },
+        {
+          "selector": "bindingFor:",
+          "arity": 1
+        },
+        {
+          "selector": "categoriesFor:are:",
+          "arity": 2
+        },
+        {
+          "selector": "category",
+          "arity": 0
+        },
+        {
+          "selector": "category:",
+          "arity": 1
+        },
+        {
+          "selector": "check:",
+          "arity": 1
+        },
+        {
+          "selector": "classInstanceVariableNames:",
+          "arity": 1
+        },
+        {
+          "selector": "classPool",
+          "arity": 0
+        },
+        {
+          "selector": "classPragmas",
+          "arity": 0
+        },
+        {
+          "selector": "classVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "comment",
+          "arity": 0
+        },
+        {
+          "selector": "comment:",
+          "arity": 1
+        },
+        {
+          "selector": "convertFromVersion:withFixedVariables:indexedVariables:for:",
+          "arity": 4
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "environment:",
+          "arity": 1
+        },
+        {
+          "selector": "extend",
+          "arity": 0
+        },
+        {
+          "selector": "fileOutDeclarationOn:",
+          "arity": 1
+        },
+        {
+          "selector": "fileOutOn:",
+          "arity": 1
+        },
+        {
+          "selector": "inheritShape",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "initializeAsRootClass",
+          "arity": 0
+        },
+        {
+          "selector": "isClass",
+          "arity": 0
+        },
+        {
+          "selector": "metaclassFor:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "nonVersionedInstSize",
+          "arity": 0
+        },
+        {
+          "selector": "pragmaHandlerFor:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "registerHandler:forPragma:",
+          "arity": 2
+        },
+        {
+          "selector": "removeClassVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "securityPolicy",
+          "arity": 0
+        },
+        {
+          "selector": "securityPolicy:",
+          "arity": 1
+        },
+        {
+          "selector": "setClassVariables:",
+          "arity": 1
+        },
+        {
+          "selector": "setEnvironment:",
+          "arity": 1
+        },
+        {
+          "selector": "setName:",
+          "arity": 1
+        },
+        {
+          "selector": "setSharedPools:",
+          "arity": 1
+        },
+        {
+          "selector": "sharedPoolDictionaries",
+          "arity": 0
+        },
+        {
+          "selector": "sharedPools",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "subclass:",
+          "arity": 1
+        },
+        {
+          "selector": "subclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "subclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "superclass:",
+          "arity": 1
+        },
+        {
+          "selector": "variable:subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 6
+        },
+        {
+          "selector": "variableByteSubclass:classInstanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableByteSubclass:classVariableNames:poolDictionaries:",
+          "arity": 3
+        },
+        {
+          "selector": "variableByteSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "variableLongSubclass:classInstanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableLongSubclass:classVariableNames:poolDictionaries:",
+          "arity": 3
+        },
+        {
+          "selector": "variableSubclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "variableSubclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "variableWordSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "allPoolDictionaries:except:do:",
+          "arity": 3
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        }
+      ]
+    },
+    "ClassDescription": {
+      "superclass": "Behavior",
+      "instanceSelectors": [
+        {
+          "selector": "addSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "asClass",
+          "arity": 0
+        },
+        {
+          "selector": "asMetaclass",
+          "arity": 0
+        },
+        {
+          "selector": "binding",
+          "arity": 0
+        },
+        {
+          "selector": "classVariableString",
+          "arity": 0
+        },
+        {
+          "selector": "classify:under:",
+          "arity": 2
+        },
+        {
+          "selector": "collectCategories",
+          "arity": 0
+        },
+        {
+          "selector": "compile:classified:",
+          "arity": 2
+        },
+        {
+          "selector": "compile:classified:ifError:",
+          "arity": 3
+        },
+        {
+          "selector": "compile:classified:notifying:",
+          "arity": 3
+        },
+        {
+          "selector": "copy:from:",
+          "arity": 2
+        },
+        {
+          "selector": "copy:from:classified:",
+          "arity": 3
+        },
+        {
+          "selector": "copyAll:from:",
+          "arity": 2
+        },
+        {
+          "selector": "copyAll:from:classified:",
+          "arity": 3
+        },
+        {
+          "selector": "copyAllCategoriesFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "copyCategory:from:",
+          "arity": 2
+        },
+        {
+          "selector": "copyCategory:from:classified:",
+          "arity": 3
+        },
+        {
+          "selector": "createGetMethod:",
+          "arity": 1
+        },
+        {
+          "selector": "createGetMethod:default:",
+          "arity": 2
+        },
+        {
+          "selector": "createSetMethod:",
+          "arity": 1
+        },
+        {
+          "selector": "defineAsyncCFunc:withSelectorArgs:args:",
+          "arity": 3
+        },
+        {
+          "selector": "defineCFunc:withSelectorArgs:returning:args:",
+          "arity": 4
+        },
+        {
+          "selector": "fileOut:",
+          "arity": 1
+        },
+        {
+          "selector": "fileOutCategory:to:",
+          "arity": 2
+        },
+        {
+          "selector": "fileOutCategory:toStream:",
+          "arity": 2
+        },
+        {
+          "selector": "fileOutOn:",
+          "arity": 1
+        },
+        {
+          "selector": "fileOutSelector:to:",
+          "arity": 2
+        },
+        {
+          "selector": "fileOutSelector:toStream:",
+          "arity": 2
+        },
+        {
+          "selector": "import:",
+          "arity": 1
+        },
+        {
+          "selector": "instanceVariableString",
+          "arity": 0
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "removeCategory:",
+          "arity": 1
+        },
+        {
+          "selector": "sharedVariableString",
+          "arity": 0
+        },
+        {
+          "selector": "whichCategoryIncludesSelector:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "CollectingStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "initStream:block:",
+          "arity": 2
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:collect:",
+          "arity": 2
+        }
+      ]
+    },
+    "Collection": {
+      "superclass": "Iterable",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "addAll:",
+          "arity": 1
+        },
+        {
+          "selector": "anyOne",
+          "arity": 0
+        },
+        {
+          "selector": "asArray",
+          "arity": 0
+        },
+        {
+          "selector": "asBag",
+          "arity": 0
+        },
+        {
+          "selector": "asByteArray",
+          "arity": 0
+        },
+        {
+          "selector": "asOrderedCollection",
+          "arity": 0
+        },
+        {
+          "selector": "asRunArray",
+          "arity": 0
+        },
+        {
+          "selector": "asRunArrayMap",
+          "arity": 0
+        },
+        {
+          "selector": "asSet",
+          "arity": 0
+        },
+        {
+          "selector": "asSortedCollection",
+          "arity": 0
+        },
+        {
+          "selector": "asSortedCollection:",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asUnicodeString",
+          "arity": 0
+        },
+        {
+          "selector": "beConsistent",
+          "arity": 0
+        },
+        {
+          "selector": "capacity",
+          "arity": 0
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "copyEmpty:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmptyForCollect",
+          "arity": 0
+        },
+        {
+          "selector": "copyEmptyForCollect:",
+          "arity": 1
+        },
+        {
+          "selector": "copyReplacing:withObject:",
+          "arity": 2
+        },
+        {
+          "selector": "copyWith:",
+          "arity": 1
+        },
+        {
+          "selector": "copyWithout:",
+          "arity": 1
+        },
+        {
+          "selector": "displayLines",
+          "arity": 0
+        },
+        {
+          "selector": "empty",
+          "arity": 0
+        },
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "gather:",
+          "arity": 1
+        },
+        {
+          "selector": "identityIncludes:",
+          "arity": 1
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "includesAllOf:",
+          "arity": 1
+        },
+        {
+          "selector": "includesAnyOf:",
+          "arity": 1
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "isSequenceable",
+          "arity": 0
+        },
+        {
+          "selector": "join",
+          "arity": 0
+        },
+        {
+          "selector": "mourn:",
+          "arity": 1
+        },
+        {
+          "selector": "notEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "occurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAll:",
+          "arity": 1
+        },
+        {
+          "selector": "removeAll:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAllSuchThat:",
+          "arity": 1
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "sorted",
+          "arity": 0
+        },
+        {
+          "selector": "sorted:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "from:",
+          "arity": 1
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        },
+        {
+          "selector": "join:",
+          "arity": 1
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "with:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "with:with:with:with:with:",
+          "arity": 5
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "CompiledBlock": {
+      "superclass": "CompiledCode",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "binaryRepresentationObject",
+          "arity": 0
+        },
+        {
+          "selector": "flags",
+          "arity": 0
+        },
+        {
+          "selector": "header:literals:",
+          "arity": 2
+        },
+        {
+          "selector": "method",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory:",
+          "arity": 1
+        },
+        {
+          "selector": "methodClass",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass:",
+          "arity": 1
+        },
+        {
+          "selector": "methodSourceCode",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceFile",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourcePos",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceString",
+          "arity": 0
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "numLiterals",
+          "arity": 0
+        },
+        {
+          "selector": "numTemps",
+          "arity": 0
+        },
+        {
+          "selector": "printHeaderOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "sourceCodeLinesDelta",
+          "arity": 0
+        },
+        {
+          "selector": "sourceCodeMap",
+          "arity": 0
+        },
+        {
+          "selector": "stackDepth",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new:header:method:",
+          "arity": 3
+        },
+        {
+          "selector": "numArgs:numTemps:bytecodes:depth:literals:",
+          "arity": 5
+        }
+      ]
+    },
+    "CompiledCode": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "accesses:",
+          "arity": 1
+        },
+        {
+          "selector": "allByteCodeIndicesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allLiteralSymbolsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allLiteralsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "assigns:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "blockAt:",
+          "arity": 1
+        },
+        {
+          "selector": "bytecodeAt:",
+          "arity": 1
+        },
+        {
+          "selector": "bytecodeAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "bytecodeIndex:with:",
+          "arity": 2
+        },
+        {
+          "selector": "bytecodeSizeAt:",
+          "arity": 1
+        },
+        {
+          "selector": "bytecodeStart",
+          "arity": 0
+        },
+        {
+          "selector": "containsLiteral:",
+          "arity": 1
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "discardTranslation",
+          "arity": 0
+        },
+        {
+          "selector": "dispatchByte:with:at:to:with:",
+          "arity": 5
+        },
+        {
+          "selector": "dispatchJump:at:to:with:",
+          "arity": 4
+        },
+        {
+          "selector": "dispatchOneByte:to:with:",
+          "arity": 3
+        },
+        {
+          "selector": "dispatchOtherStack:with:to:with:",
+          "arity": 4
+        },
+        {
+          "selector": "dispatchSend:with:to:with:",
+          "arity": 4
+        },
+        {
+          "selector": "dispatchSuperoperator:with:at:to:",
+          "arity": 4
+        },
+        {
+          "selector": "dispatchTo:with:",
+          "arity": 2
+        },
+        {
+          "selector": "dispatchVariableOp:with:to:with:",
+          "arity": 4
+        },
+        {
+          "selector": "dupStackTop:",
+          "arity": 1
+        },
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "exitInterpreter:",
+          "arity": 1
+        },
+        {
+          "selector": "flags",
+          "arity": 0
+        },
+        {
+          "selector": "getHeader",
+          "arity": 0
+        },
+        {
+          "selector": "hasBytecode:between:and:",
+          "arity": 3
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "header:literals:",
+          "arity": 2
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "invalidOpcode:",
+          "arity": 1
+        },
+        {
+          "selector": "isAnnotated",
+          "arity": 0
+        },
+        {
+          "selector": "jumpDestinationAt:forward:",
+          "arity": 2
+        },
+        {
+          "selector": "jumpTo:with:",
+          "arity": 2
+        },
+        {
+          "selector": "lineNo:with:",
+          "arity": 2
+        },
+        {
+          "selector": "literalAt:",
+          "arity": 1
+        },
+        {
+          "selector": "literalAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "literals",
+          "arity": 0
+        },
+        {
+          "selector": "literalsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "makeDirtyBlock:",
+          "arity": 1
+        },
+        {
+          "selector": "method",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory:",
+          "arity": 1
+        },
+        {
+          "selector": "methodClass",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass:",
+          "arity": 1
+        },
+        {
+          "selector": "methodSourceCode",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceFile",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourcePos",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceString",
+          "arity": 0
+        },
+        {
+          "selector": "nextBytecodeIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "numBytecodes",
+          "arity": 0
+        },
+        {
+          "selector": "numLiterals",
+          "arity": 0
+        },
+        {
+          "selector": "numTemps",
+          "arity": 0
+        },
+        {
+          "selector": "popIntoArray:with:",
+          "arity": 2
+        },
+        {
+          "selector": "popJumpIfFalseTo:with:",
+          "arity": 2
+        },
+        {
+          "selector": "popJumpIfTrueTo:with:",
+          "arity": 2
+        },
+        {
+          "selector": "popStackTop:",
+          "arity": 1
+        },
+        {
+          "selector": "primitive",
+          "arity": 0
+        },
+        {
+          "selector": "printByteCodesOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printHeaderOn:",
+          "arity": 1
+        },
+        {
+          "selector": "pushGlobal:with:",
+          "arity": 2
+        },
+        {
+          "selector": "pushInstVar:with:",
+          "arity": 2
+        },
+        {
+          "selector": "pushLiteral:with:",
+          "arity": 2
+        },
+        {
+          "selector": "pushSelf:",
+          "arity": 1
+        },
+        {
+          "selector": "pushTemporary:outer:with:",
+          "arity": 3
+        },
+        {
+          "selector": "pushTemporary:with:",
+          "arity": 2
+        },
+        {
+          "selector": "reads:",
+          "arity": 1
+        },
+        {
+          "selector": "refersTo:",
+          "arity": 1
+        },
+        {
+          "selector": "returnFromContext:",
+          "arity": 1
+        },
+        {
+          "selector": "returnFromMethod:",
+          "arity": 1
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "send:numArgs:with:",
+          "arity": 3
+        },
+        {
+          "selector": "sendsToSuper",
+          "arity": 0
+        },
+        {
+          "selector": "sourceCodeLinesDelta",
+          "arity": 0
+        },
+        {
+          "selector": "sourceCodeMap",
+          "arity": 0
+        },
+        {
+          "selector": "stackDepth",
+          "arity": 0
+        },
+        {
+          "selector": "storeGlobal:with:",
+          "arity": 2
+        },
+        {
+          "selector": "storeInstVar:with:",
+          "arity": 2
+        },
+        {
+          "selector": "storeTemporary:outer:with:",
+          "arity": 3
+        },
+        {
+          "selector": "storeTemporary:with:",
+          "arity": 2
+        },
+        {
+          "selector": "superSend:numArgs:with:",
+          "arity": 3
+        },
+        {
+          "selector": "traverseLiteral:with:",
+          "arity": 2
+        },
+        {
+          "selector": "verificationResult",
+          "arity": 0
+        },
+        {
+          "selector": "verify",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "bytecodeInfoTable",
+          "arity": 0
+        },
+        {
+          "selector": "flushTranslatorCache",
+          "arity": 0
+        },
+        {
+          "selector": "new:header:literals:",
+          "arity": 3
+        },
+        {
+          "selector": "new:header:numLiterals:",
+          "arity": 3
+        },
+        {
+          "selector": "specialSelectors",
+          "arity": 0
+        },
+        {
+          "selector": "specialSelectorsNumArgs",
+          "arity": 0
+        }
+      ]
+    },
+    "CompiledMethod": {
+      "superclass": "CompiledCode",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "accesses:",
+          "arity": 1
+        },
+        {
+          "selector": "allBlocksDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allLiterals",
+          "arity": 0
+        },
+        {
+          "selector": "assigns:",
+          "arity": 1
+        },
+        {
+          "selector": "attributeAt:",
+          "arity": 1
+        },
+        {
+          "selector": "attributeAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "attributes",
+          "arity": 0
+        },
+        {
+          "selector": "attributesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "binaryRepresentationObject",
+          "arity": 0
+        },
+        {
+          "selector": "descriptor",
+          "arity": 0
+        },
+        {
+          "selector": "descriptor:",
+          "arity": 1
+        },
+        {
+          "selector": "flags",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isAbstract",
+          "arity": 0
+        },
+        {
+          "selector": "isAnnotated",
+          "arity": 0
+        },
+        {
+          "selector": "isOldSyntax",
+          "arity": 0
+        },
+        {
+          "selector": "isValidCCall",
+          "arity": 0
+        },
+        {
+          "selector": "makeLiteralsReadOnly",
+          "arity": 0
+        },
+        {
+          "selector": "makeLiteralsReadOnly:",
+          "arity": 1
+        },
+        {
+          "selector": "method",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory",
+          "arity": 0
+        },
+        {
+          "selector": "methodCategory:",
+          "arity": 1
+        },
+        {
+          "selector": "methodClass",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass:",
+          "arity": 1
+        },
+        {
+          "selector": "methodFormattedSourceString",
+          "arity": 0
+        },
+        {
+          "selector": "methodParseNode",
+          "arity": 0
+        },
+        {
+          "selector": "methodRecompilationSourceString",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceCode",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceFile",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourcePos",
+          "arity": 0
+        },
+        {
+          "selector": "methodSourceString",
+          "arity": 0
+        },
+        {
+          "selector": "noteOldSyntax",
+          "arity": 0
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "numTemps",
+          "arity": 0
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "primitive",
+          "arity": 0
+        },
+        {
+          "selector": "primitiveAttribute",
+          "arity": 0
+        },
+        {
+          "selector": "printHeaderOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "reads:",
+          "arity": 1
+        },
+        {
+          "selector": "recompile",
+          "arity": 0
+        },
+        {
+          "selector": "recompileNotifying:",
+          "arity": 1
+        },
+        {
+          "selector": "rewriteAsAsyncCCall:args:",
+          "arity": 2
+        },
+        {
+          "selector": "rewriteAsCCall:for:",
+          "arity": 2
+        },
+        {
+          "selector": "rewriteAsCCall:returning:args:",
+          "arity": 3
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "sendsToSuper",
+          "arity": 0
+        },
+        {
+          "selector": "sourceCodeLinesDelta",
+          "arity": 0
+        },
+        {
+          "selector": "stackDepth",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "stripSourceCode",
+          "arity": 0
+        },
+        {
+          "selector": "valueWithReceiver:withArguments:",
+          "arity": 2
+        },
+        {
+          "selector": "withAllBlocksDo:",
+          "arity": 1
+        },
+        {
+          "selector": "withNewMethodClass:",
+          "arity": 1
+        },
+        {
+          "selector": "withNewMethodClass:selector:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "asyncCCall:numArgs:attributes:",
+          "arity": 3
+        },
+        {
+          "selector": "cCall:numArgs:attributes:",
+          "arity": 3
+        },
+        {
+          "selector": "literals:numArgs:numTemps:attributes:bytecodes:depth:",
+          "arity": 6
+        },
+        {
+          "selector": "numArgs:",
+          "arity": 1
+        },
+        {
+          "selector": "stripSourceCode",
+          "arity": 0
+        }
+      ]
+    },
+    "ConcatenatedStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "addStream:",
+          "arity": 1
+        },
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "stream",
+          "arity": 0
+        },
+        {
+          "selector": "streams:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "ContextPart": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "backtrace",
+          "arity": 0
+        },
+        {
+          "selector": "backtraceOn:",
+          "arity": 1
+        },
+        {
+          "selector": "checkSecurityFor:",
+          "arity": 1
+        },
+        {
+          "selector": "client",
+          "arity": 0
+        },
+        {
+          "selector": "continue:",
+          "arity": 1
+        },
+        {
+          "selector": "copyStack",
+          "arity": 0
+        },
+        {
+          "selector": "currentFileName",
+          "arity": 0
+        },
+        {
+          "selector": "currentLine",
+          "arity": 0
+        },
+        {
+          "selector": "currentLineInFile",
+          "arity": 0
+        },
+        {
+          "selector": "debugger",
+          "arity": 0
+        },
+        {
+          "selector": "debuggerClass",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "doSecurityCheckForName:actions:target:",
+          "arity": 3
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "home",
+          "arity": 0
+        },
+        {
+          "selector": "initialIP",
+          "arity": 0
+        },
+        {
+          "selector": "ip",
+          "arity": 0
+        },
+        {
+          "selector": "ip:",
+          "arity": 1
+        },
+        {
+          "selector": "isBlock",
+          "arity": 0
+        },
+        {
+          "selector": "isDisabled",
+          "arity": 0
+        },
+        {
+          "selector": "isEnvironment",
+          "arity": 0
+        },
+        {
+          "selector": "isInternalExceptionHandlingContext",
+          "arity": 0
+        },
+        {
+          "selector": "isJIT",
+          "arity": 0
+        },
+        {
+          "selector": "isProcess",
+          "arity": 0
+        },
+        {
+          "selector": "isUnwind",
+          "arity": 0
+        },
+        {
+          "selector": "method",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass",
+          "arity": 0
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "numTemps",
+          "arity": 0
+        },
+        {
+          "selector": "parentContext",
+          "arity": 0
+        },
+        {
+          "selector": "parentContext:",
+          "arity": 1
+        },
+        {
+          "selector": "push:",
+          "arity": 1
+        },
+        {
+          "selector": "receiver",
+          "arity": 0
+        },
+        {
+          "selector": "scanBacktraceFor:do:",
+          "arity": 2
+        },
+        {
+          "selector": "scanBacktraceForAttribute:do:",
+          "arity": 2
+        },
+        {
+          "selector": "securityCheckForName:",
+          "arity": 1
+        },
+        {
+          "selector": "securityCheckForName:action:",
+          "arity": 2
+        },
+        {
+          "selector": "securityCheckForName:actions:target:",
+          "arity": 3
+        },
+        {
+          "selector": "securityCheckForName:target:",
+          "arity": 2
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "sp",
+          "arity": 0
+        },
+        {
+          "selector": "sp:",
+          "arity": 1
+        },
+        {
+          "selector": "validSize",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "backtrace",
+          "arity": 0
+        },
+        {
+          "selector": "backtraceOn:",
+          "arity": 1
+        },
+        {
+          "selector": "checkPresenceOfJIT",
+          "arity": 0
+        },
+        {
+          "selector": "spIndex",
+          "arity": 0
+        },
+        {
+          "selector": "thisContext",
+          "arity": 0
+        }
+      ]
+    },
+    "Continuation": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "callCC",
+          "arity": 0
+        },
+        {
+          "selector": "oneShotValue",
+          "arity": 0
+        },
+        {
+          "selector": "oneShotValue:",
+          "arity": 1
+        },
+        {
+          "selector": "resume:nextContinuation:",
+          "arity": 2
+        },
+        {
+          "selector": "stack",
+          "arity": 0
+        },
+        {
+          "selector": "stack:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        },
+        {
+          "selector": "valueWithArguments:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "current",
+          "arity": 0
+        },
+        {
+          "selector": "currentDo:",
+          "arity": 1
+        },
+        {
+          "selector": "escapeDo:",
+          "arity": 1
+        }
+      ]
+    },
+    "DLD": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "addLibrary:",
+          "arity": 1
+        },
+        {
+          "selector": "addLibraryHandle:",
+          "arity": 1
+        },
+        {
+          "selector": "addModule:",
+          "arity": 1
+        },
+        {
+          "selector": "defineCFunc:as:",
+          "arity": 2
+        },
+        {
+          "selector": "defineExternFunc:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "library:getFunc:",
+          "arity": 2
+        },
+        {
+          "selector": "libraryList",
+          "arity": 0
+        },
+        {
+          "selector": "linkFile:",
+          "arity": 1
+        },
+        {
+          "selector": "moduleList",
+          "arity": 0
+        },
+        {
+          "selector": "primDefineExternFunc:",
+          "arity": 1
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        }
+      ]
+    },
+    "Date": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "addDays:",
+          "arity": 1
+        },
+        {
+          "selector": "asSeconds",
+          "arity": 0
+        },
+        {
+          "selector": "day",
+          "arity": 0
+        },
+        {
+          "selector": "dayName",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfMonth",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfWeek",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfWeekAbbreviation",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfWeekName",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfYear",
+          "arity": 0
+        },
+        {
+          "selector": "days",
+          "arity": 0
+        },
+        {
+          "selector": "daysFromBaseDay",
+          "arity": 0
+        },
+        {
+          "selector": "daysInMonth",
+          "arity": 0
+        },
+        {
+          "selector": "daysInYear",
+          "arity": 0
+        },
+        {
+          "selector": "daysLeftInMonth",
+          "arity": 0
+        },
+        {
+          "selector": "daysLeftInYear",
+          "arity": 0
+        },
+        {
+          "selector": "firstDayOfMonth",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "isLeapYear",
+          "arity": 0
+        },
+        {
+          "selector": "lastDayOfMonth",
+          "arity": 0
+        },
+        {
+          "selector": "month",
+          "arity": 0
+        },
+        {
+          "selector": "monthAbbreviation",
+          "arity": 0
+        },
+        {
+          "selector": "monthIndex",
+          "arity": 0
+        },
+        {
+          "selector": "monthName",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "setDay:monthIndex:year:",
+          "arity": 3
+        },
+        {
+          "selector": "setDays:",
+          "arity": 1
+        },
+        {
+          "selector": "shortMonthName",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "subtractDate:",
+          "arity": 1
+        },
+        {
+          "selector": "subtractDays:",
+          "arity": 1
+        },
+        {
+          "selector": "year",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "abbreviationOfDay:",
+          "arity": 1
+        },
+        {
+          "selector": "dateAndTimeNow",
+          "arity": 0
+        },
+        {
+          "selector": "dayOfWeek:",
+          "arity": 1
+        },
+        {
+          "selector": "daysInMonth:forYear:",
+          "arity": 2
+        },
+        {
+          "selector": "daysInMonthIndex:forYear:",
+          "arity": 2
+        },
+        {
+          "selector": "daysInYear:",
+          "arity": 1
+        },
+        {
+          "selector": "daysUntilMonth:year:",
+          "arity": 2
+        },
+        {
+          "selector": "fromDays:",
+          "arity": 1
+        },
+        {
+          "selector": "fromJulian:",
+          "arity": 1
+        },
+        {
+          "selector": "fromSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOfMonth:",
+          "arity": 1
+        },
+        {
+          "selector": "initDayNameDict",
+          "arity": 0
+        },
+        {
+          "selector": "initMonthNameDict",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "nameOfDay:",
+          "arity": 1
+        },
+        {
+          "selector": "nameOfMonth:",
+          "arity": 1
+        },
+        {
+          "selector": "newDay:month:year:",
+          "arity": 3
+        },
+        {
+          "selector": "newDay:monthIndex:year:",
+          "arity": 3
+        },
+        {
+          "selector": "newDay:year:",
+          "arity": 2
+        },
+        {
+          "selector": "readFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "shortNameOfMonth:",
+          "arity": 1
+        },
+        {
+          "selector": "today",
+          "arity": 0
+        },
+        {
+          "selector": "utcDateAndTimeNow",
+          "arity": 0
+        },
+        {
+          "selector": "utcToday",
+          "arity": 0
+        },
+        {
+          "selector": "year:day:hour:minute:second:",
+          "arity": 5
+        },
+        {
+          "selector": "year:month:day:hour:minute:second:",
+          "arity": 6
+        },
+        {
+          "selector": "yearAsDays:",
+          "arity": 1
+        }
+      ]
+    },
+    "DateTime": {
+      "superclass": "Date",
+      "instanceSelectors": [
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asDate",
+          "arity": 0
+        },
+        {
+          "selector": "asLocal",
+          "arity": 0
+        },
+        {
+          "selector": "asSeconds",
+          "arity": 0
+        },
+        {
+          "selector": "asTime",
+          "arity": 0
+        },
+        {
+          "selector": "asUTC",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "dayOfWeek",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hour",
+          "arity": 0
+        },
+        {
+          "selector": "hour12",
+          "arity": 0
+        },
+        {
+          "selector": "hour24",
+          "arity": 0
+        },
+        {
+          "selector": "meridianAbbreviation",
+          "arity": 0
+        },
+        {
+          "selector": "minute",
+          "arity": 0
+        },
+        {
+          "selector": "offset",
+          "arity": 0
+        },
+        {
+          "selector": "offset:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "second",
+          "arity": 0
+        },
+        {
+          "selector": "seconds",
+          "arity": 0
+        },
+        {
+          "selector": "setDay:monthIndex:year:",
+          "arity": 3
+        },
+        {
+          "selector": "setDays:",
+          "arity": 1
+        },
+        {
+          "selector": "setOffset:",
+          "arity": 1
+        },
+        {
+          "selector": "setSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "timeZoneAbbreviation",
+          "arity": 0
+        },
+        {
+          "selector": "timeZoneName",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "clockPrecision",
+          "arity": 0
+        },
+        {
+          "selector": "date:time:",
+          "arity": 2
+        },
+        {
+          "selector": "date:time:offset:",
+          "arity": 3
+        },
+        {
+          "selector": "fromDays:seconds:",
+          "arity": 2
+        },
+        {
+          "selector": "fromDays:seconds:offset:",
+          "arity": 3
+        },
+        {
+          "selector": "fromSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "fromSeconds:offset:",
+          "arity": 2
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "now",
+          "arity": 0
+        },
+        {
+          "selector": "readFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "today",
+          "arity": 0
+        },
+        {
+          "selector": "year:day:hour:minute:second:",
+          "arity": 5
+        },
+        {
+          "selector": "year:day:hour:minute:second:offset:",
+          "arity": 6
+        },
+        {
+          "selector": "year:month:day:hour:minute:second:",
+          "arity": 6
+        },
+        {
+          "selector": "year:month:day:hour:minute:second:offset:",
+          "arity": 7
+        }
+      ]
+    },
+    "DeferredVariableBinding": {
+      "superclass": "LookupKey",
+      "instanceSelectors": [
+        {
+          "selector": "class:",
+          "arity": 1
+        },
+        {
+          "selector": "defaultDictionary:",
+          "arity": 1
+        },
+        {
+          "selector": "path",
+          "arity": 0
+        },
+        {
+          "selector": "path:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "resolveBinding",
+          "arity": 0
+        },
+        {
+          "selector": "resolvePathFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "key:class:defaultDictionary:",
+          "arity": 3
+        },
+        {
+          "selector": "path:class:defaultDictionary:",
+          "arity": 3
+        }
+      ]
+    },
+    "Delay": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "basicDelayDuration",
+          "arity": 0
+        },
+        {
+          "selector": "delayDuration",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "initForNanoseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "initUntilNanoseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isActive",
+          "arity": 0
+        },
+        {
+          "selector": "notifyChange",
+          "arity": 0
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "reset",
+          "arity": 0
+        },
+        {
+          "selector": "resumptionTime",
+          "arity": 0
+        },
+        {
+          "selector": "signal",
+          "arity": 0
+        },
+        {
+          "selector": "start",
+          "arity": 0
+        },
+        {
+          "selector": "timedWaitOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value:onTimeoutDo:",
+          "arity": 2
+        },
+        {
+          "selector": "wait",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "activeDelay",
+          "arity": 0
+        },
+        {
+          "selector": "forMilliseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "forNanoseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "forSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "handleDelayRequestor",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "runDelayProcess",
+          "arity": 0
+        },
+        {
+          "selector": "scheduleDelay:",
+          "arity": 1
+        },
+        {
+          "selector": "startDelayLoop",
+          "arity": 0
+        },
+        {
+          "selector": "unscheduleDelay:",
+          "arity": 1
+        },
+        {
+          "selector": "untilMilliseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "untilNanoseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        }
+      ]
+    },
+    "DelayedAdaptor": {
+      "superclass": "PluggableAdaptor",
+      "instanceSelectors": [
+        {
+          "selector": "getBlock:putBlock:",
+          "arity": 2
+        },
+        {
+          "selector": "trigger",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "Dictionary": {
+      "superclass": "HashedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "addAll:",
+          "arity": 1
+        },
+        {
+          "selector": "allSuperspaces",
+          "arity": 0
+        },
+        {
+          "selector": "allSuperspacesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "associationAt:",
+          "arity": 1
+        },
+        {
+          "selector": "associationAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "associations",
+          "arity": 0
+        },
+        {
+          "selector": "associationsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifAbsentPut:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifPresent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atAll:",
+          "arity": 1
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "copyAllFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "definedKeys",
+          "arity": 0
+        },
+        {
+          "selector": "definesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "findElementIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findKeyIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "hereAssociationAt:",
+          "arity": 1
+        },
+        {
+          "selector": "hereAssociationAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "hereAt:",
+          "arity": 1
+        },
+        {
+          "selector": "hereAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "includesAssociation:",
+          "arity": 1
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "inheritsFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "keyAtValue:",
+          "arity": 1
+        },
+        {
+          "selector": "keyAtValue:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "keysAndValuesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        },
+        {
+          "selector": "keysDo:",
+          "arity": 1
+        },
+        {
+          "selector": "occurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAllKeys:",
+          "arity": 1
+        },
+        {
+          "selector": "removeAllKeys:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAllKeysSuchThat:",
+          "arity": 1
+        },
+        {
+          "selector": "removeKey:",
+          "arity": 1
+        },
+        {
+          "selector": "removeKey:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "scopeDictionary",
+          "arity": 0
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "superspace",
+          "arity": 0
+        },
+        {
+          "selector": "values",
+          "arity": 0
+        },
+        {
+          "selector": "whileGrowingAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "withAllSuperspaces",
+          "arity": 0
+        },
+        {
+          "selector": "withAllSuperspacesDo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "from:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "DirectedMessage": {
+      "superclass": "Message",
+      "instanceSelectors": [
+        {
+          "selector": "fork",
+          "arity": 0
+        },
+        {
+          "selector": "forkAt:",
+          "arity": 1
+        },
+        {
+          "selector": "newProcess",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "receiver",
+          "arity": 0
+        },
+        {
+          "selector": "receiver:",
+          "arity": 1
+        },
+        {
+          "selector": "reconstructOriginalObject",
+          "arity": 0
+        },
+        {
+          "selector": "send",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        },
+        {
+          "selector": "value:value:",
+          "arity": 2
+        },
+        {
+          "selector": "valueWithArguments:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "receiver:selector:",
+          "arity": 2
+        },
+        {
+          "selector": "receiver:selector:argument:",
+          "arity": 3
+        },
+        {
+          "selector": "receiver:selector:arguments:",
+          "arity": 3
+        },
+        {
+          "selector": "selector:arguments:",
+          "arity": 2
+        },
+        {
+          "selector": "selector:arguments:receiver:",
+          "arity": 3
+        }
+      ]
+    },
+    "Directory": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "allFilesMatching:do:",
+          "arity": 2
+        },
+        {
+          "selector": "append:to:",
+          "arity": 2
+        },
+        {
+          "selector": "create:",
+          "arity": 1
+        },
+        {
+          "selector": "createTemporary:",
+          "arity": 1
+        },
+        {
+          "selector": "execPrefix",
+          "arity": 0
+        },
+        {
+          "selector": "home",
+          "arity": 0
+        },
+        {
+          "selector": "image",
+          "arity": 0
+        },
+        {
+          "selector": "kernel",
+          "arity": 0
+        },
+        {
+          "selector": "libexec",
+          "arity": 0
+        },
+        {
+          "selector": "localKernel",
+          "arity": 0
+        },
+        {
+          "selector": "module",
+          "arity": 0
+        },
+        {
+          "selector": "pathSeparator",
+          "arity": 0
+        },
+        {
+          "selector": "pathSeparatorString",
+          "arity": 0
+        },
+        {
+          "selector": "prefix",
+          "arity": 0
+        },
+        {
+          "selector": "primCreateTemporary:",
+          "arity": 1
+        },
+        {
+          "selector": "primWorking:",
+          "arity": 1
+        },
+        {
+          "selector": "systemKernel",
+          "arity": 0
+        },
+        {
+          "selector": "temporary",
+          "arity": 0
+        },
+        {
+          "selector": "userBase",
+          "arity": 0
+        },
+        {
+          "selector": "working",
+          "arity": 0
+        },
+        {
+          "selector": "working:",
+          "arity": 1
+        },
+        {
+          "selector": "workingName",
+          "arity": 0
+        }
+      ]
+    },
+    "DisabledPackage": {
+      "superclass": "Package",
+      "instanceSelectors": [
+        {
+          "selector": "isDisabled",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:indent:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": []
+    },
+    "DumperProxy": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "dumpTo:",
+          "arity": 1
+        },
+        {
+          "selector": "object",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "acceptUsageForClass:",
+          "arity": 1
+        },
+        {
+          "selector": "loadFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "Duration": {
+      "superclass": "Time",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "abs",
+          "arity": 0
+        },
+        {
+          "selector": "days",
+          "arity": 0
+        },
+        {
+          "selector": "isZero",
+          "arity": 0
+        },
+        {
+          "selector": "negated",
+          "arity": 0
+        },
+        {
+          "selector": "negative",
+          "arity": 0
+        },
+        {
+          "selector": "positive",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "setSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "wait",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "days:",
+          "arity": 1
+        },
+        {
+          "selector": "days:hours:minutes:seconds:",
+          "arity": 4
+        },
+        {
+          "selector": "fromDays:seconds:offset:",
+          "arity": 3
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "milliseconds:",
+          "arity": 1
+        },
+        {
+          "selector": "readFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "weeks:",
+          "arity": 1
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        }
+      ]
+    },
+    "DynamicVariable": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "processVariable",
+          "arity": 0
+        },
+        {
+          "selector": "use:during:",
+          "arity": 2
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "valueIfAbsent:",
+          "arity": 1
+        }
+      ]
+    },
+    "EmptyCollection": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "EndOfStream": {
+      "superclass": "Notification",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "stream",
+          "arity": 0
+        },
+        {
+          "selector": "stream:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:",
+          "arity": 1
+        }
+      ]
+    },
+    "Error": {
+      "superclass": "Exception",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Exception": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "activateHandler:",
+          "arity": 1
+        },
+        {
+          "selector": "basicMessageText",
+          "arity": 0
+        },
+        {
+          "selector": "context",
+          "arity": 0
+        },
+        {
+          "selector": "creator",
+          "arity": 0
+        },
+        {
+          "selector": "defaultAction",
+          "arity": 0
+        },
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "initialize:",
+          "arity": 1
+        },
+        {
+          "selector": "instantiateDefaultHandler",
+          "arity": 0
+        },
+        {
+          "selector": "instantiateNextHandlerFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "isNested",
+          "arity": 0
+        },
+        {
+          "selector": "isNested:",
+          "arity": 1
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        },
+        {
+          "selector": "messageText",
+          "arity": 0
+        },
+        {
+          "selector": "messageText:",
+          "arity": 1
+        },
+        {
+          "selector": "noTag",
+          "arity": 0
+        },
+        {
+          "selector": "onDoBlock:handlerBlock:onDoContext:previousState:",
+          "arity": 4
+        },
+        {
+          "selector": "outer",
+          "arity": 0
+        },
+        {
+          "selector": "pass",
+          "arity": 0
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "resetHandler",
+          "arity": 0
+        },
+        {
+          "selector": "resignalAs:",
+          "arity": 1
+        },
+        {
+          "selector": "resignalAsUnhandled:",
+          "arity": 1
+        },
+        {
+          "selector": "resume",
+          "arity": 0
+        },
+        {
+          "selector": "resume:",
+          "arity": 1
+        },
+        {
+          "selector": "retry",
+          "arity": 0
+        },
+        {
+          "selector": "retryUsing:",
+          "arity": 1
+        },
+        {
+          "selector": "return",
+          "arity": 0
+        },
+        {
+          "selector": "return:",
+          "arity": 1
+        },
+        {
+          "selector": "signal",
+          "arity": 0
+        },
+        {
+          "selector": "signal:",
+          "arity": 1
+        },
+        {
+          "selector": "signalingContext",
+          "arity": 0
+        },
+        {
+          "selector": "tag",
+          "arity": 0
+        },
+        {
+          "selector": "tag:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "allExceptionsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "goodness:",
+          "arity": 1
+        },
+        {
+          "selector": "handles:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "resetAllHandlers",
+          "arity": 0
+        },
+        {
+          "selector": "signal",
+          "arity": 0
+        },
+        {
+          "selector": "signal:",
+          "arity": 1
+        }
+      ]
+    },
+    "ExceptionSet": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "allExceptionsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "collection:",
+          "arity": 1
+        },
+        {
+          "selector": "goodness:",
+          "arity": 1
+        },
+        {
+          "selector": "handles:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "FailedMatchRegexResults": {
+      "superclass": "RegexResults",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "from",
+          "arity": 0
+        },
+        {
+          "selector": "fromAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ifMatched:ifNotMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotMatched:ifMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "intervalAt:",
+          "arity": 1
+        },
+        {
+          "selector": "match",
+          "arity": 0
+        },
+        {
+          "selector": "matchInterval",
+          "arity": 0
+        },
+        {
+          "selector": "matched",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "subject",
+          "arity": 0
+        },
+        {
+          "selector": "to",
+          "arity": 0
+        },
+        {
+          "selector": "toAt:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "uniqueInstance",
+          "arity": 0
+        }
+      ]
+    },
+    "False": {
+      "superclass": "Boolean",
+      "instanceSelectors": [
+        {
+          "selector": "&",
+          "arity": 1
+        },
+        {
+          "selector": "and:",
+          "arity": 1
+        },
+        {
+          "selector": "asCBooleanValue",
+          "arity": 0
+        },
+        {
+          "selector": "eqv:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "ifTrue:",
+          "arity": 1
+        },
+        {
+          "selector": "ifTrue:ifFalse:",
+          "arity": 2
+        },
+        {
+          "selector": "not",
+          "arity": 0
+        },
+        {
+          "selector": "or:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "xor:",
+          "arity": 1
+        },
+        {
+          "selector": "|",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "File": {
+      "superclass": "FilePath",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "closeDir:",
+          "arity": 1
+        },
+        {
+          "selector": "createDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "creationTime",
+          "arity": 0
+        },
+        {
+          "selector": "exists",
+          "arity": 0
+        },
+        {
+          "selector": "extractDirentName:",
+          "arity": 1
+        },
+        {
+          "selector": "full",
+          "arity": 0
+        },
+        {
+          "selector": "getDateAndTime:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "init:",
+          "arity": 1
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isAccessible",
+          "arity": 0
+        },
+        {
+          "selector": "isDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "isExecutable",
+          "arity": 0
+        },
+        {
+          "selector": "isFileSystemPath",
+          "arity": 0
+        },
+        {
+          "selector": "isReadable",
+          "arity": 0
+        },
+        {
+          "selector": "isSocket",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbolicLink",
+          "arity": 0
+        },
+        {
+          "selector": "isWriteable",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime:lastModifyTime:",
+          "arity": 2
+        },
+        {
+          "selector": "lastChangeTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastModifyTime",
+          "arity": 0
+        },
+        {
+          "selector": "lstatOn:into:",
+          "arity": 2
+        },
+        {
+          "selector": "mode",
+          "arity": 0
+        },
+        {
+          "selector": "mode:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "openDir:",
+          "arity": 1
+        },
+        {
+          "selector": "owner:group:",
+          "arity": 2
+        },
+        {
+          "selector": "pathFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "pathTo:",
+          "arity": 1
+        },
+        {
+          "selector": "primChmod:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "primCreateDir:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "primIsExecutable:",
+          "arity": 1
+        },
+        {
+          "selector": "primIsReadable:",
+          "arity": 1
+        },
+        {
+          "selector": "primIsWriteable:",
+          "arity": 1
+        },
+        {
+          "selector": "primRemoveDir:",
+          "arity": 1
+        },
+        {
+          "selector": "primRename:to:",
+          "arity": 2
+        },
+        {
+          "selector": "primSymlink:as:",
+          "arity": 2
+        },
+        {
+          "selector": "primUnlink:",
+          "arity": 1
+        },
+        {
+          "selector": "readDir:",
+          "arity": 1
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "remove",
+          "arity": 0
+        },
+        {
+          "selector": "renameTo:",
+          "arity": 1
+        },
+        {
+          "selector": "rewindDir:",
+          "arity": 1
+        },
+        {
+          "selector": "secondsFromDateTime:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "stat",
+          "arity": 0
+        },
+        {
+          "selector": "statOn:into:",
+          "arity": 2
+        },
+        {
+          "selector": "symlinkAs:",
+          "arity": 1
+        },
+        {
+          "selector": "symlinkFrom:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "checkError",
+          "arity": 0
+        },
+        {
+          "selector": "checkError:",
+          "arity": 1
+        },
+        {
+          "selector": "errno",
+          "arity": 0
+        },
+        {
+          "selector": "executable",
+          "arity": 0
+        },
+        {
+          "selector": "exists:",
+          "arity": 1
+        },
+        {
+          "selector": "image",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isAccessible:",
+          "arity": 1
+        },
+        {
+          "selector": "isExecutable:",
+          "arity": 1
+        },
+        {
+          "selector": "isReadable:",
+          "arity": 1
+        },
+        {
+          "selector": "isWriteable:",
+          "arity": 1
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "path:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "rename:to:",
+          "arity": 2
+        },
+        {
+          "selector": "setOwnerFor:owner:group:",
+          "arity": 3
+        },
+        {
+          "selector": "setTimeFor:atime:mtime:",
+          "arity": 3
+        },
+        {
+          "selector": "stringError:",
+          "arity": 1
+        },
+        {
+          "selector": "symlink:as:",
+          "arity": 2
+        },
+        {
+          "selector": "symlink:from:",
+          "arity": 2
+        },
+        {
+          "selector": "touch:",
+          "arity": 1
+        }
+      ]
+    },
+    "FileDescriptor": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "addToBeFinalized",
+          "arity": 0
+        },
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "canRead",
+          "arity": 0
+        },
+        {
+          "selector": "canWrite",
+          "arity": 0
+        },
+        {
+          "selector": "checkError",
+          "arity": 0
+        },
+        {
+          "selector": "checkIfPipe",
+          "arity": 0
+        },
+        {
+          "selector": "close",
+          "arity": 0
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "ensureReadable",
+          "arity": 0
+        },
+        {
+          "selector": "ensureWriteable",
+          "arity": 0
+        },
+        {
+          "selector": "exceptionalCondition",
+          "arity": 0
+        },
+        {
+          "selector": "fd",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "fileIn",
+          "arity": 0
+        },
+        {
+          "selector": "fileOp:",
+          "arity": 1
+        },
+        {
+          "selector": "fileOp:ifFail:",
+          "arity": 2
+        },
+        {
+          "selector": "fileOp:with:",
+          "arity": 2
+        },
+        {
+          "selector": "fileOp:with:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "fileOp:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "fileOp:with:with:ifFail:",
+          "arity": 4
+        },
+        {
+          "selector": "fileOp:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "fileOp:with:with:with:ifFail:",
+          "arity": 5
+        },
+        {
+          "selector": "fileOp:with:with:with:with:",
+          "arity": 5
+        },
+        {
+          "selector": "fileOp:with:with:with:with:ifFail:",
+          "arity": 6
+        },
+        {
+          "selector": "finalize",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "invalidate",
+          "arity": 0
+        },
+        {
+          "selector": "isBinary",
+          "arity": 0
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "isExternalStream",
+          "arity": 0
+        },
+        {
+          "selector": "isOpen",
+          "arity": 0
+        },
+        {
+          "selector": "isPeerAlive",
+          "arity": 0
+        },
+        {
+          "selector": "isPipe",
+          "arity": 0
+        },
+        {
+          "selector": "isPositionable",
+          "arity": 0
+        },
+        {
+          "selector": "isText",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "next:putAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextAvailable:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextByte",
+          "arity": 0
+        },
+        {
+          "selector": "nextByteArray:",
+          "arity": 1
+        },
+        {
+          "selector": "nextBytes:signed:",
+          "arity": 2
+        },
+        {
+          "selector": "nextDouble",
+          "arity": 0
+        },
+        {
+          "selector": "nextFloat",
+          "arity": 0
+        },
+        {
+          "selector": "nextLong",
+          "arity": 0
+        },
+        {
+          "selector": "nextLongLong",
+          "arity": 0
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutByte:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutByteArray:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutBytes:of:",
+          "arity": 2
+        },
+        {
+          "selector": "nextPutDouble:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutFloat:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutInt64:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutLong:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutShort:",
+          "arity": 1
+        },
+        {
+          "selector": "nextShort",
+          "arity": 0
+        },
+        {
+          "selector": "nextSignedByte",
+          "arity": 0
+        },
+        {
+          "selector": "nextUint64",
+          "arity": 0
+        },
+        {
+          "selector": "nextUlong",
+          "arity": 0
+        },
+        {
+          "selector": "nextUshort",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "removeToBeFinalized",
+          "arity": 0
+        },
+        {
+          "selector": "reset",
+          "arity": 0
+        },
+        {
+          "selector": "reverseContents",
+          "arity": 0
+        },
+        {
+          "selector": "setFD:",
+          "arity": 1
+        },
+        {
+          "selector": "setFile:",
+          "arity": 1
+        },
+        {
+          "selector": "setToEnd",
+          "arity": 0
+        },
+        {
+          "selector": "shutdown",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "skip:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "truncate",
+          "arity": 0
+        },
+        {
+          "selector": "waitForException",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "append",
+          "arity": 0
+        },
+        {
+          "selector": "create",
+          "arity": 0
+        },
+        {
+          "selector": "fopen:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "fopen:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "open:",
+          "arity": 1
+        },
+        {
+          "selector": "open:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "openTemporaryFile:",
+          "arity": 1
+        },
+        {
+          "selector": "popen:dir:",
+          "arity": 2
+        },
+        {
+          "selector": "popen:dir:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "read",
+          "arity": 0
+        },
+        {
+          "selector": "readWrite",
+          "arity": 0
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        },
+        {
+          "selector": "write",
+          "arity": 0
+        }
+      ]
+    },
+    "FileError": {
+      "superclass": "PrimitiveFailed",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "FilePath": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "all",
+          "arity": 0
+        },
+        {
+          "selector": "allFilesMatching:do:",
+          "arity": 2
+        },
+        {
+          "selector": "asFile",
+          "arity": 0
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "autoload",
+          "arity": 0
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "createDirectories",
+          "arity": 0
+        },
+        {
+          "selector": "createDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "creationTime",
+          "arity": 0
+        },
+        {
+          "selector": "directories",
+          "arity": 0
+        },
+        {
+          "selector": "directory",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "entries",
+          "arity": 0
+        },
+        {
+          "selector": "entryNames",
+          "arity": 0
+        },
+        {
+          "selector": "exists",
+          "arity": 0
+        },
+        {
+          "selector": "extension",
+          "arity": 0
+        },
+        {
+          "selector": "fileIn",
+          "arity": 0
+        },
+        {
+          "selector": "files",
+          "arity": 0
+        },
+        {
+          "selector": "filesMatching:",
+          "arity": 1
+        },
+        {
+          "selector": "filesMatching:do:",
+          "arity": 2
+        },
+        {
+          "selector": "full",
+          "arity": 0
+        },
+        {
+          "selector": "fullName",
+          "arity": 0
+        },
+        {
+          "selector": "group:",
+          "arity": 1
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isAccessible",
+          "arity": 0
+        },
+        {
+          "selector": "isDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "isExecutable",
+          "arity": 0
+        },
+        {
+          "selector": "isFile",
+          "arity": 0
+        },
+        {
+          "selector": "isFileSystemPath",
+          "arity": 0
+        },
+        {
+          "selector": "isReadable",
+          "arity": 0
+        },
+        {
+          "selector": "isRelative",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbolicLink",
+          "arity": 0
+        },
+        {
+          "selector": "isWriteable",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime:",
+          "arity": 1
+        },
+        {
+          "selector": "lastAccessTime:lastModifyTime:",
+          "arity": 2
+        },
+        {
+          "selector": "lastChangeTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastModifyTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastModifyTime:",
+          "arity": 1
+        },
+        {
+          "selector": "mode",
+          "arity": 0
+        },
+        {
+          "selector": "mode:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "nameAt:",
+          "arity": 1
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "namesMatching:do:",
+          "arity": 2
+        },
+        {
+          "selector": "open:",
+          "arity": 1
+        },
+        {
+          "selector": "open:ifFail:",
+          "arity": 2
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "openDescriptor:",
+          "arity": 1
+        },
+        {
+          "selector": "openDescriptor:ifFail:",
+          "arity": 2
+        },
+        {
+          "selector": "owner:",
+          "arity": 1
+        },
+        {
+          "selector": "owner:group:",
+          "arity": 2
+        },
+        {
+          "selector": "parent",
+          "arity": 0
+        },
+        {
+          "selector": "path",
+          "arity": 0
+        },
+        {
+          "selector": "pathFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "pathTo:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "remove",
+          "arity": 0
+        },
+        {
+          "selector": "renameTo:",
+          "arity": 1
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "stripExtension",
+          "arity": 0
+        },
+        {
+          "selector": "stripFileName",
+          "arity": 0
+        },
+        {
+          "selector": "stripPath",
+          "arity": 0
+        },
+        {
+          "selector": "symlinkAs:",
+          "arity": 1
+        },
+        {
+          "selector": "symlinkFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "touch",
+          "arity": 0
+        },
+        {
+          "selector": "withReadStreamDo:",
+          "arity": 1
+        },
+        {
+          "selector": "withShellEscapes",
+          "arity": 0
+        },
+        {
+          "selector": "withWriteStreamDo:",
+          "arity": 1
+        },
+        {
+          "selector": "writeStream",
+          "arity": 0
+        },
+        {
+          "selector": "zip",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "append:to:",
+          "arity": 2
+        },
+        {
+          "selector": "computePathFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "extensionFor:",
+          "arity": 1
+        },
+        {
+          "selector": "fullNameFor:",
+          "arity": 1
+        },
+        {
+          "selector": "isAbsolute:",
+          "arity": 1
+        },
+        {
+          "selector": "pathFor:",
+          "arity": 1
+        },
+        {
+          "selector": "pathFor:ifNone:",
+          "arity": 2
+        },
+        {
+          "selector": "pathFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "stripExtensionFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "stripFileNameFor:",
+          "arity": 1
+        },
+        {
+          "selector": "stripPathFrom:",
+          "arity": 1
+        }
+      ]
+    },
+    "FileSegment": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "fileName",
+          "arity": 0
+        },
+        {
+          "selector": "filePos",
+          "arity": 0
+        },
+        {
+          "selector": "getFile",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "printedFileName",
+          "arity": 0
+        },
+        {
+          "selector": "relocateFrom:map:",
+          "arity": 2
+        },
+        {
+          "selector": "setFile:start:size:",
+          "arity": 3
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "withFileDo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:startingAt:for:",
+          "arity": 3
+        },
+        {
+          "selector": "relocate",
+          "arity": 0
+        }
+      ]
+    },
+    "FileStream": {
+      "superclass": "FileDescriptor",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "bufferSize",
+          "arity": 0
+        },
+        {
+          "selector": "bufferSize:",
+          "arity": 1
+        },
+        {
+          "selector": "bufferStart",
+          "arity": 0
+        },
+        {
+          "selector": "clean",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "fill",
+          "arity": 0
+        },
+        {
+          "selector": "flush",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "newBuffer",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "next:bufferAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "next:putAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextAvailable:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextAvailable:putAllOn:",
+          "arity": 2
+        },
+        {
+          "selector": "nextLine",
+          "arity": 0
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "pendingWrite",
+          "arity": 0
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "resetBuffer",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "truncate",
+          "arity": 0
+        },
+        {
+          "selector": "upTo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fileIn:",
+          "arity": 1
+        },
+        {
+          "selector": "fileIn:ifMissing:",
+          "arity": 2
+        },
+        {
+          "selector": "fileIn:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "fileIn:line:from:at:",
+          "arity": 4
+        },
+        {
+          "selector": "generateMakefileOnto:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "record:",
+          "arity": 1
+        },
+        {
+          "selector": "recursiveGenerateOnto:with:",
+          "arity": 2
+        },
+        {
+          "selector": "require:",
+          "arity": 1
+        },
+        {
+          "selector": "stderr",
+          "arity": 0
+        },
+        {
+          "selector": "stdin",
+          "arity": 0
+        },
+        {
+          "selector": "stdout",
+          "arity": 0
+        },
+        {
+          "selector": "verbose:",
+          "arity": 1
+        }
+      ]
+    },
+    "FileWrapper": {
+      "superclass": "FilePath",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "creationTime",
+          "arity": 0
+        },
+        {
+          "selector": "exists",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "file:",
+          "arity": 1
+        },
+        {
+          "selector": "full",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "isAbsolute",
+          "arity": 0
+        },
+        {
+          "selector": "isAccessible",
+          "arity": 0
+        },
+        {
+          "selector": "isDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "isExecutable",
+          "arity": 0
+        },
+        {
+          "selector": "isReadable",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbolicLink",
+          "arity": 0
+        },
+        {
+          "selector": "isWriteable",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime:lastModifyTime:",
+          "arity": 2
+        },
+        {
+          "selector": "lastChangeTime",
+          "arity": 0
+        },
+        {
+          "selector": "lastModifyTime",
+          "arity": 0
+        },
+        {
+          "selector": "mode",
+          "arity": 0
+        },
+        {
+          "selector": "mode:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "owner:group:",
+          "arity": 2
+        },
+        {
+          "selector": "pathFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "pathTo:",
+          "arity": 1
+        },
+        {
+          "selector": "remove",
+          "arity": 0
+        },
+        {
+          "selector": "renameTo:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "symlinkAs:",
+          "arity": 1
+        },
+        {
+          "selector": "symlinkFrom:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        }
+      ]
+    },
+    "FilteringStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "initStream:block:result:",
+          "arity": 3
+        },
+        {
+          "selector": "lookahead",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:reject:",
+          "arity": 2
+        },
+        {
+          "selector": "on:select:",
+          "arity": 2
+        }
+      ]
+    },
+    "Float": {
+      "superclass": "Number",
+      "instanceSelectors": [
+        {
+          "selector": "arcCos",
+          "arity": 0
+        },
+        {
+          "selector": "arcSin",
+          "arity": 0
+        },
+        {
+          "selector": "arcTan",
+          "arity": 0
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asExactFraction",
+          "arity": 0
+        },
+        {
+          "selector": "asFloat",
+          "arity": 0
+        },
+        {
+          "selector": "asFraction",
+          "arity": 0
+        },
+        {
+          "selector": "ceiling",
+          "arity": 0
+        },
+        {
+          "selector": "ceilingLog:",
+          "arity": 1
+        },
+        {
+          "selector": "checkCoercion",
+          "arity": 0
+        },
+        {
+          "selector": "cos",
+          "arity": 0
+        },
+        {
+          "selector": "estimatedLog",
+          "arity": 0
+        },
+        {
+          "selector": "exp",
+          "arity": 0
+        },
+        {
+          "selector": "floor",
+          "arity": 0
+        },
+        {
+          "selector": "floorLog:",
+          "arity": 1
+        },
+        {
+          "selector": "half",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "integerPart",
+          "arity": 0
+        },
+        {
+          "selector": "isExact",
+          "arity": 0
+        },
+        {
+          "selector": "isFinite",
+          "arity": 0
+        },
+        {
+          "selector": "isFloat",
+          "arity": 0
+        },
+        {
+          "selector": "isInfinite",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "isNaN",
+          "arity": 0
+        },
+        {
+          "selector": "ln",
+          "arity": 0
+        },
+        {
+          "selector": "log",
+          "arity": 0
+        },
+        {
+          "selector": "log:",
+          "arity": 1
+        },
+        {
+          "selector": "max:",
+          "arity": 1
+        },
+        {
+          "selector": "min:",
+          "arity": 1
+        },
+        {
+          "selector": "negated",
+          "arity": 0
+        },
+        {
+          "selector": "negative",
+          "arity": 0
+        },
+        {
+          "selector": "positive",
+          "arity": 0
+        },
+        {
+          "selector": "predecessor",
+          "arity": 0
+        },
+        {
+          "selector": "primHash",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:special:",
+          "arity": 2
+        },
+        {
+          "selector": "raisedTo:",
+          "arity": 1
+        },
+        {
+          "selector": "raisedToInteger:",
+          "arity": 1
+        },
+        {
+          "selector": "rounded",
+          "arity": 0
+        },
+        {
+          "selector": "sign",
+          "arity": 0
+        },
+        {
+          "selector": "sin",
+          "arity": 0
+        },
+        {
+          "selector": "sqrt",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "strictlyPositive",
+          "arity": 0
+        },
+        {
+          "selector": "successor",
+          "arity": 0
+        },
+        {
+          "selector": "tan",
+          "arity": 0
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "withSignOf:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "denormalized",
+          "arity": 0
+        },
+        {
+          "selector": "e",
+          "arity": 0
+        },
+        {
+          "selector": "epsilon",
+          "arity": 0
+        },
+        {
+          "selector": "fmin",
+          "arity": 0
+        },
+        {
+          "selector": "fminDenormalized",
+          "arity": 0
+        },
+        {
+          "selector": "ln10",
+          "arity": 0
+        },
+        {
+          "selector": "log10Base2",
+          "arity": 0
+        },
+        {
+          "selector": "pi",
+          "arity": 0
+        },
+        {
+          "selector": "radix",
+          "arity": 0
+        },
+        {
+          "selector": "signByte",
+          "arity": 0
+        }
+      ]
+    },
+    "FloatD": {
+      "superclass": "Float",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "exponent",
+          "arity": 0
+        },
+        {
+          "selector": "exponentLetter",
+          "arity": 0
+        },
+        {
+          "selector": "fractionPart",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "half",
+          "arity": 0
+        },
+        {
+          "selector": "ten",
+          "arity": 0
+        },
+        {
+          "selector": "timesTwoPower:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "decimalDigits",
+          "arity": 0
+        },
+        {
+          "selector": "emax",
+          "arity": 0
+        },
+        {
+          "selector": "emin",
+          "arity": 0
+        },
+        {
+          "selector": "fmax",
+          "arity": 0
+        },
+        {
+          "selector": "fminNormalized",
+          "arity": 0
+        },
+        {
+          "selector": "fromBytes:",
+          "arity": 1
+        },
+        {
+          "selector": "infinity",
+          "arity": 0
+        },
+        {
+          "selector": "nan",
+          "arity": 0
+        },
+        {
+          "selector": "negativeInfinity",
+          "arity": 0
+        },
+        {
+          "selector": "precision",
+          "arity": 0
+        },
+        {
+          "selector": "signByte",
+          "arity": 0
+        }
+      ]
+    },
+    "FloatE": {
+      "superclass": "Float",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "exponent",
+          "arity": 0
+        },
+        {
+          "selector": "exponentLetter",
+          "arity": 0
+        },
+        {
+          "selector": "fractionPart",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "half",
+          "arity": 0
+        },
+        {
+          "selector": "ten",
+          "arity": 0
+        },
+        {
+          "selector": "timesTwoPower:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "decimalDigits",
+          "arity": 0
+        },
+        {
+          "selector": "e",
+          "arity": 0
+        },
+        {
+          "selector": "emax",
+          "arity": 0
+        },
+        {
+          "selector": "emin",
+          "arity": 0
+        },
+        {
+          "selector": "fmax",
+          "arity": 0
+        },
+        {
+          "selector": "fminNormalized",
+          "arity": 0
+        },
+        {
+          "selector": "fromBytes:",
+          "arity": 1
+        },
+        {
+          "selector": "infinity",
+          "arity": 0
+        },
+        {
+          "selector": "ln10",
+          "arity": 0
+        },
+        {
+          "selector": "log10Base2",
+          "arity": 0
+        },
+        {
+          "selector": "nan",
+          "arity": 0
+        },
+        {
+          "selector": "negativeInfinity",
+          "arity": 0
+        },
+        {
+          "selector": "pi",
+          "arity": 0
+        },
+        {
+          "selector": "precision",
+          "arity": 0
+        },
+        {
+          "selector": "signByte",
+          "arity": 0
+        }
+      ]
+    },
+    "FloatQ": {
+      "superclass": "Float",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "exponent",
+          "arity": 0
+        },
+        {
+          "selector": "exponentLetter",
+          "arity": 0
+        },
+        {
+          "selector": "fractionPart",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "half",
+          "arity": 0
+        },
+        {
+          "selector": "ten",
+          "arity": 0
+        },
+        {
+          "selector": "timesTwoPower:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "decimalDigits",
+          "arity": 0
+        },
+        {
+          "selector": "e",
+          "arity": 0
+        },
+        {
+          "selector": "emax",
+          "arity": 0
+        },
+        {
+          "selector": "emin",
+          "arity": 0
+        },
+        {
+          "selector": "fmax",
+          "arity": 0
+        },
+        {
+          "selector": "fminNormalized",
+          "arity": 0
+        },
+        {
+          "selector": "infinity",
+          "arity": 0
+        },
+        {
+          "selector": "ln10",
+          "arity": 0
+        },
+        {
+          "selector": "log10Base2",
+          "arity": 0
+        },
+        {
+          "selector": "nan",
+          "arity": 0
+        },
+        {
+          "selector": "negativeInfinity",
+          "arity": 0
+        },
+        {
+          "selector": "pi",
+          "arity": 0
+        },
+        {
+          "selector": "precision",
+          "arity": 0
+        },
+        {
+          "selector": "signByte",
+          "arity": 0
+        }
+      ]
+    },
+    "Fraction": {
+      "superclass": "Number",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asExactFraction",
+          "arity": 0
+        },
+        {
+          "selector": "asFloat:",
+          "arity": 1
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "asFraction",
+          "arity": 0
+        },
+        {
+          "selector": "ceiling",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "compare:",
+          "arity": 1
+        },
+        {
+          "selector": "denominator",
+          "arity": 0
+        },
+        {
+          "selector": "estimatedLog",
+          "arity": 0
+        },
+        {
+          "selector": "floor",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "integerPart",
+          "arity": 0
+        },
+        {
+          "selector": "isRational",
+          "arity": 0
+        },
+        {
+          "selector": "negated",
+          "arity": 0
+        },
+        {
+          "selector": "numerator",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "raisedToInteger:",
+          "arity": 1
+        },
+        {
+          "selector": "reciprocal",
+          "arity": 0
+        },
+        {
+          "selector": "reduce",
+          "arity": 0
+        },
+        {
+          "selector": "setNumerator:setDenominator:",
+          "arity": 2
+        },
+        {
+          "selector": "sqrt",
+          "arity": 0
+        },
+        {
+          "selector": "squared",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "numerator:denominator:",
+          "arity": 2
+        }
+      ]
+    },
+    "Generator": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "forkOn:",
+          "arity": 1
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "yield:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "inject:into:",
+          "arity": 2
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "on:do:",
+          "arity": 2
+        }
+      ]
+    },
+    "Getopt": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "actionBlock:",
+          "arity": 1
+        },
+        {
+          "selector": "addLongOption:",
+          "arity": 1
+        },
+        {
+          "selector": "atAllSynonyms:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atSynonym:put:",
+          "arity": 2
+        },
+        {
+          "selector": "checkSynonyms:",
+          "arity": 1
+        },
+        {
+          "selector": "colonsToKind:",
+          "arity": 1
+        },
+        {
+          "selector": "errorBlock:",
+          "arity": 1
+        },
+        {
+          "selector": "fullOptionName:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "optionKind:",
+          "arity": 1
+        },
+        {
+          "selector": "optionName:",
+          "arity": 1
+        },
+        {
+          "selector": "parse",
+          "arity": 0
+        },
+        {
+          "selector": "parse:",
+          "arity": 1
+        },
+        {
+          "selector": "parseLongOption:",
+          "arity": 1
+        },
+        {
+          "selector": "parseOneArgument",
+          "arity": 0
+        },
+        {
+          "selector": "parseOption:",
+          "arity": 1
+        },
+        {
+          "selector": "parseOption:kind:with:",
+          "arity": 3
+        },
+        {
+          "selector": "parsePattern:",
+          "arity": 1
+        },
+        {
+          "selector": "parseRemainingArguments",
+          "arity": 0
+        },
+        {
+          "selector": "parseShortOptions:",
+          "arity": 1
+        },
+        {
+          "selector": "rejectBadPrefixes",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "parse:with:do:",
+          "arity": 3
+        },
+        {
+          "selector": "parse:with:do:ifError:",
+          "arity": 4
+        }
+      ]
+    },
+    "Halt": {
+      "superclass": "Exception",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "HashedCollection": {
+      "superclass": "Collection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "addWhileGrowing:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "capacity",
+          "arity": 0
+        },
+        {
+          "selector": "copyAllFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "decrementTally",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "findElementIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndexOrNil:",
+          "arity": 1
+        },
+        {
+          "selector": "grow",
+          "arity": 0
+        },
+        {
+          "selector": "growBy:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "incrementTally",
+          "arity": 0
+        },
+        {
+          "selector": "initialize:",
+          "arity": 1
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "occurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "postLoad",
+          "arity": 0
+        },
+        {
+          "selector": "postStore",
+          "arity": 0
+        },
+        {
+          "selector": "primAt:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "primSize",
+          "arity": 0
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "rehashObjectsAfter:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "resetTally",
+          "arity": 0
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "primNew:",
+          "arity": 1
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "HomedAssociation": {
+      "superclass": "Association",
+      "instanceSelectors": [
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "environment:",
+          "arity": 1
+        },
+        {
+          "selector": "mourn",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "key:value:environment:",
+          "arity": 3
+        }
+      ]
+    },
+    "IdentityDictionary": {
+      "superclass": "LookupTable",
+      "instanceSelectors": [
+        {
+          "selector": "findElementIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "IdentitySet": {
+      "superclass": "Set",
+      "instanceSelectors": [
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "identityIncludes:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "IndexOutOfRange": {
+      "superclass": "ArgumentOutOfRange",
+      "instanceSelectors": [
+        {
+          "selector": "collection",
+          "arity": 0
+        },
+        {
+          "selector": "collection:",
+          "arity": 1
+        },
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "messageText",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:withIndex:",
+          "arity": 2
+        }
+      ]
+    },
+    "Integer": {
+      "superclass": "Number",
+      "instanceSelectors": [
+        {
+          "selector": "alignTo:",
+          "arity": 1
+        },
+        {
+          "selector": "allMask:",
+          "arity": 1
+        },
+        {
+          "selector": "anyMask:",
+          "arity": 1
+        },
+        {
+          "selector": "asCharacter",
+          "arity": 0
+        },
+        {
+          "selector": "asFraction",
+          "arity": 0
+        },
+        {
+          "selector": "asScaledDecimal:",
+          "arity": 1
+        },
+        {
+          "selector": "binomial:",
+          "arity": 1
+        },
+        {
+          "selector": "bitAt:",
+          "arity": 1
+        },
+        {
+          "selector": "bitAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "bitClear:",
+          "arity": 1
+        },
+        {
+          "selector": "bitInvert",
+          "arity": 0
+        },
+        {
+          "selector": "ceiling",
+          "arity": 0
+        },
+        {
+          "selector": "ceilingLog:",
+          "arity": 1
+        },
+        {
+          "selector": "clearBit:",
+          "arity": 1
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "denominator",
+          "arity": 0
+        },
+        {
+          "selector": "digitAt:",
+          "arity": 1
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "displayString",
+          "arity": 0
+        },
+        {
+          "selector": "estimatedLog",
+          "arity": 0
+        },
+        {
+          "selector": "even",
+          "arity": 0
+        },
+        {
+          "selector": "factorial",
+          "arity": 0
+        },
+        {
+          "selector": "floor",
+          "arity": 0
+        },
+        {
+          "selector": "floorLog:",
+          "arity": 1
+        },
+        {
+          "selector": "gcd:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "highBit",
+          "arity": 0
+        },
+        {
+          "selector": "isBitSet:",
+          "arity": 1
+        },
+        {
+          "selector": "isInteger",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "isRational",
+          "arity": 0
+        },
+        {
+          "selector": "lcm:",
+          "arity": 1
+        },
+        {
+          "selector": "lowBit",
+          "arity": 0
+        },
+        {
+          "selector": "noMask:",
+          "arity": 1
+        },
+        {
+          "selector": "numerator",
+          "arity": 0
+        },
+        {
+          "selector": "odd",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:base:",
+          "arity": 2
+        },
+        {
+          "selector": "printOn:paddedWith:to:",
+          "arity": 3
+        },
+        {
+          "selector": "printOn:paddedWith:to:base:",
+          "arity": 4
+        },
+        {
+          "selector": "printPaddedWith:to:",
+          "arity": 2
+        },
+        {
+          "selector": "printPaddedWith:to:base:",
+          "arity": 3
+        },
+        {
+          "selector": "printString",
+          "arity": 0
+        },
+        {
+          "selector": "printString:",
+          "arity": 1
+        },
+        {
+          "selector": "printStringRadix:",
+          "arity": 1
+        },
+        {
+          "selector": "radix:",
+          "arity": 1
+        },
+        {
+          "selector": "replace:withStringBase:",
+          "arity": 2
+        },
+        {
+          "selector": "rounded",
+          "arity": 0
+        },
+        {
+          "selector": "setBit:",
+          "arity": 1
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:base:",
+          "arity": 2
+        },
+        {
+          "selector": "storeString",
+          "arity": 0
+        },
+        {
+          "selector": "timesRepeat:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        }
+      ]
+    },
+    "Interval": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "increment",
+          "arity": 0
+        },
+        {
+          "selector": "initializeFrom:to:by:",
+          "arity": 3
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "isExact",
+          "arity": 0
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "reverse",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "from:to:",
+          "arity": 2
+        },
+        {
+          "selector": "from:to:by:",
+          "arity": 3
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "InvalidArgument": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "messageText",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "InvalidProcessState": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "InvalidSize": {
+      "superclass": "InvalidArgument",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "InvalidState": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "messageText",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "InvalidValue": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "messageText",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:",
+          "arity": 1
+        },
+        {
+          "selector": "signalOn:reason:",
+          "arity": 2
+        }
+      ]
+    },
+    "Iterable": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "allSatisfy:",
+          "arity": 1
+        },
+        {
+          "selector": "anySatisfy:",
+          "arity": 1
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "conform:",
+          "arity": 1
+        },
+        {
+          "selector": "contains:",
+          "arity": 1
+        },
+        {
+          "selector": "count:",
+          "arity": 1
+        },
+        {
+          "selector": "detect:",
+          "arity": 1
+        },
+        {
+          "selector": "detect:ifNone:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "do:separatedBy:",
+          "arity": 2
+        },
+        {
+          "selector": "fold:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNil:ifNotNilDo:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotNilDo:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNotNilDo:ifNil:",
+          "arity": 2
+        },
+        {
+          "selector": "inject:into:",
+          "arity": 2
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "noneSatisfy:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        }
+      ]
+    },
+    "Kernel.PackageInfo": {
+      "instanceSelectors": [
+        {
+          "selector": "autoload",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargeArray": {
+      "superclass": "LargeArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "newCollection:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargeArraySubpart": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "cutAt:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "first:last:index:",
+          "arity": 3
+        },
+        {
+          "selector": "firstIndex",
+          "arity": 0
+        },
+        {
+          "selector": "grow",
+          "arity": 0
+        },
+        {
+          "selector": "growBy:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "lastIndex",
+          "arity": 0
+        },
+        {
+          "selector": "relocateTo:",
+          "arity": 1
+        },
+        {
+          "selector": "removeFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "removeLast:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "first:last:index:",
+          "arity": 3
+        }
+      ]
+    },
+    "LargeArrayedCollection": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "addToStorage:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atPutSubpart:",
+          "arity": 1
+        },
+        {
+          "selector": "atSubpart:",
+          "arity": 1
+        },
+        {
+          "selector": "checkIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "compress",
+          "arity": 0
+        },
+        {
+          "selector": "costOfNewIndex",
+          "arity": 0
+        },
+        {
+          "selector": "defaultElement",
+          "arity": 0
+        },
+        {
+          "selector": "from:to:putOn:",
+          "arity": 3
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "indices",
+          "arity": 0
+        },
+        {
+          "selector": "initialize:",
+          "arity": 1
+        },
+        {
+          "selector": "newCollection:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "storage",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "LargeByteArray": {
+      "superclass": "LargeArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "costOfNewIndex",
+          "arity": 0
+        },
+        {
+          "selector": "defaultElement",
+          "arity": 0
+        },
+        {
+          "selector": "newCollection:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargeInteger": {
+      "superclass": "Integer",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asObject",
+          "arity": 0
+        },
+        {
+          "selector": "asObjectNoFail",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicLeftShift:",
+          "arity": 1
+        },
+        {
+          "selector": "basicRightShift:",
+          "arity": 1
+        },
+        {
+          "selector": "bitAnd:",
+          "arity": 1
+        },
+        {
+          "selector": "bitAt:",
+          "arity": 1
+        },
+        {
+          "selector": "bitInvert",
+          "arity": 0
+        },
+        {
+          "selector": "bitOr:",
+          "arity": 1
+        },
+        {
+          "selector": "bitShift:",
+          "arity": 1
+        },
+        {
+          "selector": "bitXor:",
+          "arity": 1
+        },
+        {
+          "selector": "bytes",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "digitAt:",
+          "arity": 1
+        },
+        {
+          "selector": "digitAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "digitLength",
+          "arity": 0
+        },
+        {
+          "selector": "divExact:",
+          "arity": 1
+        },
+        {
+          "selector": "estimatedLog",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "largeNegated",
+          "arity": 0
+        },
+        {
+          "selector": "lowBit",
+          "arity": 0
+        },
+        {
+          "selector": "mostSignificantByte",
+          "arity": 0
+        },
+        {
+          "selector": "negated",
+          "arity": 0
+        },
+        {
+          "selector": "primReplaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "quo:",
+          "arity": 1
+        },
+        {
+          "selector": "raisedToInteger:",
+          "arity": 1
+        },
+        {
+          "selector": "rem:",
+          "arity": 1
+        },
+        {
+          "selector": "setBytes:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "from:",
+          "arity": 1
+        },
+        {
+          "selector": "fromInteger:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "resultFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "test:with:with:",
+          "arity": 3
+        }
+      ]
+    },
+    "LargeNegativeInteger": {
+      "superclass": "LargeInteger",
+      "instanceSelectors": [
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "abs",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "gcd:",
+          "arity": 1
+        },
+        {
+          "selector": "highBit",
+          "arity": 0
+        },
+        {
+          "selector": "mostSignificantByte",
+          "arity": 0
+        },
+        {
+          "selector": "negative",
+          "arity": 0
+        },
+        {
+          "selector": "positive",
+          "arity": 0
+        },
+        {
+          "selector": "sign",
+          "arity": 0
+        },
+        {
+          "selector": "strictlyPositive",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargePositiveInteger": {
+      "superclass": "LargeInteger",
+      "instanceSelectors": [
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "abs",
+          "arity": 0
+        },
+        {
+          "selector": "asFloat:",
+          "arity": 1
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "bytes:from:compare:",
+          "arity": 3
+        },
+        {
+          "selector": "bytes:from:subtract:",
+          "arity": 3
+        },
+        {
+          "selector": "bytes:multiply:",
+          "arity": 2
+        },
+        {
+          "selector": "bytesLeftShift:",
+          "arity": 1
+        },
+        {
+          "selector": "bytesLeftShift:big:",
+          "arity": 2
+        },
+        {
+          "selector": "bytesLeftShift:n:",
+          "arity": 2
+        },
+        {
+          "selector": "bytesRightShift:big:",
+          "arity": 2
+        },
+        {
+          "selector": "bytesRightShift:n:",
+          "arity": 2
+        },
+        {
+          "selector": "bytesTrailingZeros:",
+          "arity": 1
+        },
+        {
+          "selector": "divide:using:",
+          "arity": 2
+        },
+        {
+          "selector": "fastAsFloat:",
+          "arity": 1
+        },
+        {
+          "selector": "gcd:",
+          "arity": 1
+        },
+        {
+          "selector": "highBit",
+          "arity": 0
+        },
+        {
+          "selector": "isSmall",
+          "arity": 0
+        },
+        {
+          "selector": "mostSignificantByte",
+          "arity": 0
+        },
+        {
+          "selector": "multiply:",
+          "arity": 1
+        },
+        {
+          "selector": "negative",
+          "arity": 0
+        },
+        {
+          "selector": "positive",
+          "arity": 0
+        },
+        {
+          "selector": "primDivide:",
+          "arity": 1
+        },
+        {
+          "selector": "replace:withStringBase:",
+          "arity": 2
+        },
+        {
+          "selector": "sign",
+          "arity": 0
+        },
+        {
+          "selector": "strictlyPositive",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargeWordArray": {
+      "superclass": "LargeArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "defaultElement",
+          "arity": 0
+        },
+        {
+          "selector": "newCollection:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "LargeZeroInteger": {
+      "superclass": "LargePositiveInteger",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "quo:",
+          "arity": 1
+        },
+        {
+          "selector": "rem:",
+          "arity": 1
+        },
+        {
+          "selector": "replace:withStringBase:",
+          "arity": 2
+        },
+        {
+          "selector": "sign",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "strictlyPositive",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "LimitedStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "close",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "fileIn",
+          "arity": 0
+        },
+        {
+          "selector": "flush",
+          "arity": 0
+        },
+        {
+          "selector": "isPositionable",
+          "arity": 0
+        },
+        {
+          "selector": "limit:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "nextAvailable:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "offset:",
+          "arity": 1
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "setToEnd",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "skip:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "stream:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:from:to:",
+          "arity": 3
+        }
+      ]
+    },
+    "LineStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "initStream:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "Link": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "nextLink",
+          "arity": 0
+        },
+        {
+          "selector": "nextLink:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "nextLink:",
+          "arity": 1
+        }
+      ]
+    },
+    "LinkedList": {
+      "superclass": "SequenceableCollection",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "addFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addLast:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "identityIncludes:",
+          "arity": 1
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "notEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeFirst",
+          "arity": 0
+        },
+        {
+          "selector": "removeLast",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "LookupKey": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "key",
+          "arity": 0
+        },
+        {
+          "selector": "key:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "key:",
+          "arity": 1
+        }
+      ]
+    },
+    "LookupTable": {
+      "superclass": "Dictionary",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "addWhileGrowing:",
+          "arity": 1
+        },
+        {
+          "selector": "associationAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "associationsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifPresent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "copyAllFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "findElementIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "keysAndValuesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "keysDo:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "primSize",
+          "arity": 0
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "rehashObjectsAfter:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeKey:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "valueAt:",
+          "arity": 1
+        },
+        {
+          "selector": "valueAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "whileGrowingAt:put:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "primNew:",
+          "arity": 1
+        }
+      ]
+    },
+    "Magnitude": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "between:and:",
+          "arity": 2
+        },
+        {
+          "selector": "max:",
+          "arity": 1
+        },
+        {
+          "selector": "min:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "MappedCollection": {
+      "superclass": "Collection",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atAll:",
+          "arity": 1
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "domain",
+          "arity": 0
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "keysAndValuesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "keysDo:",
+          "arity": 1
+        },
+        {
+          "selector": "map",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "setCollection:andMap:",
+          "arity": 2
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "collection:map:",
+          "arity": 2
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "MatchingRegexResults": {
+      "superclass": "RegexResults",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "from",
+          "arity": 0
+        },
+        {
+          "selector": "fromAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ifMatched:ifNotMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotMatched:ifMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "intervalAt:",
+          "arity": 1
+        },
+        {
+          "selector": "match",
+          "arity": 0
+        },
+        {
+          "selector": "matchInterval",
+          "arity": 0
+        },
+        {
+          "selector": "matched",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "subject",
+          "arity": 0
+        },
+        {
+          "selector": "to",
+          "arity": 0
+        },
+        {
+          "selector": "toAt:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "Memory": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "bigEndian",
+          "arity": 0
+        },
+        {
+          "selector": "charAt:",
+          "arity": 1
+        },
+        {
+          "selector": "charAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "deref:",
+          "arity": 1
+        },
+        {
+          "selector": "doubleAt:",
+          "arity": 1
+        },
+        {
+          "selector": "doubleAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "floatAt:",
+          "arity": 1
+        },
+        {
+          "selector": "floatAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "intAt:",
+          "arity": 1
+        },
+        {
+          "selector": "intAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "longAt:",
+          "arity": 1
+        },
+        {
+          "selector": "longAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "longDoubleAt:",
+          "arity": 1
+        },
+        {
+          "selector": "longDoubleAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "shortAt:",
+          "arity": 1
+        },
+        {
+          "selector": "shortAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "stringAt:",
+          "arity": 1
+        },
+        {
+          "selector": "stringAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "type:at:",
+          "arity": 2
+        },
+        {
+          "selector": "type:at:put:",
+          "arity": 3
+        },
+        {
+          "selector": "ucharAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "uintAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "ulongAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedCharAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedCharAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedIntAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedIntAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedLongAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedLongAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "unsignedShortAt:",
+          "arity": 1
+        },
+        {
+          "selector": "unsignedShortAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "ushortAt:put:",
+          "arity": 2
+        }
+      ]
+    },
+    "Message": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "argument",
+          "arity": 0
+        },
+        {
+          "selector": "arguments",
+          "arity": 0
+        },
+        {
+          "selector": "arguments:",
+          "arity": 1
+        },
+        {
+          "selector": "printAsAttributeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "reinvokeFor:",
+          "arity": 1
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "sendTo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "selector:argument:",
+          "arity": 2
+        },
+        {
+          "selector": "selector:arguments:",
+          "arity": 2
+        }
+      ]
+    },
+    "MessageNotUnderstood": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        },
+        {
+          "selector": "message",
+          "arity": 0
+        },
+        {
+          "selector": "message:receiver:",
+          "arity": 2
+        },
+        {
+          "selector": "receiver",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Metaclass": {
+      "superclass": "ClassDescription",
+      "instanceSelectors": [
+        {
+          "selector": "addClassVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "addSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "allClassVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "allSharedPoolDictionariesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "allSharedPools",
+          "arity": 0
+        },
+        {
+          "selector": "asClass",
+          "arity": 0
+        },
+        {
+          "selector": "category",
+          "arity": 0
+        },
+        {
+          "selector": "classPool",
+          "arity": 0
+        },
+        {
+          "selector": "classVarNames",
+          "arity": 0
+        },
+        {
+          "selector": "comment",
+          "arity": 0
+        },
+        {
+          "selector": "debuggerClass",
+          "arity": 0
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "fileOutOn:",
+          "arity": 1
+        },
+        {
+          "selector": "growClassInstance",
+          "arity": 0
+        },
+        {
+          "selector": "initMetaclass:",
+          "arity": 1
+        },
+        {
+          "selector": "instanceClass",
+          "arity": 0
+        },
+        {
+          "selector": "isMetaclass",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:environment:subclassOf:",
+          "arity": 3
+        },
+        {
+          "selector": "name:environment:subclassOf:instanceVariableArray:shape:classPool:poolDictionaries:category:",
+          "arity": 8
+        },
+        {
+          "selector": "name:environment:subclassOf:instanceVariableNames:shape:classVariableNames:poolDictionaries:category:",
+          "arity": 8
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "newMeta:environment:subclassOf:instanceVariableArray:shape:classPool:poolDictionaries:category:",
+          "arity": 8
+        },
+        {
+          "selector": "parse:toDictionary:",
+          "arity": 2
+        },
+        {
+          "selector": "parsePools:in:",
+          "arity": 2
+        },
+        {
+          "selector": "pragmaHandlerFor:",
+          "arity": 1
+        },
+        {
+          "selector": "primaryInstance",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "removeClassVarName:",
+          "arity": 1
+        },
+        {
+          "selector": "removeSharedPool:",
+          "arity": 1
+        },
+        {
+          "selector": "sharedPools",
+          "arity": 0
+        },
+        {
+          "selector": "soleInstance",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "subclassOf:",
+          "arity": 1
+        }
+      ]
+    },
+    "MethodContext": {
+      "superclass": "ContextPart",
+      "instanceSelectors": [
+        {
+          "selector": "home",
+          "arity": 0
+        },
+        {
+          "selector": "isBlock",
+          "arity": 0
+        },
+        {
+          "selector": "isDisabled",
+          "arity": 0
+        },
+        {
+          "selector": "isEnvironment",
+          "arity": 0
+        },
+        {
+          "selector": "isInternalExceptionHandlingContext",
+          "arity": 0
+        },
+        {
+          "selector": "isUnwind",
+          "arity": 0
+        },
+        {
+          "selector": "mark",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:line:",
+          "arity": 2
+        },
+        {
+          "selector": "sender",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "MethodDictionary": {
+      "superclass": "IdentityDictionary",
+      "instanceSelectors": [
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "dangerouslyRemove:",
+          "arity": 1
+        },
+        {
+          "selector": "dangerouslyRemoveKey:",
+          "arity": 1
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "removeKey:ifAbsent:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": []
+    },
+    "MethodInfo": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "category",
+          "arity": 0
+        },
+        {
+          "selector": "category:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass",
+          "arity": 0
+        },
+        {
+          "selector": "methodClass:",
+          "arity": 1
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "setSourceCode:",
+          "arity": 1
+        },
+        {
+          "selector": "sourceCode",
+          "arity": 0
+        },
+        {
+          "selector": "sourceFile",
+          "arity": 0
+        },
+        {
+          "selector": "sourcePos",
+          "arity": 0
+        },
+        {
+          "selector": "sourceString",
+          "arity": 0
+        },
+        {
+          "selector": "stripSourceCode",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "MustBeBoolean": {
+      "superclass": "WrongClass",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "signalOn:",
+          "arity": 1
+        }
+      ]
+    },
+    "MutationError": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "Namespace": {
+      "superclass": "AbstractNamespace",
+      "instanceSelectors": [
+        {
+          "selector": "associationAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "associationsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifPresent:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "inheritedKeys",
+          "arity": 0
+        },
+        {
+          "selector": "keysAndValuesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "keysDo:",
+          "arity": 1
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "set:to:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "siblings",
+          "arity": 0
+        },
+        {
+          "selector": "siblingsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "current",
+          "arity": 0
+        },
+        {
+          "selector": "current:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "NoRunnableProcess": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "NotEnoughElements": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "messageText",
+          "arity": 0
+        },
+        {
+          "selector": "remainingCount",
+          "arity": 0
+        },
+        {
+          "selector": "remainingCount:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:",
+          "arity": 1
+        }
+      ]
+    },
+    "NotFound": {
+      "superclass": "InvalidArgument",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:reason:",
+          "arity": 2
+        },
+        {
+          "selector": "signalOn:what:",
+          "arity": 2
+        }
+      ]
+    },
+    "NotImplemented": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "NotIndexable": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "NotYetImplemented": {
+      "superclass": "NotImplemented",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Notification": {
+      "superclass": "Exception",
+      "instanceSelectors": [
+        {
+          "selector": "defaultAction",
+          "arity": 0
+        },
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "NullProxy": {
+      "superclass": "AlternativeObjectProxy",
+      "instanceSelectors": [
+        {
+          "selector": "dumpTo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "loadFrom:",
+          "arity": 1
+        }
+      ]
+    },
+    "NullValueHolder": {
+      "superclass": "ValueAdaptor",
+      "instanceSelectors": [
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "uniqueInstance",
+          "arity": 0
+        }
+      ]
+    },
+    "Number": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "@",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "abs",
+          "arity": 0
+        },
+        {
+          "selector": "arcCos",
+          "arity": 0
+        },
+        {
+          "selector": "arcCosh",
+          "arity": 0
+        },
+        {
+          "selector": "arcSin",
+          "arity": 0
+        },
+        {
+          "selector": "arcSinh",
+          "arity": 0
+        },
+        {
+          "selector": "arcTan",
+          "arity": 0
+        },
+        {
+          "selector": "arcTan:",
+          "arity": 1
+        },
+        {
+          "selector": "arcTanh",
+          "arity": 0
+        },
+        {
+          "selector": "arithmeticError:",
+          "arity": 1
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asExactFraction",
+          "arity": 0
+        },
+        {
+          "selector": "asFloat",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "asFraction",
+          "arity": 0
+        },
+        {
+          "selector": "asInteger",
+          "arity": 0
+        },
+        {
+          "selector": "asNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asPoint",
+          "arity": 0
+        },
+        {
+          "selector": "asRectangle",
+          "arity": 0
+        },
+        {
+          "selector": "asScaledDecimal:",
+          "arity": 1
+        },
+        {
+          "selector": "asScaledDecimal:radix:scale:",
+          "arity": 3
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "ceilingLog:",
+          "arity": 1
+        },
+        {
+          "selector": "closeTo:",
+          "arity": 1
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "cos",
+          "arity": 0
+        },
+        {
+          "selector": "cosh",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "degreesToRadians",
+          "arity": 0
+        },
+        {
+          "selector": "estimatedLog",
+          "arity": 0
+        },
+        {
+          "selector": "even",
+          "arity": 0
+        },
+        {
+          "selector": "exp",
+          "arity": 0
+        },
+        {
+          "selector": "floor",
+          "arity": 0
+        },
+        {
+          "selector": "floorLog:",
+          "arity": 1
+        },
+        {
+          "selector": "fractionPart",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "integerPart",
+          "arity": 0
+        },
+        {
+          "selector": "isExact",
+          "arity": 0
+        },
+        {
+          "selector": "isFinite",
+          "arity": 0
+        },
+        {
+          "selector": "isInfinite",
+          "arity": 0
+        },
+        {
+          "selector": "isNaN",
+          "arity": 0
+        },
+        {
+          "selector": "isNumber",
+          "arity": 0
+        },
+        {
+          "selector": "isRational",
+          "arity": 0
+        },
+        {
+          "selector": "ln",
+          "arity": 0
+        },
+        {
+          "selector": "log",
+          "arity": 0
+        },
+        {
+          "selector": "log:",
+          "arity": 1
+        },
+        {
+          "selector": "max:",
+          "arity": 1
+        },
+        {
+          "selector": "min:",
+          "arity": 1
+        },
+        {
+          "selector": "negated",
+          "arity": 0
+        },
+        {
+          "selector": "negative",
+          "arity": 0
+        },
+        {
+          "selector": "odd",
+          "arity": 0
+        },
+        {
+          "selector": "positive",
+          "arity": 0
+        },
+        {
+          "selector": "positiveDifference:",
+          "arity": 1
+        },
+        {
+          "selector": "powerTable",
+          "arity": 0
+        },
+        {
+          "selector": "quo:",
+          "arity": 1
+        },
+        {
+          "selector": "radiansToDegrees",
+          "arity": 0
+        },
+        {
+          "selector": "raisedTo:",
+          "arity": 1
+        },
+        {
+          "selector": "raisedToInteger:",
+          "arity": 1
+        },
+        {
+          "selector": "raisedToInteger:withCache:",
+          "arity": 2
+        },
+        {
+          "selector": "reciprocal",
+          "arity": 0
+        },
+        {
+          "selector": "rem:",
+          "arity": 1
+        },
+        {
+          "selector": "retry:coercing:",
+          "arity": 2
+        },
+        {
+          "selector": "retryDifferenceCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "retryDivisionCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "retryEqualityCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "retryError",
+          "arity": 0
+        },
+        {
+          "selector": "retryInequalityCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "retryMultiplicationCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "retryRelationalOp:coercing:",
+          "arity": 2
+        },
+        {
+          "selector": "retrySumCoercing:",
+          "arity": 1
+        },
+        {
+          "selector": "roundTo:",
+          "arity": 1
+        },
+        {
+          "selector": "rounded",
+          "arity": 0
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "sign",
+          "arity": 0
+        },
+        {
+          "selector": "sin",
+          "arity": 0
+        },
+        {
+          "selector": "sinh",
+          "arity": 0
+        },
+        {
+          "selector": "sqrt",
+          "arity": 0
+        },
+        {
+          "selector": "squared",
+          "arity": 0
+        },
+        {
+          "selector": "strictlyPositive",
+          "arity": 0
+        },
+        {
+          "selector": "tan",
+          "arity": 0
+        },
+        {
+          "selector": "tanh",
+          "arity": 0
+        },
+        {
+          "selector": "to:",
+          "arity": 1
+        },
+        {
+          "selector": "to:by:",
+          "arity": 2
+        },
+        {
+          "selector": "to:by:collect:",
+          "arity": 3
+        },
+        {
+          "selector": "to:by:do:",
+          "arity": 3
+        },
+        {
+          "selector": "to:collect:",
+          "arity": 2
+        },
+        {
+          "selector": "to:do:",
+          "arity": 2
+        },
+        {
+          "selector": "truncateTo:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "withSignOf:",
+          "arity": 1
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "zeroDivide",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "isImmediate",
+          "arity": 0
+        },
+        {
+          "selector": "readFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "readFrom:radix:",
+          "arity": 2
+        }
+      ]
+    },
+    "Object": {
+      "superclass": "nil",
+      "instanceSelectors": [
+        {
+          "selector": "->",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "==",
+          "arity": 1
+        },
+        {
+          "selector": "addDependent:",
+          "arity": 1
+        },
+        {
+          "selector": "addToBeFinalized",
+          "arity": 0
+        },
+        {
+          "selector": "allOwners",
+          "arity": 0
+        },
+        {
+          "selector": "asOop",
+          "arity": 0
+        },
+        {
+          "selector": "asValue",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "badReturnError",
+          "arity": 0
+        },
+        {
+          "selector": "basicAt:",
+          "arity": 1
+        },
+        {
+          "selector": "basicAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicPrint",
+          "arity": 0
+        },
+        {
+          "selector": "basicPrintNl",
+          "arity": 0
+        },
+        {
+          "selector": "basicPrintOn:",
+          "arity": 1
+        },
+        {
+          "selector": "basicSize",
+          "arity": 0
+        },
+        {
+          "selector": "become:",
+          "arity": 1
+        },
+        {
+          "selector": "becomeForward:",
+          "arity": 1
+        },
+        {
+          "selector": "binaryRepresentationObject",
+          "arity": 0
+        },
+        {
+          "selector": "broadcast:",
+          "arity": 1
+        },
+        {
+          "selector": "broadcast:with:",
+          "arity": 2
+        },
+        {
+          "selector": "broadcast:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "broadcast:withArguments:",
+          "arity": 2
+        },
+        {
+          "selector": "broadcast:withBlock:",
+          "arity": 2
+        },
+        {
+          "selector": "changeClassTo:",
+          "arity": 1
+        },
+        {
+          "selector": "changed",
+          "arity": 0
+        },
+        {
+          "selector": "changed:",
+          "arity": 1
+        },
+        {
+          "selector": "checkIndexableBounds:",
+          "arity": 1
+        },
+        {
+          "selector": "checkIndexableBounds:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "checkIndexableBounds:put:",
+          "arity": 2
+        },
+        {
+          "selector": "class",
+          "arity": 0
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "dependents",
+          "arity": 0
+        },
+        {
+          "selector": "display",
+          "arity": 0
+        },
+        {
+          "selector": "displayNl",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "displayString",
+          "arity": 0
+        },
+        {
+          "selector": "doesNotUnderstand:",
+          "arity": 1
+        },
+        {
+          "selector": "error:",
+          "arity": 1
+        },
+        {
+          "selector": "examine",
+          "arity": 0
+        },
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "finalize",
+          "arity": 0
+        },
+        {
+          "selector": "halt",
+          "arity": 0
+        },
+        {
+          "selector": "halt:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "identityHash",
+          "arity": 0
+        },
+        {
+          "selector": "ifNil:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNil:ifNotNil:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotNil:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNotNil:ifNil:",
+          "arity": 2
+        },
+        {
+          "selector": "inspect",
+          "arity": 0
+        },
+        {
+          "selector": "instVarAt:",
+          "arity": 1
+        },
+        {
+          "selector": "instVarAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "instVarNamed:",
+          "arity": 1
+        },
+        {
+          "selector": "instVarNamed:put:",
+          "arity": 2
+        },
+        {
+          "selector": "isArray",
+          "arity": 0
+        },
+        {
+          "selector": "isBehavior",
+          "arity": 0
+        },
+        {
+          "selector": "isCObject",
+          "arity": 0
+        },
+        {
+          "selector": "isCharacter",
+          "arity": 0
+        },
+        {
+          "selector": "isCharacterArray",
+          "arity": 0
+        },
+        {
+          "selector": "isClass",
+          "arity": 0
+        },
+        {
+          "selector": "isFloat",
+          "arity": 0
+        },
+        {
+          "selector": "isInteger",
+          "arity": 0
+        },
+        {
+          "selector": "isKindOf:",
+          "arity": 1
+        },
+        {
+          "selector": "isMemberOf:",
+          "arity": 1
+        },
+        {
+          "selector": "isMeta",
+          "arity": 0
+        },
+        {
+          "selector": "isMetaClass",
+          "arity": 0
+        },
+        {
+          "selector": "isMetaclass",
+          "arity": 0
+        },
+        {
+          "selector": "isNamespace",
+          "arity": 0
+        },
+        {
+          "selector": "isNil",
+          "arity": 0
+        },
+        {
+          "selector": "isNumber",
+          "arity": 0
+        },
+        {
+          "selector": "isReadOnly",
+          "arity": 0
+        },
+        {
+          "selector": "isSmallInteger",
+          "arity": 0
+        },
+        {
+          "selector": "isString",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "isUntrusted",
+          "arity": 0
+        },
+        {
+          "selector": "makeEphemeron",
+          "arity": 0
+        },
+        {
+          "selector": "makeFixed",
+          "arity": 0
+        },
+        {
+          "selector": "makeReadOnly:",
+          "arity": 1
+        },
+        {
+          "selector": "makeUntrusted:",
+          "arity": 1
+        },
+        {
+          "selector": "makeWeak",
+          "arity": 0
+        },
+        {
+          "selector": "mark:",
+          "arity": 1
+        },
+        {
+          "selector": "mourn",
+          "arity": 0
+        },
+        {
+          "selector": "mustBeBoolean",
+          "arity": 0
+        },
+        {
+          "selector": "nextInstance",
+          "arity": 0
+        },
+        {
+          "selector": "noRunnableProcess",
+          "arity": 0
+        },
+        {
+          "selector": "notNil",
+          "arity": 0
+        },
+        {
+          "selector": "notYetImplemented",
+          "arity": 0
+        },
+        {
+          "selector": "perform:",
+          "arity": 1
+        },
+        {
+          "selector": "perform:with:",
+          "arity": 2
+        },
+        {
+          "selector": "perform:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "perform:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "perform:with:with:with:with:",
+          "arity": 5
+        },
+        {
+          "selector": "perform:withArguments:",
+          "arity": 2
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "postLoad",
+          "arity": 0
+        },
+        {
+          "selector": "postStore",
+          "arity": 0
+        },
+        {
+          "selector": "preStore",
+          "arity": 0
+        },
+        {
+          "selector": "primitiveFailed",
+          "arity": 0
+        },
+        {
+          "selector": "print",
+          "arity": 0
+        },
+        {
+          "selector": "printNl",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printString",
+          "arity": 0
+        },
+        {
+          "selector": "reconstructOriginalObject",
+          "arity": 0
+        },
+        {
+          "selector": "release",
+          "arity": 0
+        },
+        {
+          "selector": "removeDependent:",
+          "arity": 1
+        },
+        {
+          "selector": "removeToBeFinalized",
+          "arity": 0
+        },
+        {
+          "selector": "respondsTo:",
+          "arity": 1
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "shouldNotImplement",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "store",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeNl",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeString",
+          "arity": 0
+        },
+        {
+          "selector": "subclassResponsibility",
+          "arity": 0
+        },
+        {
+          "selector": "tenure",
+          "arity": 0
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        },
+        {
+          "selector": "userInterrupt",
+          "arity": 0
+        },
+        {
+          "selector": "validSize",
+          "arity": 0
+        },
+        {
+          "selector": "yourself",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        },
+        {
+          "selector": "~~",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "dependencies",
+          "arity": 0
+        },
+        {
+          "selector": "dependencies:",
+          "arity": 1
+        },
+        {
+          "selector": "finalizableObjects",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        }
+      ]
+    },
+    "ObjectDumper": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "dump:",
+          "arity": 1
+        },
+        {
+          "selector": "dumpContentsOf:",
+          "arity": 1
+        },
+        {
+          "selector": "flush",
+          "arity": 0
+        },
+        {
+          "selector": "initializeStream:",
+          "arity": 1
+        },
+        {
+          "selector": "isClass:",
+          "arity": 1
+        },
+        {
+          "selector": "load",
+          "arity": 0
+        },
+        {
+          "selector": "load:through:",
+          "arity": 2
+        },
+        {
+          "selector": "loadClass",
+          "arity": 0
+        },
+        {
+          "selector": "loadFixedPart:",
+          "arity": 1
+        },
+        {
+          "selector": "loadFromVersion:fixedSize:index:",
+          "arity": 3
+        },
+        {
+          "selector": "loadGlobal",
+          "arity": 0
+        },
+        {
+          "selector": "lookup:",
+          "arity": 1
+        },
+        {
+          "selector": "lookupIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "nextAsciiz",
+          "arity": 0
+        },
+        {
+          "selector": "nextByte",
+          "arity": 0
+        },
+        {
+          "selector": "nextByteArray:",
+          "arity": 1
+        },
+        {
+          "selector": "nextBytes:signed:",
+          "arity": 2
+        },
+        {
+          "selector": "nextDouble",
+          "arity": 0
+        },
+        {
+          "selector": "nextFloat",
+          "arity": 0
+        },
+        {
+          "selector": "nextLong",
+          "arity": 0
+        },
+        {
+          "selector": "nextLongLong",
+          "arity": 0
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutByte:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutByteArray:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutBytes:of:",
+          "arity": 2
+        },
+        {
+          "selector": "nextPutDouble:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutFloat:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutInt64:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutLong:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutShort:",
+          "arity": 1
+        },
+        {
+          "selector": "nextShort",
+          "arity": 0
+        },
+        {
+          "selector": "nextSignedByte",
+          "arity": 0
+        },
+        {
+          "selector": "nextUint64",
+          "arity": 0
+        },
+        {
+          "selector": "nextUlong",
+          "arity": 0
+        },
+        {
+          "selector": "nextUshort",
+          "arity": 0
+        },
+        {
+          "selector": "primDump:",
+          "arity": 1
+        },
+        {
+          "selector": "primLoad:",
+          "arity": 1
+        },
+        {
+          "selector": "register:",
+          "arity": 1
+        },
+        {
+          "selector": "specialCaseDump:",
+          "arity": 1
+        },
+        {
+          "selector": "specialCaseLoad:",
+          "arity": 1
+        },
+        {
+          "selector": "store:through:",
+          "arity": 2
+        },
+        {
+          "selector": "storeClass:",
+          "arity": 1
+        },
+        {
+          "selector": "storeGlobal:",
+          "arity": 1
+        },
+        {
+          "selector": "stream",
+          "arity": 0
+        },
+        {
+          "selector": "stream:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "disableProxyFor:",
+          "arity": 1
+        },
+        {
+          "selector": "dump:to:",
+          "arity": 2
+        },
+        {
+          "selector": "example",
+          "arity": 0
+        },
+        {
+          "selector": "hasProxyFor:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "loadFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "proxyClassFor:",
+          "arity": 1
+        },
+        {
+          "selector": "proxyFor:",
+          "arity": 1
+        },
+        {
+          "selector": "registerProxyClass:for:",
+          "arity": 2
+        },
+        {
+          "selector": "specialCaseIf:dump:load:",
+          "arity": 3
+        }
+      ]
+    },
+    "ObjectMemory": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "allocFailures",
+          "arity": 0
+        },
+        {
+          "selector": "allocMatches",
+          "arity": 0
+        },
+        {
+          "selector": "allocProbes",
+          "arity": 0
+        },
+        {
+          "selector": "allocSplits",
+          "arity": 0
+        },
+        {
+          "selector": "bytesPerOOP",
+          "arity": 0
+        },
+        {
+          "selector": "bytesPerOTE",
+          "arity": 0
+        },
+        {
+          "selector": "edenSize",
+          "arity": 0
+        },
+        {
+          "selector": "edenUsedBytes",
+          "arity": 0
+        },
+        {
+          "selector": "fixedSpaceSize",
+          "arity": 0
+        },
+        {
+          "selector": "fixedSpaceUsedBytes",
+          "arity": 0
+        },
+        {
+          "selector": "numCompactions",
+          "arity": 0
+        },
+        {
+          "selector": "numFixedOOPs",
+          "arity": 0
+        },
+        {
+          "selector": "numFreeOTEs",
+          "arity": 0
+        },
+        {
+          "selector": "numGlobalGCs",
+          "arity": 0
+        },
+        {
+          "selector": "numGrowths",
+          "arity": 0
+        },
+        {
+          "selector": "numOTEs",
+          "arity": 0
+        },
+        {
+          "selector": "numOldOOPs",
+          "arity": 0
+        },
+        {
+          "selector": "numScavenges",
+          "arity": 0
+        },
+        {
+          "selector": "numWeakOOPs",
+          "arity": 0
+        },
+        {
+          "selector": "oldSpaceSize",
+          "arity": 0
+        },
+        {
+          "selector": "oldSpaceUsedBytes",
+          "arity": 0
+        },
+        {
+          "selector": "reclaimedBytesPerGlobalGC",
+          "arity": 0
+        },
+        {
+          "selector": "reclaimedBytesPerScavenge",
+          "arity": 0
+        },
+        {
+          "selector": "reclaimedPercentPerScavenge",
+          "arity": 0
+        },
+        {
+          "selector": "scavengesBeforeTenuring",
+          "arity": 0
+        },
+        {
+          "selector": "survSpaceSize",
+          "arity": 0
+        },
+        {
+          "selector": "survSpaceUsedBytes",
+          "arity": 0
+        },
+        {
+          "selector": "tenuredBytesPerScavenge",
+          "arity": 0
+        },
+        {
+          "selector": "timeBetweenGlobalGCs",
+          "arity": 0
+        },
+        {
+          "selector": "timeBetweenGrowths",
+          "arity": 0
+        },
+        {
+          "selector": "timeBetweenScavenges",
+          "arity": 0
+        },
+        {
+          "selector": "timeToCollect",
+          "arity": 0
+        },
+        {
+          "selector": "timeToCompact",
+          "arity": 0
+        },
+        {
+          "selector": "timeToScavenge",
+          "arity": 0
+        },
+        {
+          "selector": "update",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "abort",
+          "arity": 0
+        },
+        {
+          "selector": "addressOf:",
+          "arity": 1
+        },
+        {
+          "selector": "addressOfOOP:",
+          "arity": 1
+        },
+        {
+          "selector": "bigObjectThreshold",
+          "arity": 0
+        },
+        {
+          "selector": "bigObjectThreshold:",
+          "arity": 1
+        },
+        {
+          "selector": "changed:",
+          "arity": 1
+        },
+        {
+          "selector": "compact",
+          "arity": 0
+        },
+        {
+          "selector": "current",
+          "arity": 0
+        },
+        {
+          "selector": "finishIncrementalGC",
+          "arity": 0
+        },
+        {
+          "selector": "gcMessage",
+          "arity": 0
+        },
+        {
+          "selector": "gcMessage:",
+          "arity": 1
+        },
+        {
+          "selector": "globalGarbageCollect",
+          "arity": 0
+        },
+        {
+          "selector": "growThresholdPercent",
+          "arity": 0
+        },
+        {
+          "selector": "growThresholdPercent:",
+          "arity": 1
+        },
+        {
+          "selector": "growTo:",
+          "arity": 1
+        },
+        {
+          "selector": "incrementalGCStep",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "primSnapshot:",
+          "arity": 1
+        },
+        {
+          "selector": "quit",
+          "arity": 0
+        },
+        {
+          "selector": "quit:",
+          "arity": 1
+        },
+        {
+          "selector": "scavenge",
+          "arity": 0
+        },
+        {
+          "selector": "smoothingFactor",
+          "arity": 0
+        },
+        {
+          "selector": "smoothingFactor:",
+          "arity": 1
+        },
+        {
+          "selector": "snapshot",
+          "arity": 0
+        },
+        {
+          "selector": "snapshot:",
+          "arity": 1
+        },
+        {
+          "selector": "spaceGrowRate",
+          "arity": 0
+        },
+        {
+          "selector": "spaceGrowRate:",
+          "arity": 1
+        }
+      ]
+    },
+    "OneOfEachStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "reset",
+          "arity": 0
+        },
+        {
+          "selector": "skip:",
+          "arity": 1
+        },
+        {
+          "selector": "streams:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "with:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "withAll:",
+          "arity": 1
+        }
+      ]
+    },
+    "OrderedCollection": {
+      "superclass": "SequenceableCollection",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "add:after:",
+          "arity": 2
+        },
+        {
+          "selector": "add:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "add:before:",
+          "arity": 2
+        },
+        {
+          "selector": "add:beforeIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:",
+          "arity": 1
+        },
+        {
+          "selector": "addAll:after:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:before:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:beforeIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAllFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addAllLast:",
+          "arity": 1
+        },
+        {
+          "selector": "addFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addLast:",
+          "arity": 1
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicAddAllLast:",
+          "arity": 1
+        },
+        {
+          "selector": "basicAddLast:",
+          "arity": 1
+        },
+        {
+          "selector": "basicRemoveAtIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "basicRemoveFirst",
+          "arity": 0
+        },
+        {
+          "selector": "basicRemoveLast",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "firstIndex:lastIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "grow",
+          "arity": 0
+        },
+        {
+          "selector": "growBy:shiftBy:",
+          "arity": 2
+        },
+        {
+          "selector": "identityRemove:",
+          "arity": 1
+        },
+        {
+          "selector": "identityRemove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "initIndices",
+          "arity": 0
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "makeRoomFirstFor:",
+          "arity": 1
+        },
+        {
+          "selector": "makeRoomLastFor:",
+          "arity": 1
+        },
+        {
+          "selector": "primReplaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAtIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "removeFirst",
+          "arity": 0
+        },
+        {
+          "selector": "removeLast",
+          "arity": 0
+        },
+        {
+          "selector": "shrink",
+          "arity": 0
+        },
+        {
+          "selector": "shrinkSize",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "Package": {
+      "superclass": "Kernel.PackageInfo",
+      "instanceSelectors": [
+        {
+          "selector": "addBuiltFile:",
+          "arity": 1
+        },
+        {
+          "selector": "addCallout:",
+          "arity": 1
+        },
+        {
+          "selector": "addFeature:",
+          "arity": 1
+        },
+        {
+          "selector": "addFile:",
+          "arity": 1
+        },
+        {
+          "selector": "addFileIn:",
+          "arity": 1
+        },
+        {
+          "selector": "addLibrary:",
+          "arity": 1
+        },
+        {
+          "selector": "addModule:",
+          "arity": 1
+        },
+        {
+          "selector": "addPrerequisite:",
+          "arity": 1
+        },
+        {
+          "selector": "addSunitScript:",
+          "arity": 1
+        },
+        {
+          "selector": "baseDirectories",
+          "arity": 0
+        },
+        {
+          "selector": "baseDirectories:",
+          "arity": 1
+        },
+        {
+          "selector": "builtFiles",
+          "arity": 0
+        },
+        {
+          "selector": "callouts",
+          "arity": 0
+        },
+        {
+          "selector": "checkTagIfInPath:",
+          "arity": 1
+        },
+        {
+          "selector": "dir:tag:",
+          "arity": 2
+        },
+        {
+          "selector": "directory",
+          "arity": 0
+        },
+        {
+          "selector": "features",
+          "arity": 0
+        },
+        {
+          "selector": "fileIns",
+          "arity": 0
+        },
+        {
+          "selector": "files",
+          "arity": 0
+        },
+        {
+          "selector": "fullPathOf:",
+          "arity": 1
+        },
+        {
+          "selector": "isInPath",
+          "arity": 0
+        },
+        {
+          "selector": "libraries",
+          "arity": 0
+        },
+        {
+          "selector": "modules",
+          "arity": 0
+        },
+        {
+          "selector": "namespace",
+          "arity": 0
+        },
+        {
+          "selector": "namespace:",
+          "arity": 1
+        },
+        {
+          "selector": "parse:tag:",
+          "arity": 2
+        },
+        {
+          "selector": "parseAttributes:",
+          "arity": 1
+        },
+        {
+          "selector": "parseVersion:",
+          "arity": 1
+        },
+        {
+          "selector": "path",
+          "arity": 0
+        },
+        {
+          "selector": "path:",
+          "arity": 1
+        },
+        {
+          "selector": "prerequisites",
+          "arity": 0
+        },
+        {
+          "selector": "primFileIn",
+          "arity": 0
+        },
+        {
+          "selector": "relativeDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "relativeDirectory:",
+          "arity": 1
+        },
+        {
+          "selector": "startScript",
+          "arity": 0
+        },
+        {
+          "selector": "startScript:",
+          "arity": 1
+        },
+        {
+          "selector": "stopScript",
+          "arity": 0
+        },
+        {
+          "selector": "stopScript:",
+          "arity": 1
+        },
+        {
+          "selector": "sunitScripts",
+          "arity": 0
+        },
+        {
+          "selector": "test",
+          "arity": 0
+        },
+        {
+          "selector": "test:",
+          "arity": 1
+        },
+        {
+          "selector": "url",
+          "arity": 0
+        },
+        {
+          "selector": "url:",
+          "arity": 1
+        },
+        {
+          "selector": "version",
+          "arity": 0
+        },
+        {
+          "selector": "version:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "parse:",
+          "arity": 1
+        },
+        {
+          "selector": "tags",
+          "arity": 0
+        }
+      ]
+    },
+    "PackageContainer": {
+      "superclass": "PackageGroup",
+      "instanceSelectors": [
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "baseDirectoriesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "file:",
+          "arity": 1
+        },
+        {
+          "selector": "fileName",
+          "arity": 0
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "packages",
+          "arity": 0
+        },
+        {
+          "selector": "packages:",
+          "arity": 1
+        },
+        {
+          "selector": "parse:",
+          "arity": 1
+        },
+        {
+          "selector": "refresh:",
+          "arity": 1
+        },
+        {
+          "selector": "testPackageValidity:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "PackageDirectories": {
+      "superclass": "PackageGroup",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "refresh:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "PackageDirectory": {
+      "superclass": "PackageContainer",
+      "instanceSelectors": [
+        {
+          "selector": "baseDirectories:",
+          "arity": 1
+        },
+        {
+          "selector": "baseDirectoriesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "refresh:",
+          "arity": 1
+        },
+        {
+          "selector": "refreshPackageList",
+          "arity": 0
+        },
+        {
+          "selector": "refreshStarList:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:baseDirectories:",
+          "arity": 2
+        }
+      ]
+    },
+    "PackageGroup": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "do:separatedBy:",
+          "arity": 2
+        },
+        {
+          "selector": "extractDependenciesFor:ifMissing:",
+          "arity": 2
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "refresh:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "PackageInfo": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "allDistFiles",
+          "arity": 0
+        },
+        {
+          "selector": "allDistFiles:",
+          "arity": 1
+        },
+        {
+          "selector": "allFiles",
+          "arity": 0
+        },
+        {
+          "selector": "allFiles:",
+          "arity": 1
+        },
+        {
+          "selector": "builtFiles",
+          "arity": 0
+        },
+        {
+          "selector": "callouts",
+          "arity": 0
+        },
+        {
+          "selector": "createNamespace",
+          "arity": 0
+        },
+        {
+          "selector": "directory",
+          "arity": 0
+        },
+        {
+          "selector": "features",
+          "arity": 0
+        },
+        {
+          "selector": "fileIn",
+          "arity": 0
+        },
+        {
+          "selector": "fileIns",
+          "arity": 0
+        },
+        {
+          "selector": "files",
+          "arity": 0
+        },
+        {
+          "selector": "fullPathOf:",
+          "arity": 1
+        },
+        {
+          "selector": "fullPathsOf:",
+          "arity": 1
+        },
+        {
+          "selector": "isDisabled",
+          "arity": 0
+        },
+        {
+          "selector": "libraries",
+          "arity": 0
+        },
+        {
+          "selector": "loaded",
+          "arity": 0
+        },
+        {
+          "selector": "modules",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "namespace",
+          "arity": 0
+        },
+        {
+          "selector": "prerequisites",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:indent:",
+          "arity": 2
+        },
+        {
+          "selector": "printOn:tag:indent:",
+          "arity": 3
+        },
+        {
+          "selector": "printXmlOn:collection:tag:indent:",
+          "arity": 4
+        },
+        {
+          "selector": "relativeDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "start",
+          "arity": 0
+        },
+        {
+          "selector": "start:",
+          "arity": 1
+        },
+        {
+          "selector": "startScript",
+          "arity": 0
+        },
+        {
+          "selector": "stop",
+          "arity": 0
+        },
+        {
+          "selector": "stop:",
+          "arity": 1
+        },
+        {
+          "selector": "stopScript",
+          "arity": 0
+        },
+        {
+          "selector": "sunitScript",
+          "arity": 0
+        },
+        {
+          "selector": "sunitScripts",
+          "arity": 0
+        },
+        {
+          "selector": "url",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "PackageLoader": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "builtFilesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "calloutsFor:",
+          "arity": 1
+        },
+        {
+          "selector": "canLoad:",
+          "arity": 1
+        },
+        {
+          "selector": "directoryFor:",
+          "arity": 1
+        },
+        {
+          "selector": "featuresFor:",
+          "arity": 1
+        },
+        {
+          "selector": "fileInPackage:",
+          "arity": 1
+        },
+        {
+          "selector": "fileInPackages:",
+          "arity": 1
+        },
+        {
+          "selector": "fileInsFor:",
+          "arity": 1
+        },
+        {
+          "selector": "filesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "flush",
+          "arity": 0
+        },
+        {
+          "selector": "ignoreCallouts",
+          "arity": 0
+        },
+        {
+          "selector": "ignoreCallouts:",
+          "arity": 1
+        },
+        {
+          "selector": "isLoadable:",
+          "arity": 1
+        },
+        {
+          "selector": "librariesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "localPackageFile",
+          "arity": 0
+        },
+        {
+          "selector": "modulesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "packageAt:",
+          "arity": 1
+        },
+        {
+          "selector": "packageAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "packageFile",
+          "arity": 0
+        },
+        {
+          "selector": "prerequisitesFor:",
+          "arity": 1
+        },
+        {
+          "selector": "rebuildPackageFile",
+          "arity": 0
+        },
+        {
+          "selector": "refresh",
+          "arity": 0
+        },
+        {
+          "selector": "sitePackageFile",
+          "arity": 0
+        },
+        {
+          "selector": "sunitScriptFor:",
+          "arity": 1
+        },
+        {
+          "selector": "userPackageFile",
+          "arity": 0
+        }
+      ]
+    },
+    "PackageNotAvailable": {
+      "superclass": "NotFound",
+      "instanceSelectors": [
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signal:",
+          "arity": 1
+        },
+        {
+          "selector": "signal:reason:",
+          "arity": 2
+        }
+      ]
+    },
+    "PackageSkip": {
+      "superclass": "Notification",
+      "instanceSelectors": [],
+      "classSelectors": []
+    },
+    "PeekableStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "initStream:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "Permission": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "action:",
+          "arity": 1
+        },
+        {
+          "selector": "actions",
+          "arity": 0
+        },
+        {
+          "selector": "actions:",
+          "arity": 1
+        },
+        {
+          "selector": "allow",
+          "arity": 0
+        },
+        {
+          "selector": "allowing",
+          "arity": 0
+        },
+        {
+          "selector": "check:for:",
+          "arity": 2
+        },
+        {
+          "selector": "deny",
+          "arity": 0
+        },
+        {
+          "selector": "denying",
+          "arity": 0
+        },
+        {
+          "selector": "implies:",
+          "arity": 1
+        },
+        {
+          "selector": "isAllowing",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "target",
+          "arity": 0
+        },
+        {
+          "selector": "target:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "allowing:target:action:",
+          "arity": 3
+        },
+        {
+          "selector": "allowing:target:actions:",
+          "arity": 3
+        },
+        {
+          "selector": "denying:target:action:",
+          "arity": 3
+        },
+        {
+          "selector": "denying:target:actions:",
+          "arity": 3
+        },
+        {
+          "selector": "granting:target:action:",
+          "arity": 3
+        },
+        {
+          "selector": "granting:target:actions:",
+          "arity": 3
+        },
+        {
+          "selector": "name:target:action:",
+          "arity": 3
+        },
+        {
+          "selector": "name:target:actions:",
+          "arity": 3
+        }
+      ]
+    },
+    "PluggableAdaptor": {
+      "superclass": "ValueAdaptor",
+      "instanceSelectors": [
+        {
+          "selector": "getBlock:putBlock:",
+          "arity": 2
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "getBlock:putBlock:",
+          "arity": 2
+        },
+        {
+          "selector": "on:aspect:",
+          "arity": 2
+        },
+        {
+          "selector": "on:getSelector:putSelector:",
+          "arity": 3
+        },
+        {
+          "selector": "on:index:",
+          "arity": 2
+        },
+        {
+          "selector": "on:key:",
+          "arity": 2
+        }
+      ]
+    },
+    "PluggableProxy": {
+      "superclass": "AlternativeObjectProxy",
+      "instanceSelectors": [
+        {
+          "selector": "object",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "Point": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "abs",
+          "arity": 0
+        },
+        {
+          "selector": "arcTan",
+          "arity": 0
+        },
+        {
+          "selector": "asPoint",
+          "arity": 0
+        },
+        {
+          "selector": "asRectangle",
+          "arity": 0
+        },
+        {
+          "selector": "corner:",
+          "arity": 1
+        },
+        {
+          "selector": "dist:",
+          "arity": 1
+        },
+        {
+          "selector": "dotProduct:",
+          "arity": 1
+        },
+        {
+          "selector": "extent:",
+          "arity": 1
+        },
+        {
+          "selector": "grid:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "max:",
+          "arity": 1
+        },
+        {
+          "selector": "min:",
+          "arity": 1
+        },
+        {
+          "selector": "normal",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "rounded",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "transpose",
+          "arity": 0
+        },
+        {
+          "selector": "truncateTo:",
+          "arity": 1
+        },
+        {
+          "selector": "truncatedGrid:",
+          "arity": 1
+        },
+        {
+          "selector": "x",
+          "arity": 0
+        },
+        {
+          "selector": "x:",
+          "arity": 1
+        },
+        {
+          "selector": "x:y:",
+          "arity": 2
+        },
+        {
+          "selector": "y",
+          "arity": 0
+        },
+        {
+          "selector": "y:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "x:y:",
+          "arity": 2
+        }
+      ]
+    },
+    "PositionableStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "basicAtEnd",
+          "arity": 0
+        },
+        {
+          "selector": "basicPosition:",
+          "arity": 1
+        },
+        {
+          "selector": "beReadOnly",
+          "arity": 0
+        },
+        {
+          "selector": "beReadWrite",
+          "arity": 0
+        },
+        {
+          "selector": "beWriteOnly",
+          "arity": 0
+        },
+        {
+          "selector": "close",
+          "arity": 0
+        },
+        {
+          "selector": "collection",
+          "arity": 0
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "isExternalStream",
+          "arity": 0
+        },
+        {
+          "selector": "isPositionable",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "nextAvailable:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextAvailable:putAllOn:",
+          "arity": 2
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "position",
+          "arity": 0
+        },
+        {
+          "selector": "position:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "reset",
+          "arity": 0
+        },
+        {
+          "selector": "reverseContents",
+          "arity": 0
+        },
+        {
+          "selector": "setToEnd",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "skip:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "status:",
+          "arity": 1
+        },
+        {
+          "selector": "truncate",
+          "arity": 0
+        },
+        {
+          "selector": "upTo:",
+          "arity": 1
+        },
+        {
+          "selector": "upToEnd",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "on:from:to:",
+          "arity": 3
+        }
+      ]
+    },
+    "PrimitiveFailed": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Process": {
+      "superclass": "Link",
+      "instanceSelectors": [
+        {
+          "selector": "context",
+          "arity": 0
+        },
+        {
+          "selector": "debugger",
+          "arity": 0
+        },
+        {
+          "selector": "detach",
+          "arity": 0
+        },
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "evaluate:ifNotTerminated:",
+          "arity": 2
+        },
+        {
+          "selector": "externalInterruptsEnabled",
+          "arity": 0
+        },
+        {
+          "selector": "finalize",
+          "arity": 0
+        },
+        {
+          "selector": "interruptLock",
+          "arity": 0
+        },
+        {
+          "selector": "isActive",
+          "arity": 0
+        },
+        {
+          "selector": "isReady",
+          "arity": 0
+        },
+        {
+          "selector": "isSuspended",
+          "arity": 0
+        },
+        {
+          "selector": "isTerminated",
+          "arity": 0
+        },
+        {
+          "selector": "isWaiting",
+          "arity": 0
+        },
+        {
+          "selector": "lowerPriority",
+          "arity": 0
+        },
+        {
+          "selector": "makeUntrusted:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "onBlock:at:suspend:",
+          "arity": 3
+        },
+        {
+          "selector": "primTerminate",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "priority",
+          "arity": 0
+        },
+        {
+          "selector": "priority:",
+          "arity": 1
+        },
+        {
+          "selector": "queueInterrupt:",
+          "arity": 1
+        },
+        {
+          "selector": "raisePriority",
+          "arity": 0
+        },
+        {
+          "selector": "resume",
+          "arity": 0
+        },
+        {
+          "selector": "signalInterrupt:",
+          "arity": 1
+        },
+        {
+          "selector": "singleStep",
+          "arity": 0
+        },
+        {
+          "selector": "singleStepWaitingOn:",
+          "arity": 1
+        },
+        {
+          "selector": "startExecution:",
+          "arity": 1
+        },
+        {
+          "selector": "suspend",
+          "arity": 0
+        },
+        {
+          "selector": "suspendedContext",
+          "arity": 0
+        },
+        {
+          "selector": "suspendedContext:",
+          "arity": 1
+        },
+        {
+          "selector": "terminate",
+          "arity": 0
+        },
+        {
+          "selector": "terminateOnQuit",
+          "arity": 0
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        },
+        {
+          "selector": "valueWithoutInterrupts:",
+          "arity": 1
+        },
+        {
+          "selector": "yield",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:at:suspend:",
+          "arity": 3
+        }
+      ]
+    },
+    "ProcessBeingTerminated": {
+      "superclass": "Notification",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "semaphore",
+          "arity": 0
+        },
+        {
+          "selector": "semaphore:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "initialize",
+          "arity": 0
+        }
+      ]
+    },
+    "ProcessEnvironment": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "associationAt:",
+          "arity": 1
+        },
+        {
+          "selector": "associationAt:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifAbsentPut:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifPresent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "remove:",
+          "arity": 1
+        },
+        {
+          "selector": "remove:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeAllKeys:",
+          "arity": 1
+        },
+        {
+          "selector": "removeAllKeys:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "removeKey:",
+          "arity": 1
+        },
+        {
+          "selector": "removeKey:ifAbsent:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "uniqueInstance",
+          "arity": 0
+        }
+      ]
+    },
+    "ProcessTerminated": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "ProcessVariable": {
+      "superclass": "LookupKey",
+      "instanceSelectors": [
+        {
+          "selector": "environment",
+          "arity": 0
+        },
+        {
+          "selector": "use:during:",
+          "arity": 2
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        },
+        {
+          "selector": "valueIfAbsent:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "key:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "ProcessorScheduler": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "activeDebugger",
+          "arity": 0
+        },
+        {
+          "selector": "activePriority",
+          "arity": 0
+        },
+        {
+          "selector": "activeProcess",
+          "arity": 0
+        },
+        {
+          "selector": "disableInterrupts",
+          "arity": 0
+        },
+        {
+          "selector": "enableInterrupts",
+          "arity": 0
+        },
+        {
+          "selector": "highIOPriority",
+          "arity": 0
+        },
+        {
+          "selector": "highestPriority",
+          "arity": 0
+        },
+        {
+          "selector": "idle",
+          "arity": 0
+        },
+        {
+          "selector": "idleAdd:",
+          "arity": 1
+        },
+        {
+          "selector": "idlePriority",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isTimeoutProgrammed",
+          "arity": 0
+        },
+        {
+          "selector": "lowIOPriority",
+          "arity": 0
+        },
+        {
+          "selector": "lowestPriority",
+          "arity": 0
+        },
+        {
+          "selector": "pause:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "priorityName:",
+          "arity": 1
+        },
+        {
+          "selector": "processEnvironment",
+          "arity": 0
+        },
+        {
+          "selector": "processesAt:",
+          "arity": 1
+        },
+        {
+          "selector": "signal:atNanosecondClockValue:",
+          "arity": 2
+        },
+        {
+          "selector": "signal:onInterrupt:",
+          "arity": 2
+        },
+        {
+          "selector": "startFinalizers",
+          "arity": 0
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "systemBackgroundPriority",
+          "arity": 0
+        },
+        {
+          "selector": "terminateActive",
+          "arity": 0
+        },
+        {
+          "selector": "timeSlice",
+          "arity": 0
+        },
+        {
+          "selector": "timeSlice:",
+          "arity": 1
+        },
+        {
+          "selector": "timingPriority",
+          "arity": 0
+        },
+        {
+          "selector": "unpreemptedPriority",
+          "arity": 0
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        },
+        {
+          "selector": "userBackgroundPriority",
+          "arity": 0
+        },
+        {
+          "selector": "userInterruptPriority",
+          "arity": 0
+        },
+        {
+          "selector": "userSchedulingPriority",
+          "arity": 0
+        },
+        {
+          "selector": "yield",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "Promise": {
+      "superclass": "ValueHolder",
+      "instanceSelectors": [
+        {
+          "selector": "errorValue:",
+          "arity": 1
+        },
+        {
+          "selector": "hasError",
+          "arity": 0
+        },
+        {
+          "selector": "hasValue",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "for:",
+          "arity": 1
+        },
+        {
+          "selector": "null",
+          "arity": 0
+        }
+      ]
+    },
+    "Random": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "between:and:",
+          "arity": 2
+        },
+        {
+          "selector": "chiSquare",
+          "arity": 0
+        },
+        {
+          "selector": "chiSquare:range:",
+          "arity": 2
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "seed:",
+          "arity": 1
+        },
+        {
+          "selector": "setSeed",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "between:and:",
+          "arity": 2
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "seed:",
+          "arity": 1
+        },
+        {
+          "selector": "source",
+          "arity": 0
+        }
+      ]
+    },
+    "ReadOnlyObject": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "ReadStream": {
+      "superclass": "PositionableStream",
+      "instanceSelectors": [
+        {
+          "selector": "initCollection:limit:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "on:from:to:",
+          "arity": 3
+        }
+      ]
+    },
+    "ReadWriteStream": {
+      "superclass": "WriteStream",
+      "instanceSelectors": [
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "limit:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "on:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        }
+      ]
+    },
+    "Rectangle": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "amountToTranslateWithin:",
+          "arity": 1
+        },
+        {
+          "selector": "area",
+          "arity": 0
+        },
+        {
+          "selector": "areasOutside:",
+          "arity": 1
+        },
+        {
+          "selector": "bottom",
+          "arity": 0
+        },
+        {
+          "selector": "bottom:",
+          "arity": 1
+        },
+        {
+          "selector": "bottomCenter",
+          "arity": 0
+        },
+        {
+          "selector": "bottomLeft",
+          "arity": 0
+        },
+        {
+          "selector": "bottomLeft:",
+          "arity": 1
+        },
+        {
+          "selector": "bottomRight",
+          "arity": 0
+        },
+        {
+          "selector": "bottomRight:",
+          "arity": 1
+        },
+        {
+          "selector": "center",
+          "arity": 0
+        },
+        {
+          "selector": "contains:",
+          "arity": 1
+        },
+        {
+          "selector": "containsPoint:",
+          "arity": 1
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "corner",
+          "arity": 0
+        },
+        {
+          "selector": "corner:",
+          "arity": 1
+        },
+        {
+          "selector": "expandBy:",
+          "arity": 1
+        },
+        {
+          "selector": "extent",
+          "arity": 0
+        },
+        {
+          "selector": "extent:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "height",
+          "arity": 0
+        },
+        {
+          "selector": "height:",
+          "arity": 1
+        },
+        {
+          "selector": "insetBy:",
+          "arity": 1
+        },
+        {
+          "selector": "insetOriginBy:corner:",
+          "arity": 2
+        },
+        {
+          "selector": "intersect:",
+          "arity": 1
+        },
+        {
+          "selector": "intersects:",
+          "arity": 1
+        },
+        {
+          "selector": "left",
+          "arity": 0
+        },
+        {
+          "selector": "left:",
+          "arity": 1
+        },
+        {
+          "selector": "left:top:right:bottom:",
+          "arity": 4
+        },
+        {
+          "selector": "leftCenter",
+          "arity": 0
+        },
+        {
+          "selector": "merge:",
+          "arity": 1
+        },
+        {
+          "selector": "moveBy:",
+          "arity": 1
+        },
+        {
+          "selector": "moveTo:",
+          "arity": 1
+        },
+        {
+          "selector": "normalize",
+          "arity": 0
+        },
+        {
+          "selector": "normalized",
+          "arity": 0
+        },
+        {
+          "selector": "origin",
+          "arity": 0
+        },
+        {
+          "selector": "origin:",
+          "arity": 1
+        },
+        {
+          "selector": "origin:corner:",
+          "arity": 2
+        },
+        {
+          "selector": "origin:extent:",
+          "arity": 2
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "right",
+          "arity": 0
+        },
+        {
+          "selector": "right:",
+          "arity": 1
+        },
+        {
+          "selector": "rightCenter",
+          "arity": 0
+        },
+        {
+          "selector": "rounded",
+          "arity": 0
+        },
+        {
+          "selector": "scaleBy:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "top",
+          "arity": 0
+        },
+        {
+          "selector": "top:",
+          "arity": 1
+        },
+        {
+          "selector": "topCenter",
+          "arity": 0
+        },
+        {
+          "selector": "topLeft",
+          "arity": 0
+        },
+        {
+          "selector": "topLeft:",
+          "arity": 1
+        },
+        {
+          "selector": "topRight",
+          "arity": 0
+        },
+        {
+          "selector": "topRight:",
+          "arity": 1
+        },
+        {
+          "selector": "translateBy:",
+          "arity": 1
+        },
+        {
+          "selector": "translatedToBeWithin:",
+          "arity": 1
+        },
+        {
+          "selector": "width",
+          "arity": 0
+        },
+        {
+          "selector": "width:",
+          "arity": 1
+        },
+        {
+          "selector": "xCenter",
+          "arity": 0
+        },
+        {
+          "selector": "yCenter",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "left:right:top:bottom:",
+          "arity": 4
+        },
+        {
+          "selector": "left:top:right:bottom:",
+          "arity": 4
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "origin:corner:",
+          "arity": 2
+        },
+        {
+          "selector": "origin:extent:",
+          "arity": 2
+        }
+      ]
+    },
+    "RecursionLock": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "critical:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isOwnerProcess",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "waitingProcesses",
+          "arity": 0
+        },
+        {
+          "selector": "wouldBlock",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "RecursiveFileWrapper": {
+      "superclass": "VFS.FileWrapper",
+      "instanceSelectors": [
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "fileMode:directoryMode:",
+          "arity": 2
+        },
+        {
+          "selector": "isFileSystemPath",
+          "arity": 0
+        },
+        {
+          "selector": "lastAccessTime:lastModifyTime:",
+          "arity": 2
+        },
+        {
+          "selector": "mode:",
+          "arity": 1
+        },
+        {
+          "selector": "namesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "namesDo:prefixLength:",
+          "arity": 2
+        },
+        {
+          "selector": "owner:group:",
+          "arity": 2
+        },
+        {
+          "selector": "remove",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Regex": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "asRegex",
+          "arity": 0
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "displayString",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromString:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "RegexResults": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "asArray",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "from",
+          "arity": 0
+        },
+        {
+          "selector": "fromAt:",
+          "arity": 1
+        },
+        {
+          "selector": "ifMatched:",
+          "arity": 1
+        },
+        {
+          "selector": "ifMatched:ifNotMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotMatched:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNotMatched:ifMatched:",
+          "arity": 2
+        },
+        {
+          "selector": "intervalAt:",
+          "arity": 1
+        },
+        {
+          "selector": "match",
+          "arity": 0
+        },
+        {
+          "selector": "matchInterval",
+          "arity": 0
+        },
+        {
+          "selector": "matched",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "subject",
+          "arity": 0
+        },
+        {
+          "selector": "to",
+          "arity": 0
+        },
+        {
+          "selector": "toAt:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "RootNamespace": {
+      "superclass": "AbstractNamespace",
+      "instanceSelectors": [
+        {
+          "selector": "inheritedKeys",
+          "arity": 0
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "set:to:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "siblings",
+          "arity": 0
+        },
+        {
+          "selector": "siblingsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "RoundRobinStream": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "stream",
+          "arity": 0
+        },
+        {
+          "selector": "stream:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "test:get:",
+          "arity": 2
+        },
+        {
+          "selector": "test:leaveAfter:",
+          "arity": 2
+        },
+        {
+          "selector": "testOn:",
+          "arity": 1
+        }
+      ]
+    },
+    "RunArray": {
+      "superclass": "OrderedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "add:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAllFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addAllLast:",
+          "arity": 1
+        },
+        {
+          "selector": "addFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addLast:",
+          "arity": 1
+        },
+        {
+          "selector": "afterMapIndexAdd:copiesOf:",
+          "arity": 2
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "at:splitAndPut:decrementBy:",
+          "arity": 3
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "indexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "map",
+          "arity": 0
+        },
+        {
+          "selector": "map:",
+          "arity": 1
+        },
+        {
+          "selector": "objectsAndRunLengthsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "packTwoRuns:",
+          "arity": 1
+        },
+        {
+          "selector": "removeAtIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "removeFirst",
+          "arity": 0
+        },
+        {
+          "selector": "removeLast",
+          "arity": 0
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "splitAt:decrementBy:",
+          "arity": 2
+        },
+        {
+          "selector": "updateMapIndexFor:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "ScaledDecimal": {
+      "superclass": "Number",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "asFraction",
+          "arity": 0
+        },
+        {
+          "selector": "ceiling",
+          "arity": 0
+        },
+        {
+          "selector": "coerce:",
+          "arity": 1
+        },
+        {
+          "selector": "compare:",
+          "arity": 1
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "fraction",
+          "arity": 0
+        },
+        {
+          "selector": "fractionPart",
+          "arity": 0
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "integerPart",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "one",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "scale",
+          "arity": 0
+        },
+        {
+          "selector": "setFraction:scale:",
+          "arity": 2
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "truncated",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "newFromNumber:scale:",
+          "arity": 2
+        }
+      ]
+    },
+    "SecurityError": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "failedPermission",
+          "arity": 0
+        },
+        {
+          "selector": "failedPermission:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signal:",
+          "arity": 1
+        }
+      ]
+    },
+    "SecurityPolicy": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "addPermission:",
+          "arity": 1
+        },
+        {
+          "selector": "check:",
+          "arity": 1
+        },
+        {
+          "selector": "implies:",
+          "arity": 1
+        },
+        {
+          "selector": "owner:",
+          "arity": 1
+        },
+        {
+          "selector": "removePermission:",
+          "arity": 1
+        },
+        {
+          "selector": "withOwner:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "Semaphore": {
+      "superclass": "LinkedList",
+      "instanceSelectors": [
+        {
+          "selector": "critical:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "lock",
+          "arity": 0
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "name:",
+          "arity": 1
+        },
+        {
+          "selector": "notify",
+          "arity": 0
+        },
+        {
+          "selector": "notifyAll",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "signal",
+          "arity": 0
+        },
+        {
+          "selector": "signals",
+          "arity": 0
+        },
+        {
+          "selector": "wait",
+          "arity": 0
+        },
+        {
+          "selector": "waitAfterSignalling:",
+          "arity": 1
+        },
+        {
+          "selector": "waitingProcesses",
+          "arity": 0
+        },
+        {
+          "selector": "wouldBlock",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "forMutualExclusion",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "SequenceableCollection": {
+      "superclass": "Collection",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "after:",
+          "arity": 1
+        },
+        {
+          "selector": "allButFirst",
+          "arity": 0
+        },
+        {
+          "selector": "allButFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "allButLast",
+          "arity": 0
+        },
+        {
+          "selector": "allButLast:",
+          "arity": 1
+        },
+        {
+          "selector": "anyOne",
+          "arity": 0
+        },
+        {
+          "selector": "asRunArrayMap",
+          "arity": 0
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "atAll:",
+          "arity": 1
+        },
+        {
+          "selector": "atAll:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atAllPut:",
+          "arity": 1
+        },
+        {
+          "selector": "atRandom",
+          "arity": 0
+        },
+        {
+          "selector": "before:",
+          "arity": 1
+        },
+        {
+          "selector": "copyAfter:",
+          "arity": 1
+        },
+        {
+          "selector": "copyAfterLast:",
+          "arity": 1
+        },
+        {
+          "selector": "copyFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "copyFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "copyReplaceAll:with:",
+          "arity": 2
+        },
+        {
+          "selector": "copyReplaceFrom:to:with:",
+          "arity": 3
+        },
+        {
+          "selector": "copyReplaceFrom:to:withObject:",
+          "arity": 3
+        },
+        {
+          "selector": "copyUpTo:",
+          "arity": 1
+        },
+        {
+          "selector": "copyUpToLast:",
+          "arity": 1
+        },
+        {
+          "selector": "copyWithFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "countSubCollectionOccurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "do:separatedBy:",
+          "arity": 2
+        },
+        {
+          "selector": "doWithIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "endsWith:",
+          "arity": 1
+        },
+        {
+          "selector": "examineOn:",
+          "arity": 1
+        },
+        {
+          "selector": "findFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "findLast:",
+          "arity": 1
+        },
+        {
+          "selector": "first",
+          "arity": 0
+        },
+        {
+          "selector": "first:",
+          "arity": 1
+        },
+        {
+          "selector": "fold:",
+          "arity": 1
+        },
+        {
+          "selector": "fourth",
+          "arity": 0
+        },
+        {
+          "selector": "from:to:do:",
+          "arity": 3
+        },
+        {
+          "selector": "from:to:doWithIndex:",
+          "arity": 3
+        },
+        {
+          "selector": "from:to:keysAndValuesDo:",
+          "arity": 3
+        },
+        {
+          "selector": "growSize",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "identityIncludes:",
+          "arity": 1
+        },
+        {
+          "selector": "identityIndexOf:",
+          "arity": 1
+        },
+        {
+          "selector": "identityIndexOf:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "identityIndexOf:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "identityIndexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "identityIndexOfLast:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOf:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOf:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOf:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "indexOfLast:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOfSubCollection:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOfSubCollection:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOfSubCollection:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOfSubCollection:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "isSequenceable",
+          "arity": 0
+        },
+        {
+          "selector": "join:",
+          "arity": 1
+        },
+        {
+          "selector": "keys",
+          "arity": 0
+        },
+        {
+          "selector": "keysAndValuesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "last:",
+          "arity": 1
+        },
+        {
+          "selector": "matchSubCollection:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "readWriteStream",
+          "arity": 0
+        },
+        {
+          "selector": "replaceAll:with:",
+          "arity": 2
+        },
+        {
+          "selector": "replaceFrom:to:with:",
+          "arity": 3
+        },
+        {
+          "selector": "replaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "replaceFrom:to:withObject:",
+          "arity": 3
+        },
+        {
+          "selector": "reverse",
+          "arity": 0
+        },
+        {
+          "selector": "reverseDo:",
+          "arity": 1
+        },
+        {
+          "selector": "second",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "sort",
+          "arity": 0
+        },
+        {
+          "selector": "sort:",
+          "arity": 1
+        },
+        {
+          "selector": "sorted",
+          "arity": 0
+        },
+        {
+          "selector": "sorted:",
+          "arity": 1
+        },
+        {
+          "selector": "startsWith:",
+          "arity": 1
+        },
+        {
+          "selector": "swap:with:",
+          "arity": 2
+        },
+        {
+          "selector": "third",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:collect:",
+          "arity": 2
+        },
+        {
+          "selector": "with:do:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "join:separatedBy:",
+          "arity": 2
+        }
+      ]
+    },
+    "Set": {
+      "superclass": "HashedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "&",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findObjectIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "SharedQueue": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "init:",
+          "arity": 1
+        },
+        {
+          "selector": "isEmpty",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "sortBlock:",
+          "arity": 1
+        }
+      ]
+    },
+    "ShouldNotImplement": {
+      "superclass": "NotImplemented",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "SingletonProxy": {
+      "superclass": "AlternativeObjectProxy",
+      "instanceSelectors": [
+        {
+          "selector": "object",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "acceptUsageForClass:",
+          "arity": 1
+        },
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "singletons",
+          "arity": 0
+        }
+      ]
+    },
+    "SmallInteger": {
+      "superclass": "Integer",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        },
+        {
+          "selector": "+",
+          "arity": 1
+        },
+        {
+          "selector": "-",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "//",
+          "arity": 1
+        },
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "<=",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "==",
+          "arity": 1
+        },
+        {
+          "selector": ">",
+          "arity": 1
+        },
+        {
+          "selector": ">=",
+          "arity": 1
+        },
+        {
+          "selector": "\\\\",
+          "arity": 1
+        },
+        {
+          "selector": "asCNumber",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatD",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatE",
+          "arity": 0
+        },
+        {
+          "selector": "asFloatQ",
+          "arity": 0
+        },
+        {
+          "selector": "asObject",
+          "arity": 0
+        },
+        {
+          "selector": "asObjectNoFail",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicAt:",
+          "arity": 1
+        },
+        {
+          "selector": "basicAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "bitAnd:",
+          "arity": 1
+        },
+        {
+          "selector": "bitOr:",
+          "arity": 1
+        },
+        {
+          "selector": "bitShift:",
+          "arity": 1
+        },
+        {
+          "selector": "bitXor:",
+          "arity": 1
+        },
+        {
+          "selector": "divExact:",
+          "arity": 1
+        },
+        {
+          "selector": "generality",
+          "arity": 0
+        },
+        {
+          "selector": "highBit",
+          "arity": 0
+        },
+        {
+          "selector": "isSmallInteger",
+          "arity": 0
+        },
+        {
+          "selector": "lowBit",
+          "arity": 0
+        },
+        {
+          "selector": "nextValidOop",
+          "arity": 0
+        },
+        {
+          "selector": "quo:",
+          "arity": 1
+        },
+        {
+          "selector": "scramble",
+          "arity": 0
+        },
+        {
+          "selector": "unity",
+          "arity": 0
+        },
+        {
+          "selector": "zero",
+          "arity": 0
+        },
+        {
+          "selector": "~=",
+          "arity": 1
+        },
+        {
+          "selector": "~~",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "bits",
+          "arity": 0
+        },
+        {
+          "selector": "isIdentity",
+          "arity": 0
+        },
+        {
+          "selector": "largest",
+          "arity": 0
+        },
+        {
+          "selector": "smallest",
+          "arity": 0
+        }
+      ]
+    },
+    "SortedCollection": {
+      "superclass": "OrderedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "add:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAll:afterIndex:",
+          "arity": 2
+        },
+        {
+          "selector": "addAllFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addAllLast:",
+          "arity": 1
+        },
+        {
+          "selector": "addFirst:",
+          "arity": 1
+        },
+        {
+          "selector": "addLast:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicRemoveAtIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "basicSwap:ifAfter:",
+          "arity": 2
+        },
+        {
+          "selector": "basicSwap:ifBefore:",
+          "arity": 2
+        },
+        {
+          "selector": "basicSwap:with:",
+          "arity": 2
+        },
+        {
+          "selector": "beConsistent",
+          "arity": 0
+        },
+        {
+          "selector": "binarySearch:low:high:",
+          "arity": 3
+        },
+        {
+          "selector": "buildHeap",
+          "arity": 0
+        },
+        {
+          "selector": "compare:with:",
+          "arity": 2
+        },
+        {
+          "selector": "copyEmpty:",
+          "arity": 1
+        },
+        {
+          "selector": "copyEmptyForCollect",
+          "arity": 0
+        },
+        {
+          "selector": "copyEmptyForCollect:",
+          "arity": 1
+        },
+        {
+          "selector": "doBinarySearch:low:high:",
+          "arity": 3
+        },
+        {
+          "selector": "includes:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "initIndices",
+          "arity": 0
+        },
+        {
+          "selector": "insertionIndexFor:upTo:",
+          "arity": 2
+        },
+        {
+          "selector": "last",
+          "arity": 0
+        },
+        {
+          "selector": "makeHeap",
+          "arity": 0
+        },
+        {
+          "selector": "makeRoomLastFor:",
+          "arity": 1
+        },
+        {
+          "selector": "median:median:median:",
+          "arity": 3
+        },
+        {
+          "selector": "merge",
+          "arity": 0
+        },
+        {
+          "selector": "occurrencesOf:",
+          "arity": 1
+        },
+        {
+          "selector": "percolateDown",
+          "arity": 0
+        },
+        {
+          "selector": "percolateUp",
+          "arity": 0
+        },
+        {
+          "selector": "postLoad",
+          "arity": 0
+        },
+        {
+          "selector": "preStore",
+          "arity": 0
+        },
+        {
+          "selector": "removeLast",
+          "arity": 0
+        },
+        {
+          "selector": "setSortBlock:",
+          "arity": 1
+        },
+        {
+          "selector": "sort",
+          "arity": 0
+        },
+        {
+          "selector": "sort:",
+          "arity": 1
+        },
+        {
+          "selector": "sortBlock",
+          "arity": 0
+        },
+        {
+          "selector": "sortBlock:",
+          "arity": 1
+        },
+        {
+          "selector": "sortFrom:to:",
+          "arity": 2
+        },
+        {
+          "selector": "sortHeap",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "defaultSortBlock",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "sortBlock:",
+          "arity": 1
+        }
+      ]
+    },
+    "StarPackage": {
+      "superclass": "PackageInfo",
+      "instanceSelectors": [
+        {
+          "selector": "builtFiles",
+          "arity": 0
+        },
+        {
+          "selector": "callouts",
+          "arity": 0
+        },
+        {
+          "selector": "directory",
+          "arity": 0
+        },
+        {
+          "selector": "features",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "file:",
+          "arity": 1
+        },
+        {
+          "selector": "fileIns",
+          "arity": 0
+        },
+        {
+          "selector": "fileName",
+          "arity": 0
+        },
+        {
+          "selector": "files",
+          "arity": 0
+        },
+        {
+          "selector": "fullPathOf:",
+          "arity": 1
+        },
+        {
+          "selector": "libraries",
+          "arity": 0
+        },
+        {
+          "selector": "loadedPackage",
+          "arity": 0
+        },
+        {
+          "selector": "modules",
+          "arity": 0
+        },
+        {
+          "selector": "namespace",
+          "arity": 0
+        },
+        {
+          "selector": "prerequisites",
+          "arity": 0
+        },
+        {
+          "selector": "primFileIn",
+          "arity": 0
+        },
+        {
+          "selector": "relativeDirectory",
+          "arity": 0
+        },
+        {
+          "selector": "startScript",
+          "arity": 0
+        },
+        {
+          "selector": "stopScript",
+          "arity": 0
+        },
+        {
+          "selector": "sunitScripts",
+          "arity": 0
+        },
+        {
+          "selector": "test",
+          "arity": 0
+        },
+        {
+          "selector": "url",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "file:",
+          "arity": 1
+        }
+      ]
+    },
+    "Stat": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "stAtime",
+          "arity": 0
+        },
+        {
+          "selector": "stCtime",
+          "arity": 0
+        },
+        {
+          "selector": "stMode",
+          "arity": 0
+        },
+        {
+          "selector": "stMtime",
+          "arity": 0
+        },
+        {
+          "selector": "stSize",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "StoredZipMember": {
+      "superclass": "TmpFileArchiveMember",
+      "instanceSelectors": [
+        {
+          "selector": "offset",
+          "arity": 0
+        },
+        {
+          "selector": "offset:",
+          "arity": 1
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        }
+      ],
+      "classSelectors": []
+    },
+    "Stream": {
+      "superclass": "Iterable",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "<<",
+          "arity": 1
+        },
+        {
+          "selector": "atEnd",
+          "arity": 0
+        },
+        {
+          "selector": "close",
+          "arity": 0
+        },
+        {
+          "selector": "collect:",
+          "arity": 1
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "cr",
+          "arity": 0
+        },
+        {
+          "selector": "crTab",
+          "arity": 0
+        },
+        {
+          "selector": "display:",
+          "arity": 1
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "encoding",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "fileIn",
+          "arity": 0
+        },
+        {
+          "selector": "fileInLine:file:at:",
+          "arity": 3
+        },
+        {
+          "selector": "fileInLine:file:fileName:at:",
+          "arity": 4
+        },
+        {
+          "selector": "fileInLine:fileName:at:",
+          "arity": 3
+        },
+        {
+          "selector": "fileOut:",
+          "arity": 1
+        },
+        {
+          "selector": "flush",
+          "arity": 0
+        },
+        {
+          "selector": "isExternalStream",
+          "arity": 0
+        },
+        {
+          "selector": "isPositionable",
+          "arity": 0
+        },
+        {
+          "selector": "isSequenceable",
+          "arity": 0
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        },
+        {
+          "selector": "lines",
+          "arity": 0
+        },
+        {
+          "selector": "linesDo:",
+          "arity": 1
+        },
+        {
+          "selector": "name",
+          "arity": 0
+        },
+        {
+          "selector": "next",
+          "arity": 0
+        },
+        {
+          "selector": "next:",
+          "arity": 1
+        },
+        {
+          "selector": "next:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "next:put:",
+          "arity": 2
+        },
+        {
+          "selector": "next:putAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "next:putAllOn:",
+          "arity": 2
+        },
+        {
+          "selector": "nextAvailable:",
+          "arity": 1
+        },
+        {
+          "selector": "nextAvailable:into:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextAvailable:putAllOn:",
+          "arity": 2
+        },
+        {
+          "selector": "nextAvailablePutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "nextLine",
+          "arity": 0
+        },
+        {
+          "selector": "nextMatchFor:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutAll:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutAllFlush:",
+          "arity": 1
+        },
+        {
+          "selector": "nextPutAllOn:",
+          "arity": 1
+        },
+        {
+          "selector": "nl",
+          "arity": 0
+        },
+        {
+          "selector": "nlTab",
+          "arity": 0
+        },
+        {
+          "selector": "pastEnd",
+          "arity": 0
+        },
+        {
+          "selector": "peek",
+          "arity": 0
+        },
+        {
+          "selector": "peekFor:",
+          "arity": 1
+        },
+        {
+          "selector": "prefixTableFor:",
+          "arity": 1
+        },
+        {
+          "selector": "print:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "reject:",
+          "arity": 1
+        },
+        {
+          "selector": "select:",
+          "arity": 1
+        },
+        {
+          "selector": "skip:",
+          "arity": 1
+        },
+        {
+          "selector": "skipSeparators",
+          "arity": 0
+        },
+        {
+          "selector": "skipTo:",
+          "arity": 1
+        },
+        {
+          "selector": "skipToAll:",
+          "arity": 1
+        },
+        {
+          "selector": "space",
+          "arity": 0
+        },
+        {
+          "selector": "space:",
+          "arity": 1
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "splitAt:",
+          "arity": 1
+        },
+        {
+          "selector": "store:",
+          "arity": 1
+        },
+        {
+          "selector": "tab",
+          "arity": 0
+        },
+        {
+          "selector": "tab:",
+          "arity": 1
+        },
+        {
+          "selector": "upTo:",
+          "arity": 1
+        },
+        {
+          "selector": "upToAll:",
+          "arity": 1
+        },
+        {
+          "selector": "upToEnd",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        }
+      ],
+      "classSelectors": []
+    },
+    "String": {
+      "superclass": "CharacterArray",
+      "instanceSelectors": [
+        {
+          "selector": ",",
+          "arity": 1
+        },
+        {
+          "selector": "/",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "=~",
+          "arity": 1
+        },
+        {
+          "selector": "allOccurrencesOfRegex:",
+          "arity": 1
+        },
+        {
+          "selector": "allOccurrencesOfRegex:do:",
+          "arity": 2
+        },
+        {
+          "selector": "allOccurrencesOfRegex:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "allOccurrencesOfRegex:from:to:do:",
+          "arity": 4
+        },
+        {
+          "selector": "asByteArray",
+          "arity": 0
+        },
+        {
+          "selector": "asCData",
+          "arity": 0
+        },
+        {
+          "selector": "asCData:",
+          "arity": 1
+        },
+        {
+          "selector": "asFile",
+          "arity": 0
+        },
+        {
+          "selector": "asRegex",
+          "arity": 0
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "basicAt:",
+          "arity": 1
+        },
+        {
+          "selector": "basicAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "byteAt:",
+          "arity": 1
+        },
+        {
+          "selector": "byteAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "copyFrom:to:replacingAllRegex:with:",
+          "arity": 4
+        },
+        {
+          "selector": "copyFrom:to:replacingRegex:with:",
+          "arity": 4
+        },
+        {
+          "selector": "copyReplacingAllRegex:with:",
+          "arity": 2
+        },
+        {
+          "selector": "copyReplacingRegex:with:",
+          "arity": 2
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "displayString",
+          "arity": 0
+        },
+        {
+          "selector": "encoding",
+          "arity": 0
+        },
+        {
+          "selector": "escapeRegex",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "indexOf:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOf:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "indexOfRegex:",
+          "arity": 1
+        },
+        {
+          "selector": "indexOfRegex:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "indexOfRegex:from:to:ifAbsent:",
+          "arity": 4
+        },
+        {
+          "selector": "indexOfRegex:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOfRegex:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "indexOfRegex:startingAt:ifAbsent:",
+          "arity": 3
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "isString",
+          "arity": 0
+        },
+        {
+          "selector": "lengthOfRegexMatch:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "matchRegex:",
+          "arity": 1
+        },
+        {
+          "selector": "matchRegex:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "occurrencesOfRegex:",
+          "arity": 1
+        },
+        {
+          "selector": "occurrencesOfRegex:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "occurrencesOfRegex:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "onOccurrencesOfRegex:do:",
+          "arity": 2
+        },
+        {
+          "selector": "onOccurrencesOfRegex:from:to:do:",
+          "arity": 4
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "replaceFrom:to:with:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "replaceFrom:to:withByteArray:startingAt:",
+          "arity": 4
+        },
+        {
+          "selector": "replacingAllRegex:with:",
+          "arity": 2
+        },
+        {
+          "selector": "replacingRegex:with:",
+          "arity": 2
+        },
+        {
+          "selector": "searchRegex:",
+          "arity": 1
+        },
+        {
+          "selector": "searchRegex:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "searchRegex:startingAt:",
+          "arity": 2
+        },
+        {
+          "selector": "searchRegexInternal:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "similarityTo:",
+          "arity": 1
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "tokenize:",
+          "arity": 1
+        },
+        {
+          "selector": "tokenize:from:to:",
+          "arity": 3
+        },
+        {
+          "selector": "~",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromCData:",
+          "arity": 1
+        },
+        {
+          "selector": "fromCData:size:",
+          "arity": 2
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        }
+      ]
+    },
+    "SubclassResponsibility": {
+      "superclass": "ShouldNotImplement",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "SymLink": {
+      "superclass": "Link",
+      "instanceSelectors": [
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "symbol",
+          "arity": 0
+        },
+        {
+          "selector": "symbol:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "symbol:nextLink:",
+          "arity": 2
+        }
+      ]
+    },
+    "Symbol": {
+      "superclass": "String",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "displayString",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "implementors",
+          "arity": 0
+        },
+        {
+          "selector": "isSimpleSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "isString",
+          "arity": 0
+        },
+        {
+          "selector": "isSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "keywords",
+          "arity": 0
+        },
+        {
+          "selector": "numArgs",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "hasInterned:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "intern:",
+          "arity": 1
+        },
+        {
+          "selector": "internCharacter:",
+          "arity": 1
+        },
+        {
+          "selector": "isSymbolString:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        },
+        {
+          "selector": "rebuildTable",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:with:",
+          "arity": 2
+        },
+        {
+          "selector": "with:with:with:",
+          "arity": 3
+        },
+        {
+          "selector": "with:with:with:with:",
+          "arity": 4
+        },
+        {
+          "selector": "with:with:with:with:with:",
+          "arity": 5
+        }
+      ]
+    },
+    "SystemDictionary": {
+      "superclass": "RootNamespace",
+      "instanceSelectors": [
+        {
+          "selector": "addFeature:",
+          "arity": 1
+        },
+        {
+          "selector": "arguments",
+          "arity": 0
+        },
+        {
+          "selector": "arguments:do:",
+          "arity": 2
+        },
+        {
+          "selector": "arguments:do:ifError:",
+          "arity": 3
+        },
+        {
+          "selector": "backtrace",
+          "arity": 0
+        },
+        {
+          "selector": "basicBacktrace",
+          "arity": 0
+        },
+        {
+          "selector": "byteCodeCounter",
+          "arity": 0
+        },
+        {
+          "selector": "debug",
+          "arity": 0
+        },
+        {
+          "selector": "declarationTrace",
+          "arity": 0
+        },
+        {
+          "selector": "declarationTrace:",
+          "arity": 1
+        },
+        {
+          "selector": "environ",
+          "arity": 0
+        },
+        {
+          "selector": "executionTrace",
+          "arity": 0
+        },
+        {
+          "selector": "executionTrace:",
+          "arity": 1
+        },
+        {
+          "selector": "getArgc",
+          "arity": 0
+        },
+        {
+          "selector": "getArgv:",
+          "arity": 1
+        },
+        {
+          "selector": "getTraceFlag:",
+          "arity": 1
+        },
+        {
+          "selector": "getenv:",
+          "arity": 1
+        },
+        {
+          "selector": "halt",
+          "arity": 0
+        },
+        {
+          "selector": "hasFeatures:",
+          "arity": 1
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hostSystem",
+          "arity": 0
+        },
+        {
+          "selector": "imageLocal",
+          "arity": 0
+        },
+        {
+          "selector": "isSmalltalk",
+          "arity": 0
+        },
+        {
+          "selector": "nameIn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "putenv:",
+          "arity": 1
+        },
+        {
+          "selector": "rawProfile:",
+          "arity": 1
+        },
+        {
+          "selector": "removeFeature:",
+          "arity": 1
+        },
+        {
+          "selector": "setTraceFlag:to:",
+          "arity": 2
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "system:",
+          "arity": 1
+        },
+        {
+          "selector": "system:withArguments:",
+          "arity": 2
+        },
+        {
+          "selector": "verboseTrace",
+          "arity": 0
+        },
+        {
+          "selector": "verboseTrace:",
+          "arity": 1
+        },
+        {
+          "selector": "version",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "initialize",
+          "arity": 0
+        }
+      ]
+    },
+    "TestPackage": {
+      "superclass": "Smalltalk.Package",
+      "instanceSelectors": [
+        {
+          "selector": "baseDirectories",
+          "arity": 0
+        },
+        {
+          "selector": "namespace",
+          "arity": 0
+        },
+        {
+          "selector": "owner:",
+          "arity": 1
+        },
+        {
+          "selector": "url",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "TextCollector": {
+      "superclass": "Stream",
+      "instanceSelectors": [
+        {
+          "selector": "cr",
+          "arity": 0
+        },
+        {
+          "selector": "critical:",
+          "arity": 1
+        },
+        {
+          "selector": "endEntry",
+          "arity": 0
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "message",
+          "arity": 0
+        },
+        {
+          "selector": "message:",
+          "arity": 1
+        },
+        {
+          "selector": "next:put:",
+          "arity": 2
+        },
+        {
+          "selector": "next:putAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "primNextPutAll:",
+          "arity": 1
+        },
+        {
+          "selector": "print:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "show:",
+          "arity": 1
+        },
+        {
+          "selector": "showCr:",
+          "arity": 1
+        },
+        {
+          "selector": "showOnNewLine:",
+          "arity": 1
+        },
+        {
+          "selector": "store:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "message:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "Time": {
+      "superclass": "Magnitude",
+      "instanceSelectors": [
+        {
+          "selector": "<",
+          "arity": 1
+        },
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "addSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "addTime:",
+          "arity": 1
+        },
+        {
+          "selector": "asMilliseconds",
+          "arity": 0
+        },
+        {
+          "selector": "asNanoseconds",
+          "arity": 0
+        },
+        {
+          "selector": "asSeconds",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "hour",
+          "arity": 0
+        },
+        {
+          "selector": "hour12",
+          "arity": 0
+        },
+        {
+          "selector": "hour24",
+          "arity": 0
+        },
+        {
+          "selector": "hours",
+          "arity": 0
+        },
+        {
+          "selector": "minute",
+          "arity": 0
+        },
+        {
+          "selector": "minutes",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "second",
+          "arity": 0
+        },
+        {
+          "selector": "seconds",
+          "arity": 0
+        },
+        {
+          "selector": "setSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "subtractTime:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromSeconds:",
+          "arity": 1
+        },
+        {
+          "selector": "hour:",
+          "arity": 1
+        },
+        {
+          "selector": "hour:minute:second:",
+          "arity": 3
+        },
+        {
+          "selector": "hours:",
+          "arity": 1
+        },
+        {
+          "selector": "hours:minutes:seconds:",
+          "arity": 3
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "midnight",
+          "arity": 0
+        },
+        {
+          "selector": "millisecondClock",
+          "arity": 0
+        },
+        {
+          "selector": "millisecondClockValue",
+          "arity": 0
+        },
+        {
+          "selector": "millisecondsPerDay",
+          "arity": 0
+        },
+        {
+          "selector": "millisecondsToRun:",
+          "arity": 1
+        },
+        {
+          "selector": "minute:",
+          "arity": 1
+        },
+        {
+          "selector": "minutes:",
+          "arity": 1
+        },
+        {
+          "selector": "nanosecondClock",
+          "arity": 0
+        },
+        {
+          "selector": "nanosecondClockValue",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "now",
+          "arity": 0
+        },
+        {
+          "selector": "primNanosecondClock",
+          "arity": 0
+        },
+        {
+          "selector": "primSecondClock",
+          "arity": 0
+        },
+        {
+          "selector": "readFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "second:",
+          "arity": 1
+        },
+        {
+          "selector": "secondClock",
+          "arity": 0
+        },
+        {
+          "selector": "seconds:",
+          "arity": 1
+        },
+        {
+          "selector": "timezone",
+          "arity": 0
+        },
+        {
+          "selector": "timezoneBias",
+          "arity": 0
+        },
+        {
+          "selector": "timezoneBias:",
+          "arity": 1
+        },
+        {
+          "selector": "update:",
+          "arity": 1
+        },
+        {
+          "selector": "utcNow",
+          "arity": 0
+        },
+        {
+          "selector": "utcSecondClock",
+          "arity": 0
+        }
+      ]
+    },
+    "TimeoutNotification": {
+      "superclass": "Notification",
+      "instanceSelectors": [
+        {
+          "selector": "defaultAction",
+          "arity": 0
+        },
+        {
+          "selector": "delay",
+          "arity": 0
+        },
+        {
+          "selector": "delay:",
+          "arity": 1
+        },
+        {
+          "selector": "isResumable",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        }
+      ]
+    },
+    "TmpFileArchiveMember": {
+      "superclass": "ArchiveMember",
+      "instanceSelectors": [
+        {
+          "selector": "extracted",
+          "arity": 0
+        },
+        {
+          "selector": "file",
+          "arity": 0
+        },
+        {
+          "selector": "open:mode:ifFail:",
+          "arity": 3
+        },
+        {
+          "selector": "release",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "True": {
+      "superclass": "Boolean",
+      "instanceSelectors": [
+        {
+          "selector": "&",
+          "arity": 1
+        },
+        {
+          "selector": "and:",
+          "arity": 1
+        },
+        {
+          "selector": "asCBooleanValue",
+          "arity": 0
+        },
+        {
+          "selector": "eqv:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:",
+          "arity": 1
+        },
+        {
+          "selector": "ifFalse:ifTrue:",
+          "arity": 2
+        },
+        {
+          "selector": "ifTrue:",
+          "arity": 1
+        },
+        {
+          "selector": "ifTrue:ifFalse:",
+          "arity": 2
+        },
+        {
+          "selector": "not",
+          "arity": 0
+        },
+        {
+          "selector": "or:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "xor:",
+          "arity": 1
+        },
+        {
+          "selector": "|",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "URIResolver": {
+      "superclass": "Object",
+      "instanceSelectors": [],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "openOn:",
+          "arity": 1
+        },
+        {
+          "selector": "openOn:ifFail:",
+          "arity": 2
+        },
+        {
+          "selector": "openStreamOn:",
+          "arity": 1
+        },
+        {
+          "selector": "openStreamOn:ifFail:",
+          "arity": 2
+        },
+        {
+          "selector": "resolve:from:",
+          "arity": 2
+        }
+      ]
+    },
+    "URL": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "=",
+          "arity": 1
+        },
+        {
+          "selector": "add:to:value:",
+          "arity": 3
+        },
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "canCache",
+          "arity": 0
+        },
+        {
+          "selector": "clearAuxiliaryParts",
+          "arity": 0
+        },
+        {
+          "selector": "clearFragment",
+          "arity": 0
+        },
+        {
+          "selector": "construct:",
+          "arity": 1
+        },
+        {
+          "selector": "constructPath:with:",
+          "arity": 2
+        },
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "copyWithoutAuxiliaryParts",
+          "arity": 0
+        },
+        {
+          "selector": "copyWithoutFragment",
+          "arity": 0
+        },
+        {
+          "selector": "decodedFields",
+          "arity": 0
+        },
+        {
+          "selector": "decodedFile",
+          "arity": 0
+        },
+        {
+          "selector": "decodedFragment",
+          "arity": 0
+        },
+        {
+          "selector": "entity",
+          "arity": 0
+        },
+        {
+          "selector": "fragment",
+          "arity": 0
+        },
+        {
+          "selector": "fragment:",
+          "arity": 1
+        },
+        {
+          "selector": "fullRequestString",
+          "arity": 0
+        },
+        {
+          "selector": "hasFragment",
+          "arity": 0
+        },
+        {
+          "selector": "hasPostData",
+          "arity": 0
+        },
+        {
+          "selector": "hasPostData:",
+          "arity": 1
+        },
+        {
+          "selector": "hasQuery",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "host",
+          "arity": 0
+        },
+        {
+          "selector": "host:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "isFileScheme",
+          "arity": 0
+        },
+        {
+          "selector": "isFragmentOnly",
+          "arity": 0
+        },
+        {
+          "selector": "newsGroup",
+          "arity": 0
+        },
+        {
+          "selector": "password",
+          "arity": 0
+        },
+        {
+          "selector": "password:",
+          "arity": 1
+        },
+        {
+          "selector": "path",
+          "arity": 0
+        },
+        {
+          "selector": "path:",
+          "arity": 1
+        },
+        {
+          "selector": "port",
+          "arity": 0
+        },
+        {
+          "selector": "port:",
+          "arity": 1
+        },
+        {
+          "selector": "postCopy",
+          "arity": 0
+        },
+        {
+          "selector": "postData",
+          "arity": 0
+        },
+        {
+          "selector": "postData:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "query",
+          "arity": 0
+        },
+        {
+          "selector": "query:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "requestString",
+          "arity": 0
+        },
+        {
+          "selector": "resolvePath:",
+          "arity": 1
+        },
+        {
+          "selector": "scheme",
+          "arity": 0
+        },
+        {
+          "selector": "scheme:",
+          "arity": 1
+        },
+        {
+          "selector": "username",
+          "arity": 0
+        },
+        {
+          "selector": "username:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "decode:",
+          "arity": 1
+        },
+        {
+          "selector": "encode:",
+          "arity": 1
+        },
+        {
+          "selector": "fromString:",
+          "arity": 1
+        },
+        {
+          "selector": "fromURLString:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "scheme:host:path:",
+          "arity": 3
+        },
+        {
+          "selector": "scheme:host:port:path:",
+          "arity": 4
+        },
+        {
+          "selector": "scheme:path:",
+          "arity": 2
+        },
+        {
+          "selector": "scheme:username:password:host:port:path:",
+          "arity": 6
+        }
+      ]
+    },
+    "UndefinedObject": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "addDependent:",
+          "arity": 1
+        },
+        {
+          "selector": "allSubclasses",
+          "arity": 0
+        },
+        {
+          "selector": "copy",
+          "arity": 0
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "free",
+          "arity": 0
+        },
+        {
+          "selector": "ifNil:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNil:ifNotNil:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNil:ifNotNilDo:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotNil:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNotNil:ifNil:",
+          "arity": 2
+        },
+        {
+          "selector": "ifNotNilDo:",
+          "arity": 1
+        },
+        {
+          "selector": "ifNotNilDo:ifNil:",
+          "arity": 2
+        },
+        {
+          "selector": "inheritsFrom:",
+          "arity": 1
+        },
+        {
+          "selector": "instSize",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "isNil",
+          "arity": 0
+        },
+        {
+          "selector": "isNull",
+          "arity": 0
+        },
+        {
+          "selector": "metaclassFor:",
+          "arity": 1
+        },
+        {
+          "selector": "methodDictionary",
+          "arity": 0
+        },
+        {
+          "selector": "mutate:startAt:newClass:",
+          "arity": 3
+        },
+        {
+          "selector": "narrow",
+          "arity": 0
+        },
+        {
+          "selector": "notNil",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "printOn:in:",
+          "arity": 2
+        },
+        {
+          "selector": "release",
+          "arity": 0
+        },
+        {
+          "selector": "removeSubclass:",
+          "arity": 1
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        },
+        {
+          "selector": "subclass:",
+          "arity": 1
+        },
+        {
+          "selector": "subclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "subclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "variable:subclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 6
+        },
+        {
+          "selector": "variableByteSubclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "variableByteSubclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableByteSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "variableLongSubclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "variableLongSubclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableSubclass:classInstanceVariableNames:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 5
+        },
+        {
+          "selector": "variableSubclass:instanceVariableNames:classVariableNames:poolDictionaries:",
+          "arity": 4
+        },
+        {
+          "selector": "variableSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        },
+        {
+          "selector": "variableWordSubclass:instanceVariableNames:classVariableNames:poolDictionaries:category:",
+          "arity": 5
+        }
+      ],
+      "classSelectors": []
+    },
+    "UnhandledException": {
+      "superclass": "Exception",
+      "instanceSelectors": [
+        {
+          "selector": "defaultAction",
+          "arity": 0
+        },
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "instantiateDefaultHandler",
+          "arity": 0
+        },
+        {
+          "selector": "originalException",
+          "arity": 0
+        },
+        {
+          "selector": "originalException:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "UnicodeCharacter": {
+      "superclass": "Character",
+      "instanceSelectors": [
+        {
+          "selector": "*",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ]
+    },
+    "UnicodeString": {
+      "superclass": "CharacterArray",
+      "instanceSelectors": [
+        {
+          "selector": "asString",
+          "arity": 0
+        },
+        {
+          "selector": "asSymbol",
+          "arity": 0
+        },
+        {
+          "selector": "asUnicodeString",
+          "arity": 0
+        },
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "displayOn:",
+          "arity": 1
+        },
+        {
+          "selector": "encoding",
+          "arity": 0
+        },
+        {
+          "selector": "hash",
+          "arity": 0
+        },
+        {
+          "selector": "numberOfCharacters",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "defaultEncoding",
+          "arity": 0
+        },
+        {
+          "selector": "fromString:",
+          "arity": 1
+        },
+        {
+          "selector": "isUnicode",
+          "arity": 0
+        }
+      ]
+    },
+    "UserInterrupt": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "VMError": {
+      "superclass": "Error",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "ValueAdaptor": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "ValueHolder": {
+      "superclass": "ValueAdaptor",
+      "instanceSelectors": [
+        {
+          "selector": "initialize",
+          "arity": 0
+        },
+        {
+          "selector": "value",
+          "arity": 0
+        },
+        {
+          "selector": "value:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "null",
+          "arity": 0
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        }
+      ]
+    },
+    "VariableBinding": {
+      "superclass": "HomedAssociation",
+      "instanceSelectors": [
+        {
+          "selector": "binaryRepresentationObject",
+          "arity": 0
+        },
+        {
+          "selector": "isDefined",
+          "arity": 0
+        },
+        {
+          "selector": "isLiteralObject",
+          "arity": 0
+        },
+        {
+          "selector": "path",
+          "arity": 0
+        },
+        {
+          "selector": "printOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeLiteralOn:",
+          "arity": 1
+        },
+        {
+          "selector": "storeOn:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "VerificationError": {
+      "superclass": "VMError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "Version": {
+      "superclass": "Object",
+      "instanceSelectors": [
+        {
+          "selector": "major",
+          "arity": 0
+        },
+        {
+          "selector": "major:",
+          "arity": 1
+        },
+        {
+          "selector": "major:minor:patch:",
+          "arity": 3
+        },
+        {
+          "selector": "minor",
+          "arity": 0
+        },
+        {
+          "selector": "minor:",
+          "arity": 1
+        },
+        {
+          "selector": "patch",
+          "arity": 0
+        },
+        {
+          "selector": "patch:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "fromString:",
+          "arity": 1
+        },
+        {
+          "selector": "major:minor:patch:",
+          "arity": 3
+        }
+      ]
+    },
+    "VersionableObjectProxy": {
+      "superclass": "NullProxy",
+      "instanceSelectors": [
+        {
+          "selector": "dumpTo:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "loadFrom:",
+          "arity": 1
+        }
+      ]
+    },
+    "Warning": {
+      "superclass": "Notification",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "WeakArray": {
+      "superclass": "Array",
+      "instanceSelectors": [
+        {
+          "selector": "aliveObjectsDo:",
+          "arity": 1
+        },
+        {
+          "selector": "asArray",
+          "arity": 0
+        },
+        {
+          "selector": "at:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atAll:put:",
+          "arity": 2
+        },
+        {
+          "selector": "atAllPut:",
+          "arity": 1
+        },
+        {
+          "selector": "clearGCFlag:",
+          "arity": 1
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize:",
+          "arity": 1
+        },
+        {
+          "selector": "isAlive:",
+          "arity": 1
+        },
+        {
+          "selector": "postLoad",
+          "arity": 0
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        },
+        {
+          "selector": "size",
+          "arity": 0
+        },
+        {
+          "selector": "species",
+          "arity": 0
+        },
+        {
+          "selector": "values:whichAreNil:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "new",
+          "arity": 0
+        },
+        {
+          "selector": "new:",
+          "arity": 1
+        }
+      ]
+    },
+    "WeakIdentitySet": {
+      "superclass": "WeakSet",
+      "instanceSelectors": [
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "identityIncludes:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    },
+    "WeakKeyDictionary": {
+      "superclass": "Dictionary",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "at:put:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "postLoad",
+          "arity": 0
+        }
+      ]
+    },
+    "WeakKeyIdentityDictionary": {
+      "superclass": "WeakKeyDictionary",
+      "instanceSelectors": [
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "WeakSet": {
+      "superclass": "Set",
+      "instanceSelectors": [
+        {
+          "selector": "add:",
+          "arity": 1
+        },
+        {
+          "selector": "deepCopy",
+          "arity": 0
+        },
+        {
+          "selector": "do:",
+          "arity": 1
+        },
+        {
+          "selector": "findElementIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "mourn:",
+          "arity": 1
+        },
+        {
+          "selector": "newAssociation:",
+          "arity": 1
+        },
+        {
+          "selector": "postLoad",
+          "arity": 0
+        },
+        {
+          "selector": "shallowCopy",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "WeakValueIdentityDictionary": {
+      "superclass": "WeakValueLookupTable",
+      "instanceSelectors": [
+        {
+          "selector": "findIndex:",
+          "arity": 1
+        },
+        {
+          "selector": "hashFor:",
+          "arity": 1
+        },
+        {
+          "selector": "keysClass",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "WeakValueLookupTable": {
+      "superclass": "LookupTable",
+      "instanceSelectors": [
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        },
+        {
+          "selector": "at:ifPresent:",
+          "arity": 2
+        },
+        {
+          "selector": "beConsistent",
+          "arity": 0
+        },
+        {
+          "selector": "includesKey:",
+          "arity": 1
+        },
+        {
+          "selector": "initialize:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:",
+          "arity": 1
+        },
+        {
+          "selector": "primAt:put:",
+          "arity": 2
+        },
+        {
+          "selector": "primSize",
+          "arity": 0
+        },
+        {
+          "selector": "rehash",
+          "arity": 0
+        },
+        {
+          "selector": "valueAt:",
+          "arity": 1
+        },
+        {
+          "selector": "valueAt:put:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "primNew:",
+          "arity": 1
+        }
+      ]
+    },
+    "WordArray": {
+      "superclass": "ArrayedCollection",
+      "instanceSelectors": [
+        {
+          "selector": "at:ifAbsent:",
+          "arity": 2
+        }
+      ],
+      "classSelectors": []
+    },
+    "WriteStream": {
+      "superclass": "PositionableStream",
+      "instanceSelectors": [
+        {
+          "selector": "contents",
+          "arity": 0
+        },
+        {
+          "selector": "emptyStream",
+          "arity": 0
+        },
+        {
+          "selector": "growCollection",
+          "arity": 0
+        },
+        {
+          "selector": "growCollectionTo:",
+          "arity": 1
+        },
+        {
+          "selector": "initCollection:",
+          "arity": 1
+        },
+        {
+          "selector": "moveToEnd",
+          "arity": 0
+        },
+        {
+          "selector": "next:putAll:startingAt:",
+          "arity": 3
+        },
+        {
+          "selector": "nextPut:",
+          "arity": 1
+        },
+        {
+          "selector": "readStream",
+          "arity": 0
+        },
+        {
+          "selector": "reverseContents",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "on:",
+          "arity": 1
+        },
+        {
+          "selector": "with:",
+          "arity": 1
+        },
+        {
+          "selector": "with:from:to:",
+          "arity": 3
+        }
+      ]
+    },
+    "WrongArgumentCount": {
+      "superclass": "PrimitiveFailed",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        }
+      ],
+      "classSelectors": []
+    },
+    "WrongClass": {
+      "superclass": "InvalidValue",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "messageText",
+          "arity": 0
+        },
+        {
+          "selector": "validClasses",
+          "arity": 0
+        },
+        {
+          "selector": "validClasses:",
+          "arity": 1
+        },
+        {
+          "selector": "validClassesString",
+          "arity": 0
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:mustBe:",
+          "arity": 2
+        }
+      ]
+    },
+    "WrongMessageSent": {
+      "superclass": "ShouldNotImplement",
+      "instanceSelectors": [
+        {
+          "selector": "messageText",
+          "arity": 0
+        },
+        {
+          "selector": "selector",
+          "arity": 0
+        },
+        {
+          "selector": "selector:",
+          "arity": 1
+        },
+        {
+          "selector": "suggestedSelector",
+          "arity": 0
+        },
+        {
+          "selector": "suggestedSelector:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "signalOn:useInstead:",
+          "arity": 2
+        }
+      ]
+    },
+    "ZeroDivide": {
+      "superclass": "ArithmeticError",
+      "instanceSelectors": [
+        {
+          "selector": "description",
+          "arity": 0
+        },
+        {
+          "selector": "dividend",
+          "arity": 0
+        },
+        {
+          "selector": "dividend:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": [
+        {
+          "selector": "dividend:",
+          "arity": 1
+        },
+        {
+          "selector": "new",
+          "arity": 0
+        }
+      ]
+    },
+    "ZipFile": {
+      "superclass": "ArchiveFile",
+      "instanceSelectors": [
+        {
+          "selector": "centralDirectoryRangeIn:",
+          "arity": 1
+        },
+        {
+          "selector": "createDirectory:",
+          "arity": 1
+        },
+        {
+          "selector": "extractMember:into:",
+          "arity": 2
+        },
+        {
+          "selector": "fileData",
+          "arity": 0
+        },
+        {
+          "selector": "member:mode:",
+          "arity": 2
+        },
+        {
+          "selector": "removeMember:",
+          "arity": 1
+        },
+        {
+          "selector": "updateMember:",
+          "arity": 1
+        }
+      ],
+      "classSelectors": []
+    }
+  }
+}

--- a/server/src/kernel/indexer.ts
+++ b/server/src/kernel/indexer.ts
@@ -1,0 +1,140 @@
+// Reusable `.st`-directory kernel indexer (US-413, slice A; ADR-0002).
+//
+// Builds a dialect-neutral KernelIndexData from a directory of GNU Smalltalk
+// `.st` source files, reusing the US-411 front end (`parse` + buildSymbolTable)
+// exactly as `kernel.test.ts` does over the 122-file corpus. The SAME function
+// serves the build-time bundled generator (this slice) and, later, the live
+// installed-kernel path (AC6) — only the source directory + header differ.
+//
+// Facts only (LGPL-2.1): we read class names, superclass links, and selectors +
+// arity from the symbol table, which carries no comment prose. Never throws —
+// unreadable or unparsable files are skipped, mirroring the index's robustness.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from '../parser/parser';
+import { buildSymbolTable, SymbolKind, type SymbolNode } from '../parser/symbols';
+import type { KernelClass, KernelIndexData, KernelIndexHeader, KernelSelector } from './model';
+
+const ST_FILE = /\.st$/i;
+
+/** Identity of the bundled GST 3.2.5 reference index. */
+export const BUNDLED_HEADER: KernelIndexHeader = {
+  dialect: 'gst',
+  library: 'gst-3.2.5',
+  version: '3.2.5',
+  source: 'bundled',
+};
+
+/** Default location of the bundled kernel corpus, relative to the repo root
+ *  (cwd for `npm run gen:kernel-index` and `npm run test:parser`). */
+export function bundledKernelDir(): string {
+  return path.join(process.cwd(), '../smalltalk-3.2.5/kernel');
+}
+
+/** Path of the committed bundled index, relative to the repo root. */
+export function bundledIndexPath(): string {
+  return path.join(process.cwd(), 'server/data/kernel-index.json');
+}
+
+interface ClassAcc {
+  superclass?: string;
+  /** selector -> arity */
+  readonly instance: Map<string, number>;
+  readonly klass: Map<string, number>;
+}
+
+function accFor(classes: Map<string, ClassAcc>, name: string): ClassAcc {
+  const existing = classes.get(name);
+  if (existing) {
+    return existing;
+  }
+  const created: ClassAcc = { instance: new Map(), klass: new Map() };
+  classes.set(name, created);
+  return created;
+}
+
+/** Walk the symbol tree, merging class facts across files/chunks into `classes`. */
+function collect(nodes: SymbolNode[], classes: Map<string, ClassAcc>): void {
+  for (const node of nodes) {
+    if (node.kind === SymbolKind.Class) {
+      const acc = accFor(classes, node.name);
+      if (acc.superclass === undefined && node.detail) {
+        acc.superclass = node.detail;
+      }
+      for (const child of node.children) {
+        if (child.kind === SymbolKind.Method && child.selector) {
+          const into = child.classSide ? acc.klass : acc.instance;
+          if (!into.has(child.selector)) {
+            into.set(child.selector, child.arity ?? 0);
+          }
+        }
+      }
+      collect(node.children, classes); // nested classes
+    } else if (node.kind === SymbolKind.Namespace) {
+      collect(node.children, classes);
+    }
+  }
+}
+
+function toSelectors(m: Map<string, number>): KernelSelector[] {
+  return [...m.keys()].sort().map((selector) => ({ selector, arity: m.get(selector) ?? 0 }));
+}
+
+/** Index every `.st` file in `dir` into a deterministic KernelIndexData. */
+export function indexKernelDirectory(dir: string, header: KernelIndexHeader): KernelIndexData {
+  const classes = new Map<string, ClassAcc>();
+
+  let files: string[] = [];
+  try {
+    files = fs.readdirSync(dir).filter((f) => ST_FILE.test(f)).sort();
+  } catch {
+    files = [];
+  }
+
+  for (const file of files) {
+    let text: string;
+    try {
+      text = fs.readFileSync(path.join(dir, file), 'utf8');
+    } catch {
+      continue;
+    }
+    try {
+      collect(buildSymbolTable(parse(text).ast), classes);
+    } catch {
+      // Never throw from indexing — skip a pathological file.
+    }
+  }
+
+  // Drop synthetic placeholders (`<anonymous>`, `<methods>`) — not real classes.
+  const names = [...classes.keys()].filter((n) => n && !n.startsWith('<')).sort();
+
+  const out: Record<string, KernelClass> = {};
+  let selectorCount = 0;
+  for (const name of names) {
+    const acc = classes.get(name);
+    if (!acc) {
+      continue;
+    }
+    const instanceSelectors = toSelectors(acc.instance);
+    const classSelectors = toSelectors(acc.klass);
+    selectorCount += instanceSelectors.length + classSelectors.length;
+    out[name] = {
+      ...(acc.superclass !== undefined ? { superclass: acc.superclass } : {}),
+      instanceSelectors,
+      classSelectors,
+    };
+  }
+
+  return {
+    ...header,
+    classCount: names.length,
+    selectorCount,
+    classes: out,
+  };
+}
+
+/** Canonical, deterministic serialization (stable key order + trailing newline). */
+export function serializeKernelIndex(data: KernelIndexData): string {
+  return `${JSON.stringify(data, null, 2)}\n`;
+}

--- a/server/src/kernel/model.ts
+++ b/server/src/kernel/model.ts
@@ -1,0 +1,57 @@
+// Dialect-neutral kernel-index model (US-413, ADR-0002).
+//
+// The shape of a "standard library" index — classes, superclass links, and
+// selectors + arity for one Smalltalk library. It is deliberately dialect- and
+// source-agnostic: the same model is produced by the bundled build-time
+// generator (GST 3.2.5 from `.st` sources) and, later, by other source adapters
+// (a live installed kernel directory, or an image-based reflective export for
+// Pharo/Squeak). Pure data — no `vscode`, no Node.
+//
+// Licensing (LGPL-2.1): this model stores FACTS ONLY — class/selector names,
+// arity, and superclass links. It must never carry method-comment prose or
+// bodies. A test (`kernelIndex.test.ts`) enforces the absence of prose fields.
+
+/** How a kernel index was sourced. `bundled` ships in the VSIX; `installed` is
+ *  built live from the user's actual Smalltalk installation. */
+export type KernelSource = 'bundled' | 'installed';
+
+/** A single selector and its arity (0 = unary, 1 = binary, n = keyword parts). */
+export interface KernelSelector {
+  readonly selector: string;
+  readonly arity: number;
+}
+
+/** The facts known about one class. The full superclass *chain* is resolved
+ *  transitively over the index, so only the immediate superclass is stored. */
+export interface KernelClass {
+  readonly superclass?: string;
+  readonly instanceSelectors: KernelSelector[];
+  readonly classSelectors: KernelSelector[];
+}
+
+/** Self-describing identity of an index (surfaced in the status bar + provenance). */
+export interface KernelIndexHeader {
+  /** Dialect family, e.g. `gst`. */
+  readonly dialect: string;
+  /** Library identifier, e.g. `gst-3.2.5`. */
+  readonly library: string;
+  /** Library version, e.g. `3.2.5`. */
+  readonly version: string;
+  readonly source: KernelSource;
+}
+
+/** A complete kernel index: identity header + derived counts + class facts.
+ *  In the serialized form, `classes` keys and every selector list are sorted. */
+export interface KernelIndexData extends KernelIndexHeader {
+  readonly classCount: number;
+  readonly selectorCount: number;
+  readonly classes: Record<string, KernelClass>;
+}
+
+/** Where a completion came from — drives ranking and the provenance label.
+ *  (Consumed by the completion provider in a later slice.) */
+export enum Provenance {
+  Workspace = 'workspace',
+  InstalledKernel = 'installed',
+  BundledKernel = 'bundled',
+}

--- a/server/test/kernelIndex.test.ts
+++ b/server/test/kernelIndex.test.ts
@@ -1,0 +1,109 @@
+// Kernel-index tests (US-413, slice A / AC1; ADR-0002).
+//
+// Two layers, mirroring kernel.test.ts's skip-when-absent pattern:
+//   1. ALWAYS (CI, corpus absent): load the COMMITTED server/data/kernel-index.json
+//      and assert its invariants — known classes, sorted/typed shape, and the
+//      LICENSING gate (facts only: structurally no comment/prose fields).
+//   2. WHEN the corpus is present (local): regenerate in-memory and assert it is
+//      byte-identical to the committed file — a drift guard.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import {
+  BUNDLED_HEADER,
+  bundledIndexPath,
+  bundledKernelDir,
+  indexKernelDirectory,
+  serializeKernelIndex,
+} from '../src/kernel/indexer.ts';
+import type { KernelIndexData } from '../src/kernel/model.ts';
+
+const CLASS_KEYS = new Set(['superclass', 'instanceSelectors', 'classSelectors']);
+const SELECTOR_KEYS = new Set(['selector', 'arity']);
+const HEADER_KEYS = new Set(['dialect', 'library', 'version', 'source', 'classCount', 'selectorCount', 'classes']);
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+const isSorted = (xs: string[]): boolean => xs.every((x, i) => i === 0 || (xs[i - 1] as string) <= x);
+
+const raw = fs.readFileSync(bundledIndexPath(), 'utf8');
+const index = JSON.parse(raw) as KernelIndexData;
+
+test('committed index has the bundled GST 3.2.5 header', () => {
+  assert.deepEqual(
+    { dialect: index.dialect, library: index.library, version: index.version, source: index.source },
+    BUNDLED_HEADER,
+  );
+  assert.deepEqual(new Set(Object.keys(index)), HEADER_KEYS);
+});
+
+test('counts are self-consistent and substantial', () => {
+  const names = Object.keys(index.classes);
+  assert.equal(index.classCount, names.length);
+  let selectors = 0;
+  for (const c of Object.values(index.classes)) {
+    selectors += c.instanceSelectors.length + c.classSelectors.length;
+  }
+  assert.equal(index.selectorCount, selectors);
+  assert.ok(index.classCount >= 100, `expected a substantial corpus (got ${index.classCount} classes)`);
+});
+
+test('known kernel classes are present with expected superclass links', () => {
+  for (const n of ['Object', 'Collection', 'String', 'Integer', 'Boolean', 'Array', 'OrderedCollection']) {
+    assert.ok(index.classes[n], `expected class ${n} in the kernel index`);
+  }
+  assert.equal(index.classes['Collection']?.superclass, 'Iterable');
+  assert.equal(index.classes['SmallInteger']?.superclass, 'Integer');
+  assert.ok((index.classes['Collection']?.instanceSelectors.length ?? 0) > 0);
+});
+
+test('class keys and selector lists are sorted (deterministic output)', () => {
+  assert.ok(isSorted(Object.keys(index.classes)), 'class names must be sorted');
+  for (const [name, c] of Object.entries(index.classes)) {
+    assert.ok(isSorted(c.instanceSelectors.map((s) => s.selector)), `${name} instance selectors must be sorted`);
+    assert.ok(isSorted(c.classSelectors.map((s) => s.selector)), `${name} class selectors must be sorted`);
+  }
+});
+
+test('LICENSING gate: facts only — no comment/prose fields (ADR-0002)', () => {
+  for (const [name, c] of Object.entries(index.classes)) {
+    // Only the allowed structural keys exist on a class — no `comment`, `doc`, `body`, …
+    for (const k of Object.keys(c)) {
+      assert.ok(CLASS_KEYS.has(k), `class ${name} has unexpected field "${k}" (possible prose leak)`);
+    }
+    if (c.superclass !== undefined) {
+      assert.equal(typeof c.superclass, 'string');
+      assert.ok(!/\s/.test(c.superclass), `superclass of ${name} looks like prose`);
+    }
+    for (const s of [...c.instanceSelectors, ...c.classSelectors]) {
+      assert.deepEqual(new Set(Object.keys(s)), SELECTOR_KEYS, `selector on ${name} has unexpected fields`);
+      assert.equal(typeof s.selector, 'string');
+      assert.equal(typeof s.arity, 'number');
+      assert.ok(s.arity >= 0 && Number.isInteger(s.arity), `bad arity for ${s.selector} on ${name}`);
+      // A selector is an identifier / keyword chain / binary op — it never
+      // contains whitespace (keyword chains can be long, e.g.
+      // `subclass:declaration:classVariableNames:poolDictionaries:category:`),
+      // so the no-whitespace invariant is the real facts-vs-prose signal.
+      assert.ok(!/\s/.test(s.selector) && s.selector.length <= 128, `selector "${s.selector}" looks like prose`);
+    }
+  }
+});
+
+if (!fs.existsSync(bundledKernelDir())) {
+  console.log('kernelIndex: drift guard skipped (corpus not found).');
+} else {
+  test('drift guard: regenerating from the corpus reproduces the committed file', () => {
+    const regenerated = serializeKernelIndex(indexKernelDirectory(bundledKernelDir(), BUNDLED_HEADER));
+    assert.equal(
+      regenerated,
+      raw,
+      'server/data/kernel-index.json is stale — run `npm run gen:kernel-index` and commit the result',
+    );
+  });
+}
+
+console.log(`kernelIndex: ${passed} tests passed.`);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -6,4 +6,5 @@ import './container.test.ts';
 import './chunk.test.ts';
 import './symbols.test.ts';
 import './kernel.test.ts';
+import './kernelIndex.test.ts';
 import './providers.test.ts';

--- a/specs/US-413-Completion-And-Kernel-Index/plan.md
+++ b/specs/US-413-Completion-And-Kernel-Index/plan.md
@@ -1,0 +1,61 @@
+# Implementation Plan: Completion + GNU Smalltalk kernel index
+
+**ID**: US-413 | **Date**: 2026-06-21 | **Spec**: ./spec.md | **Branch**: `feature/US-413-completion-and-kernel-index`
+**Architecture**: [ADR-0002](../../docs/decisions/0002-kernel-symbol-sourcing.md)
+
+## Summary
+Add `textDocument/completion` over the US-411 symbol table + US-412 workspace index, plus a
+**kernel-library tier** sourced installed-first / bundled-fallback (ADR-0002) through a dialect-neutral
+index model and a reusable `.st`-directory indexer. Ships in four reviewable PR slices; each keeps all
+three test layers green and is held for owner merge.
+
+## Approach
+**Reuse, don't rebuild.** The kernel index is a workspace index over a kernel directory — it reuses
+`parse` (`server/src/parser/parser.ts`) + `buildSymbolTable` (`server/src/parser/symbols.ts`) exactly as
+`server/test/kernel.test.ts` already does over all 122 files with 0 diagnostics. New code is the neutral
+model, the directory indexer, the build-time generator, the runtime resolution service, and the LSP
+completion boundary (mirroring the US-412 provider + `parseCache` + dynamic `didChangeConfiguration`
+patterns).
+
+Key new modules: `server/src/kernel/model.ts`, `server/src/kernel/indexer.ts`,
+`scripts/gen-kernel-index.ts`, `server/data/kernel-index.json` (committed), then
+`server/src/kernel/kernelIndexService.ts` and `server/src/providers/completion.ts`.
+
+## Steps (sliced into PRs)
+1. **Slice A — index model + bundled generator (AC1).**
+   - `model.ts` neutral types; `indexer.ts` `indexKernelDirectory(dir, meta)` (walk `*.st`, parse,
+     buildSymbolTable, merge by class across files/chunks, dedup + sort, never throw).
+   - `scripts/gen-kernel-index.ts` + `npm run gen:kernel-index`; generate & commit
+     `server/data/kernel-index.json` (deterministic, no timestamp, facts only).
+   - `server/test/kernelIndex.test.ts` (wired into `run.ts`): invariants + licensing no-prose gate
+     (run **without** corpus) + regeneration drift guard (when corpus present).
+2. **Slice B — kernel index service (AC5/AC6).** Load the bundled JSON; discover an installed kernel dir
+   (`kernelPath` → `gnuSmalltalkPath` prefix → common locations); resolve `auto|bundled|off`; expose
+   provenance-tagged lookups; re-resolve on config change. Unit + discovery tests.
+3. **Slice C — completion provider (AC2–AC4, AC7 items).** Context detection at cursor (receiver →
+   selectors; head → classes + scope variables) over `parseCache`; merge workspace + kernel; rank
+   workspace > installed > bundled with prefix/camel-hump; keyword-selector snippets; provenance in
+   items. Advertise `completionProvider` in `server.ts`. Provider unit + `test:server` completion +
+   e2e tests.
+4. **Slice D — settings + status UX (AC5/AC7).** `smalltalk.completion.kernelLibrary` +
+   `kernelPath` in `package.json`; status-bar item showing resolved identity; one-time fallback notice.
+   E2e asserting kernel + workspace completions.
+
+## Dependencies & Risks
+- **Depends on** (merged): US-411 `parse`/`buildSymbolTable`; US-412 `WorkspaceIndex`/`parseCache`/the
+  dynamic config-pull pattern.
+- **Build-time only**: the bundled GST kernel corpus (`../smalltalk-3.2.5/kernel`, absent in CI → JSON is
+  committed).
+- **Risks** (see spec §7): licensing (no-prose test), version/dialect confusion (provenance + status +
+  notice + `off`), selector over-offering (ranking/filtering), determinism drift (drift guard), discovery
+  brittleness (override + fallback). Packaging: ensure `kernel-index.json` ships in the VSIX (Slice C/D).
+
+## Verification
+- **Automated**: `test:parser` (index snapshot/invariant + licensing gate + drift guard +
+  completion-context + discovery), `test:server` (completion handshake), `test:e2e` (fixture workspace).
+  Eval: extend `evals/` with a completion dataset before the story is Done.
+- **Manual**: the §6 / `verification.md` matrix in the Extension Development Host — real-corpus
+  workspace, selector/class/variable completion, keyword snippet, installed vs bundled sourcing +
+  provenance honesty, `off`, no-`gst`, cross-platform, clean-install VSIX. Hard gate for 0.5.0.
+- CI watched per PR; **merges + the release tag held for the owner**. Close issue #1 with a demo; run
+  the doc-rot + manual-QA release ritual before tagging v0.5.0.

--- a/specs/US-413-Completion-And-Kernel-Index/requirements-validation.md
+++ b/specs/US-413-Completion-And-Kernel-Index/requirements-validation.md
@@ -1,0 +1,53 @@
+# Requirements Validation Checklist
+
+**Purpose**: Validate spec quality BEFORE implementation begins
+**Type**: Requirements Quality Gate
+**Story**: US-413 — Completion + GNU Smalltalk kernel index
+**Architecture**: [ADR-0002](../../docs/decisions/0002-kernel-symbol-sourcing.md)
+
+---
+
+## Section 1: Constitution Gates (Mandatory)
+- [x] **Native Look & Feel**: Uses the standard VS Code completion widget via LSP
+  `textDocument/completion`, snippet insertion (`InsertTextFormat.Snippet`), and a standard status-bar
+  item. No custom UI.
+- [x] **Zero Config**: Default `kernelLibrary = auto` gives useful completion out of the box — installed
+  kernel when present, bundled reference otherwise — with no settings required; discovery is automatic.
+- [x] **Protocol First**: A pure LSP completion provider over the bundled server; client unchanged except
+  the status-bar surface.
+- [x] **Robustness**: Built on the never-throws front end; indexer skips unreadable/parse-failing files;
+  providers return empty results, never errors; the bundle is an always-safe fallback.
+- [x] **Dialect Agnostic**: The kernel index model is dialect-neutral and fed by per-dialect **source
+  adapters** (GST file adapter now; image-based reflective-export adapters later) — ADR-0002,
+  Constitution Principle IV.
+
+## Section 2: Specification Completeness
+- [x] Goals and Non-Goals explicitly listed (§2/§3; hover/diagnostics/formatting, comment prose, image
+  dialects, `smalltalk.dialect`, type inference excluded).
+- [x] User stories in standard format (§4).
+- [x] Acceptance scenarios (Given/When/Then) defined (§4), one per AC incl. determinism, installed vs
+  bundled sourcing, `off`, and snippet insertion.
+- [x] Edge cases identified: corpus absent in CI, regeneration drift, no `gst`, install discovery across
+  OSes, malformed file, selector over-offering, licensing (no prose), clean-install VSIX.
+- [x] Dependencies listed: US-411 (`parse`, `buildSymbolTable`) + US-412 (`WorkspaceIndex`,
+  `parseCache`) — merged; `vscode-languageserver` types; the bundled GST kernel corpus (build-time only).
+
+## Section 3: Technical Design
+- [x] API/Command contracts defined: `textDocument/completion` + advertised `completionProvider`;
+  `gen:kernel-index` build script; `kernelLibrary`/`kernelPath` settings (§5).
+- [x] Data structures defined: the neutral `KernelIndexData`/`KernelClass`/`KernelSelector` model, the
+  committed `kernel-index.json` shape, provenance enum, the directory indexer contract (§5).
+- [x] Error handling strategy defined: never-throws indexer/providers; empty/partial results; always-safe
+  bundle fallback; discovery failures degrade gracefully.
+- [x] Testing strategy defined: unit (snapshot/invariant **without** corpus + licensing no-prose gate +
+  drift guard when corpus present + completion-context + discovery) + server (handshake completion) +
+  e2e (fixture workspace) + a **manual verification matrix** (§6 / `verification.md`) gating 0.5.0.
+
+## Section 4: Validation Result
+- [x] PASS - Ready for implementation
+
+**Emphasis**: two hard, story-specific gates beyond green CI — (1) the **licensing** constraint is
+encoded as a test (the index carries *facts only*, no comment prose), and (2) per PO direction the §6
+**manual verification matrix** (real-corpus workspace, selector/class/variable completion, keyword
+snippet, installed vs bundled sourcing + provenance honesty, no-`gst`, clean-install VSIX) is a release
+gate recorded in `verification.md`.

--- a/specs/US-413-Completion-And-Kernel-Index/spec.md
+++ b/specs/US-413-Completion-And-Kernel-Index/spec.md
@@ -1,0 +1,188 @@
+# Specification: Completion + GNU Smalltalk Kernel Index
+
+**ID**: US-413
+**Feature**: Auto-completion (selectors, classes, variables) backed by a kernel-library index
+**Status**: Draft
+**Owner**: Leonardo Nascimento
+**Created**: 2026-06-21
+**Architecture**: [ADR-0002 — Kernel symbol sourcing](../../docs/decisions/0002-kernel-symbol-sourcing.md)
+
+## 1. Overview
+The headline of **0.5.0** and the direct answer to **issue #1** (autocompletion, open since 2019). It
+adds `textDocument/completion` over the US-411 symbol table + US-412 workspace index, and introduces
+**kernel-library symbols** (`Object`, `Collection`, `String`, …) that do not live in the user's files.
+
+Per [ADR-0002](../../docs/decisions/0002-kernel-symbol-sourcing.md), kernel symbols come from an
+**installed-first, bundled-fallback** precedence chain over a **dialect-neutral index model** fed by
+**per-dialect source adapters**:
+
+1. **Workspace** (US-412) — always indexed; the user's own code.
+2. **Kernel tier** — one active source, chosen by `smalltalk.completion.kernelLibrary`
+   (`auto | bundled | off`): `auto` indexes a discoverable GST install's kernel **live**, else falls
+   back to a **bundled** reference index shipped in the VSIX.
+
+This honours ADR-0001 (works with **no `gst`** — the bundle covers the first-run user) *and* gives
+users with GST installed version-correct completions from their **actual** kernel. To keep the
+experience honest, completion items carry **provenance** (workspace / installed / bundled-reference)
+and a **status-bar item** shows the resolved kernel identity. Because GST ships its kernel as readable
+`.st`, the live and bundled paths share one parser-based directory indexer — no binary-metadata reader
+(unlike vscode-java/JDT or vscode-csharp/Roslyn).
+
+## 2. Goals
+- A reusable, `vscode`-free **`.st`-directory indexer** producing a **dialect-neutral kernel index**
+  (`dialect`, `library`, `version`, `source` header; classes → superclass + instance/class selectors
+  with arity). **Facts only** (LGPL-2.1: no method-comment prose / bodies).
+- A **build-time generator** that runs the indexer over the bundled `../smalltalk-3.2.5/kernel/` and
+  emits the committed `server/data/kernel-index.json` (deterministic output).
+- **Live installed-kernel indexing**: discover a GST kernel directory and index it with the *same*
+  indexer; otherwise fall back to the bundle.
+- `textDocument/completion`: keyword selectors after a receiver; class names in head position;
+  temp/instance/class variables from scope; multi-part keyword selectors inserted as snippets.
+- **Ranking** workspace > installed-kernel > bundled-kernel; prefix + camel-hump matching.
+- The setting `smalltalk.completion.kernelLibrary` (`auto | bundled | off`, default `auto`) +
+  `smalltalk.completion.kernelPath` override.
+- **Provenance** on items + a **status-bar** indicator of the active kernel source; a one-time notice
+  on first bundle fallback.
+- Fully functional with **no `gst`**; sensible zero-config defaults (`auto`).
+
+## 3. Non-Goals
+- No hover (US-415), diagnostics surfaced to the editor (US-414), or formatting (US-416).
+- **No method-comment prose** in the index or completions (LGPL; revisited for hover in US-415).
+- **No image-based dialect adapter** (Pharo/Squeak reflective export) and **no `smalltalk.dialect`
+  axis** yet — deferred follow-ups (ADR-0002). The model/adapter seam is built to accept them.
+- No type inference: selector completion is offered from the union of known selectors, not resolved by
+  receiver type (Smalltalk is dynamically typed). Ranking, not resolution, manages noise.
+- No "live query a running image" mode (possible later enhancement, ADR-0002).
+- No changes to the US-411 parser/symbol-table behaviour beyond additive, read-only consumption.
+
+## 4. User Stories & Acceptance Criteria
+**US-413**: As a Smalltalk developer, I want auto-completion for selectors, class names, and
+local/instance variables — including standard kernel-library selectors — so that I can write code
+faster with fewer lookups.
+
+- **AC1**: A build-time generator parses a GNU Smalltalk kernel source directory (bundled
+  `../smalltalk-3.2.5/kernel/*.st`) with our own parser into `server/data/kernel-index.json` —
+  dialect-neutral (`dialect`/`library`/`version`/`source` header; classes, superclass chains,
+  selectors + arity), built on a **reusable `.st`-directory indexer**, **facts only**.
+- **AC2**: Completion offers keyword/unary selectors after a receiver (workspace > installed-kernel >
+  bundled-kernel ranking, prefix + camel-hump matching).
+- **AC3**: Completion offers class names in expression-head position and temp/instance/class variables
+  from the symbol-table scopes at the cursor.
+- **AC4**: Multi-part keyword selectors insert as snippets (e.g. `at:put:` → `at:${1} put:${2}`).
+- **AC5**: `smalltalk.completion.kernelLibrary` (`auto | bundled | off`, default `auto`) selects the
+  kernel sourcing strategy; `smalltalk.completion.kernelPath` overrides GST kernel-directory discovery.
+- **AC6**: When a GST install is discoverable (via `kernelPath`, the `smalltalk.gnuSmalltalkPath`
+  prefix, or common locations) the kernel tier indexes its **actual** kernel sources live via the same
+  indexer; otherwise it falls back to the bundle.
+- **AC7**: Completion items carry **provenance** (workspace / installed / bundled-reference); a
+  status-bar item shows the resolved kernel identity (e.g. `bundled (gst 3.2.5)` / `installed` /
+  `off`), with a one-time notice on first fallback to the bundle.
+
+**Acceptance scenarios**
+- *Given* the bundled index, *when* it is regenerated from the same corpus, *then* the output is
+  byte-identical (deterministic) and contains no comment/prose fields. *(AC1)*
+- *Given* a receiver `aCollection`, *when* I type `aCollection ` and trigger completion, *then* I see
+  kernel `Collection` selectors (`do:`, `detect:ifNone:`, …) and any workspace selectors, workspace
+  ranked first, each labelled by provenance. *(AC2/AC7)*
+- *Given* a method with a temp `total` and an instance var `count`, *when* I complete inside it, *then*
+  both appear, plus in-scope class names. *(AC3)*
+- *Given* I accept `at:put:`, *when* it inserts, *then* I get `at:${1} put:${2}` as a snippet. *(AC4)*
+- *Given* `kernelLibrary = off`, *when* I complete, *then* only workspace symbols are offered. *(AC5)*
+- *Given* a real GST install on PATH/`kernelPath`, *when* `auto` resolves, *then* completions come from
+  the installed kernel and the status bar reads `installed`. *(AC6/AC7)*
+- *Given* no GST install, *when* `auto` resolves, *then* the bundle is used, the status bar reads
+  `bundled (gst 3.2.5)`, and a one-time notice explains it. *(AC6/AC7)*
+
+## 5. Technical Design
+**Reuse, don't rebuild.** The kernel index is "a workspace index over a kernel directory" — it reuses
+`parse` + `buildSymbolTable` (US-411), exactly as the kernel smoke test already does over all 122 files
+with 0 diagnostics. New code is the neutral model, the directory indexer, the generator, the runtime
+resolution, and the completion/LSP boundary.
+
+- **`server/src/kernel/model.ts`** — `vscode`-free types: `KernelSelector { selector, arity }`,
+  `KernelClass { superclass?, instanceSelectors[], classSelectors[] }`, and `KernelIndexData` with a
+  header `{ dialect, library, version, source }` + `classes` + derived counts. Provenance enum
+  (`workspace | installed | bundled`) used by completion.
+- **`server/src/kernel/indexer.ts`** — `indexKernelDirectory(dir, meta): KernelIndexData`. Walk `*.st`,
+  `parse` → `buildSymbolTable`, collect every `Class` node (top-level and namespace/nested), merge by
+  class name across files/chunks (first non-empty superclass wins; selectors unioned, split by
+  `classSide`), and emit **deterministically** (classes sorted by name, selectors sorted). Pure Node
+  `fs`, never throws (skips unreadable/parse-failing files). The *same* function serves the bundled
+  generator (AC1) and the live installed path (AC6).
+- **`scripts/gen-kernel-index.ts`** (run via `npm run gen:kernel-index`) — call the indexer on the GST
+  kernel dir (default `../smalltalk-3.2.5/kernel`, arg-overridable), tag
+  `{ dialect:'gst', library:'gst-3.2.5', version:'3.2.5', source:'bundled' }`, write
+  `server/data/kernel-index.json` with stable 2-space formatting (no timestamp). The corpus is absent
+  in CI, so the JSON is a **committed artifact**.
+- **`server/src/kernel/kernelIndexService.ts`** *(Slice B)* — load the bundled JSON; discover an
+  installed kernel dir (`kernelPath` → `gnuSmalltalkPath` prefix → common locations); resolve the
+  active source per `kernelLibrary`; expose lookups (selectors by prefix, classes) tagged with
+  provenance + the resolved identity. Re-resolves on `didChangeConfiguration`.
+- **`server/src/providers/completion.ts`** *(Slice C)* — at the cursor, use `parseCache` tokens/AST +
+  the symbol-table scope to decide context (receiver → selectors; head → classes + variables); merge
+  workspace + kernel candidates; rank workspace > installed > bundled with prefix/camel-hump; map to
+  `CompletionItem[]` with provenance in `detail`/label-description and keyword-selector snippets
+  (`InsertTextFormat.Snippet`).
+- **`server/src/server.ts`** — advertise `completionProvider` (trigger characters incl. space and
+  `:`), wire `onCompletion`; pull `smalltalk.completion.*` in the config handler (the same dynamic
+  `didChangeConfiguration` path US-412 uses).
+- **Client / packaging** — bundle `server/data/kernel-index.json` so the server can read it at runtime
+  (esbuild copy or `resolveJsonModule` import); a status-bar item *(Slice D)* shows the resolved kernel
+  identity and opens the setting on click; one-time fallback notice.
+
+**Slices (each a reviewable PR; all three test layers green per slice):**
+- **A** — neutral model + reusable directory indexer + bundled generator + committed JSON +
+  snapshot/licensing tests (AC1).
+- **B** — kernel index service: load bundle, discover install, resolve `auto|bundled|off`, provenance
+  (AC5/AC6) + unit tests.
+- **C** — completion provider over workspace + kernel, ranking + keyword snippets + provenance
+  (AC2–AC4, AC7 items) + server/e2e tests.
+- **D** — settings in `package.json`, status-bar indicator + fallback notice (AC5/AC7 UX) + e2e.
+
+**Testing strategy.** (a) **Unit (`test:parser`)**: an index snapshot/invariant test that runs in CI
+**without** the corpus (loads the committed JSON; asserts known classes, sorted order, arity ≥ 0,
+and structurally **no prose fields** = the licensing gate), plus a **drift guard** that regenerates
+in-memory and compares when the corpus *is* present (mirrors `kernel.test.ts`'s skip-when-absent
+pattern); completion-context unit tests at cursor positions; resolution/discovery tests with a temp
+fixture kernel dir. (b) **Server (`test:server`)**: extend the handshake test to drive real
+`textDocument/completion` and assert capability advertisement. (c) **E2E (`test:e2e`)**: a fixture
+workspace asserting kernel + workspace completions end-to-end. (d) **Manual**: §6.
+
+## 6. Manual Verification Plan (gate for 0.5.0)
+Automated tests prove the index/providers return the right data; **manual QA proves completion feels
+right in the editor, on real code.** Runs in the **Extension Development Host** (F5) and must pass
+before 0.5.0 is tagged. Full matrix in `verification.md`; the dimensions:
+
+1. **Real-corpus workspace** — open `../smalltalk-3.2.5/kernel/` (122 real files); complete kernel +
+   workspace selectors against genuine GNU Smalltalk. The strongest single manual test.
+2. **Selector completion** — after a receiver, kernel selectors appear; workspace selectors rank above
+   kernel; prefix + camel-hump both match.
+3. **Class & variable completion** — class names in head position; temps/instance/class vars in scope.
+4. **Keyword snippet** — accepting `at:put:` inserts `at:${1} put:${2}` with working tab stops.
+5. **Sourcing — installed** — with GST installed (or `kernelPath` set), `auto` uses the installed
+   kernel; status bar reads `installed`; completions match that version.
+6. **Sourcing — bundled fallback** — with no GST, `auto` falls back to the bundle; status bar reads
+   `bundled (gst 3.2.5)`; one-time notice appears; items show `bundled-reference` provenance.
+7. **`off`** — kernel completions suppressed; only workspace symbols remain.
+8. **Provenance honesty** — a user can tell where any suggestion came from (item detail + status bar).
+9. **Robustness / live editing** — malformed file still completes usefully and never throws; newly
+   typed methods/classes appear; rapid typing doesn't spike CPU.
+10. **No-`gst` & zero-config** — defaults give useful kernel completion with nothing installed.
+11. **Cross-platform sanity** — dev OS + CI (Linux/macOS/Windows builds); no path/URI glitches in
+    discovery.
+12. **Clean-install smoke** — `npm run package` → install the VSIX in clean VS Code → repeat headline
+    checks (selector + keyword-snippet + bundled fallback) to confirm the shipped artifact behaves.
+
+## 7. Risks & Limitations
+- **Licensing (LGPL-2.1)** — the index must carry *facts only*. Mitigation: the model has no prose
+  fields and a test asserts their absence; the generator copies no comments/bodies.
+- **Version/dialect confusion** — a bundled suggestion mistaken for guaranteed availability.
+  Mitigation: provenance on items + ambient status bar + one-time fallback notice + `off`; core kernel
+  API is highly stable across GST 3.x, so bundled facts are rarely wrong.
+- **Selector over-offering** (no type inference) — noise. Mitigation: prefix/camel-hump filtering +
+  workspace-first ranking; documented as expected for a dynamically typed language.
+- **Determinism / drift** — committed JSON could drift from the corpus. Mitigation: deterministic
+  generator + the corpus-present regeneration drift guard (skipped in CI where the corpus is absent).
+- **Install discovery brittleness** across OSes/distros. Mitigation: explicit `kernelPath` override +
+  layered discovery + always-safe bundle fallback; never throws.
+- **Scope growth** (ADR-0002 added AC6/AC7) — managed by the A–D slicing; image dialects stay out.

--- a/specs/US-413-Completion-And-Kernel-Index/tasks.md
+++ b/specs/US-413-Completion-And-Kernel-Index/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Completion + GNU Smalltalk kernel index
+
+**ID**: US-413 | **Spec**: ./spec.md | **Plan**: ./plan.md | **ADR**: [0002](../../docs/decisions/0002-kernel-symbol-sourcing.md)
+
+Mark each task `[x]` as it lands. Tasks map to acceptance criteria and PR slices (A–D).
+
+## Phase 0 — Decisions & Setup
+- [x] T000 ADR-0002 recorded; US-413 ACs/DoD amended in `docs/product/user-stories.md`.
+- [x] T001 Spec authored; `requirements-validation.md` gate passed (PASS).
+
+## Phase 1 — Slice A: index model + bundled generator (AC1)
+- [x] T100 `server/src/kernel/model.ts` — neutral types (`KernelSelector`, `KernelClass`,
+  `KernelIndexData` header + classes, `Provenance`).
+- [x] T101 `server/src/kernel/indexer.ts` — `indexKernelDirectory(dir, meta)`: walk `*.st`, parse +
+  `buildSymbolTable`, merge classes across files/chunks, dedup + sort, never throw; **facts only**.
+- [x] T102 `scripts/gen-kernel-index.ts` + `gen:kernel-index` npm script.
+- [x] T103 Generate & commit `server/data/kernel-index.json` (deterministic; `dialect`/`library`/
+  `version`/`source` header; no timestamp) — 250 classes, 4723 selectors.
+- [x] T104 `server/test/kernelIndex.test.ts` wired into `run.ts`: invariants (known classes, sorted,
+  arity ≥ 0) + **licensing no-prose gate** (runs without corpus) + regeneration **drift guard** (when
+  corpus present).
+- [~] T105 `npm run test:parser`, `check-types`, `lint`, `test:server` green locally; PR (A) opened,
+  CI watched, merge held. *(awaiting owner go-ahead to push/open PR)*
+
+## Phase 2 — Slice B: kernel index service (AC5/AC6)
+- [ ] T200 `server/src/kernel/kernelIndexService.ts` — load bundle; discover install
+  (`kernelPath` → `gnuSmalltalkPath` prefix → common locations); resolve `auto|bundled|off`;
+  provenance-tagged lookups; re-resolve on config change.
+- [ ] T201 Unit + discovery tests (temp fixture kernel dir; no-`gst` fallback).
+- [ ] T202 Layers green; PR (B) opened, CI watched, merge held.
+
+## Phase 3 — Slice C: completion provider (AC2–AC4, AC7 items)
+- [ ] T300 `server/src/providers/completion.ts` — cursor-context detection over `parseCache`
+  (receiver → selectors; head → classes + scope vars); merge workspace + kernel; rank
+  workspace > installed > bundled (prefix + camel-hump); keyword-selector snippets; provenance in items.
+- [ ] T301 Advertise `completionProvider` + wire `onCompletion` in `server.ts`; ensure
+  `kernel-index.json` is bundled into the VSIX.
+- [ ] T302 Provider unit tests at cursor positions; extend `test:server` for completion; e2e fixture
+  asserting kernel + workspace completions.
+- [ ] T303 Layers green; PR (C) opened, CI watched, merge held.
+
+## Phase 4 — Slice D: settings + status UX (AC5/AC7)
+- [ ] T400 `smalltalk.completion.kernelLibrary` (`auto|bundled|off`) + `smalltalk.completion.kernelPath`
+  in `package.json` (descriptions name the bundled dialect/version).
+- [ ] T401 Status-bar item showing resolved kernel identity (click → setting); one-time bundle-fallback
+  notice.
+- [ ] T402 e2e for the setting/status paths; layers green; PR (D) opened, CI watched, merge held.
+
+## Phase 5 — Verify & Release
+- [ ] T900 Output eval extended (`evals/` completion dataset) + `npm run eval` green.
+- [ ] T901 `verification.md` manual-QA matrix executed in the Extension Dev Host (incl. real-corpus +
+  clean-install VSIX) and signed off.
+- [ ] T902 CI green on Linux/macOS/Windows for all slices.
+- [ ] T903 Issue #1 closed with a demo; doc-rot audit; bump version + CHANGELOG; **owner** cuts v0.5.0.

--- a/specs/US-413-Completion-And-Kernel-Index/verification.md
+++ b/specs/US-413-Completion-And-Kernel-Index/verification.md
@@ -1,0 +1,29 @@
+# Implementation Verification Checklist
+
+**Purpose**: Verify implementation correctness AFTER coding  
+**Type**: Implementation Verification  
+
+---
+
+## Section 1: Acceptance Criteria
+- [ ] All ACs in `tasks.md` are checked?
+- [ ] Each AC has a passing test?
+
+## Section 2: Code Quality
+- [ ] `npm run lint` passes?
+- [ ] `npm test` passes?
+- [ ] No `any` types in TypeScript (unless justified)?
+- [ ] JSDoc provided for public APIs?
+
+## Section 3: Constitutional Compliance
+- [ ] **Native**: Follows VS Code guidelines?
+- [ ] **Zero Config**: Works without manual setup?
+- [ ] **Robustness**: Handles errors gracefully?
+- [ ] **TDD**: Tests were written/exist?
+
+## Section 4: Manual Verification
+- [ ] Feature works in Extension Host?
+- [ ] No errors in Developer Tools console?
+
+## Section 5: Sign-Off
+- [ ] Ready for Merge?


### PR DESCRIPTION
feat(US-413): kernel-index model + bundled gst-3.2.5 index (slice A)

## Summary

First slice of **US-413** (completion + kernel index, **0.5.0**, answers #1). A build-time generator parses a GNU Smalltalk kernel source directory with **our own parser** into a **dialect-neutral, facts-only** index (**AC1**). It reuses the US-411 front end (`parse` + `buildSymbolTable`) exactly as the kernel smoke test does — the same `indexKernelDirectory` will also drive the **live installed-kernel** path (AC6) in slice B. No `gst`; **no parser/AST change**.

**Closes:** _n/a — first of 4 slices; #1 closes when the story ships in 0.5.0_ &nbsp;|&nbsp; **Story:** US-413 (#25) &nbsp;|&nbsp; **ADR:** [docs/decisions/0002-kernel-symbol-sourcing.md](docs/decisions/0002-kernel-symbol-sourcing.md)

### What's here
- **`server/src/kernel/model.ts`** — dialect-neutral, `vscode`-free model (`KernelIndexData` header + classes → superclass + instance/class selectors with arity). **Facts only** (LGPL-2.1: no comment prose/bodies).
- **`server/src/kernel/indexer.ts`** — `indexKernelDirectory(dir, header)`: walk `*.st`, parse + `buildSymbolTable`, merge classes across files/chunks, dedup + sort, **deterministic** output, **never throws**. Exposes `BUNDLED_HEADER`, `bundledKernelDir()`, `bundledIndexPath()`, `serializeKernelIndex()`.
- **`scripts/gen-kernel-index.ts`** + `npm run gen:kernel-index`.
- **`server/data/kernel-index.json`** — **committed** bundled index (the corpus is absent in CI, so the JSON is a checked-in artifact): `gst-3.2.5`, **250 classes, 4723 selectors**.
- **`server/test/kernelIndex.test.ts`** (wired into `run.ts`) — invariants (known classes + superclass links, sorted/typed shape), the **licensing no-prose gate** (runs **without** the corpus), and a regeneration **drift guard** (when the corpus is present).

### Architecture (ADR-0002)
Kernel symbols follow an **installed-first / bundled-fallback** precedence chain over a dialect-neutral model fed by per-dialect **source adapters** (GST file adapter now; image-based reflective-export adapters later — Constitution Principle IV). `kernelLibrary = auto|bundled|off`; identity lives in the index header + status bar, not the enum.

### Next
- **Slice B** — kernel index service: load bundle, discover an installed kernel dir, resolve `auto|bundled|off`, provenance tagging.

## Output Eval — *is the artifact right?*
- [x] **AC1** met — facts-only dialect-neutral index generated + committed (250 classes / 4723 selectors).
- [ ] Output eval dataset — _n/a for this slice_ (grammar `npm run eval` unaffected; the completion eval dataset lands with the provider, slice C, per `plan.md`).
- [x] CI green on **Linux/macOS/Windows** — all three `build` jobs pass (run 27908940294).
- [ ] Manual QA in an Extension Dev Host — _n/a for this slice_ (build-time artifact, not user-visible yet; gated at the story's `verification.md` matrix).
- [x] Local: `check-types` ✓ · `lint` ✓ · `test:parser` (incl. **6 new** kernelIndex tests) ✓ · `test:server` ✓ · `compile` ✓.

## Trajectory Eval — *was it produced the right way?*
- [x] Traces to US-413 (#25); spec authored + `requirements-validation.md` gate **PASS** before coding; ADR-0002 recorded.
- [x] Tests written with the change (licensing gate + drift guard); decisions recorded as an ADR; no drift left behind.
- [x] Conventional scoped commits (`docs(US-413)` + `feat(US-413)`); outcomes reported faithfully.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice.
