### PR TITLE
feat(US-413): kernel index service — load, discover, resolve (slice B)

### DIFF
--- a/server/src/kernel/bundledIndex.ts
+++ b/server/src/kernel/bundledIndex.ts
@@ -1,0 +1,3 @@
+import data from '../../data/kernel-index.json';
+import type { KernelIndexData } from './model';
+export const bundledIndex: KernelIndexData = data as unknown as KernelIndexData;

--- a/server/src/kernel/discovery.ts
+++ b/server/src/kernel/discovery.ts
@@ -1,0 +1,67 @@
+// Installed GST kernel-directory discovery (US-413, slice B / AC6; ADR-0002).
+//
+// Locates a real GNU Smalltalk kernel source directory (loose `.st` files) so
+// the `auto` strategy can index the user's ACTUAL kernel. All filesystem-based —
+// never spawns `gst` (honours ADR-0001's no-runtime principle). Precedence:
+//   1. an explicit `kernelPath` override,
+//   2. the prefix derived from the `smalltalk.gnuSmalltalkPath` executable, then
+//   3. common install locations.
+// Returns the first directory that looks like a kernel, else `undefined`.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface DiscoveryOptions {
+  /** Explicit override — `smalltalk.completion.kernelPath`. */
+  readonly kernelPath?: string;
+  /** The `gst` executable path — `smalltalk.gnuSmalltalkPath`. */
+  readonly gnuSmalltalkPath?: string;
+}
+
+/** Well-known install locations (overridable for tests). */
+export const DEFAULT_COMMON_LOCATIONS: readonly string[] = [
+  '/usr/share/smalltalk/kernel',
+  '/usr/local/share/smalltalk/kernel',
+  '/opt/homebrew/share/smalltalk/kernel',
+  '/opt/local/share/smalltalk/kernel',
+];
+
+/** A directory "looks like a kernel" when it exists and holds at least one `.st`. */
+export function looksLikeKernelDir(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory() && fs.readdirSync(dir).some((f) => /\.st$/i.test(f));
+  } catch {
+    return false;
+  }
+}
+
+/** `<prefix>/bin/gst` → `<prefix>/share/smalltalk/kernel`, when derivable. */
+export function deriveKernelDirFromGst(gstPath: string): string | undefined {
+  const dir = path.dirname(gstPath); // .../bin
+  if (!dir || dir === '.' || dir === gstPath) {
+    return undefined; // bare `gst` (resolved via PATH) — nothing to derive
+  }
+  const prefix = path.dirname(dir); // strip /bin
+  return path.join(prefix, 'share', 'smalltalk', 'kernel');
+}
+
+export function discoverKernelDir(
+  opts: DiscoveryOptions,
+  commonLocations: readonly string[] = DEFAULT_COMMON_LOCATIONS,
+): string | undefined {
+  if (opts.kernelPath && looksLikeKernelDir(opts.kernelPath)) {
+    return opts.kernelPath;
+  }
+  if (opts.gnuSmalltalkPath) {
+    const derived = deriveKernelDirFromGst(opts.gnuSmalltalkPath);
+    if (derived && looksLikeKernelDir(derived)) {
+      return derived;
+    }
+  }
+  for (const loc of commonLocations) {
+    if (looksLikeKernelDir(loc)) {
+      return loc;
+    }
+  }
+  return undefined;
+}

--- a/server/src/kernel/kernelIndexService.ts
+++ b/server/src/kernel/kernelIndexService.ts
@@ -1,0 +1,167 @@
+// Kernel index service (US-413, slice B / AC5+AC6; ADR-0002).
+//
+// Resolves the active kernel tier from the `smalltalk.completion.kernelLibrary`
+// strategy and exposes provenance-tagged lookups for the completion provider:
+//   - `off`     → no kernel completions,
+//   - `bundled` → the shipped gst-3.2.5 reference index,
+//   - `auto`    → the user's INSTALLED kernel (discovered + indexed live with the
+//                 same `indexKernelDirectory`), falling back to `bundled`.
+// The resolved identity drives the status bar (slice D). Pure logic + Node `fs`;
+// no `vscode`. Re-`configure()` on `didChangeConfiguration`.
+
+import { bundledIndex } from './bundledIndex';
+import { DEFAULT_COMMON_LOCATIONS, discoverKernelDir } from './discovery';
+import { indexKernelDirectory } from './indexer';
+import { Provenance, type KernelIndexData, type KernelIndexHeader } from './model';
+
+export type KernelLibrarySetting = 'auto' | 'bundled' | 'off';
+
+export interface KernelConfig {
+  readonly kernelLibrary: KernelLibrarySetting;
+  /** `smalltalk.completion.kernelPath` — explicit installed kernel dir. */
+  readonly kernelPath?: string;
+  /** `smalltalk.gnuSmalltalkPath` — the gst executable (for prefix discovery). */
+  readonly gnuSmalltalkPath?: string;
+}
+
+/** Resolved identity of the active kernel source (for status + provenance). */
+export interface KernelIdentity {
+  readonly source: 'installed' | 'bundled' | 'off';
+  /** Short human label, e.g. `bundled (gst 3.2.5)`, `installed (gst)`, `off`. */
+  readonly label: string;
+  readonly library?: string;
+  readonly version?: string;
+}
+
+export interface KernelSelectorEntry {
+  readonly selector: string;
+  readonly arity: number;
+  readonly provenance: Provenance;
+}
+
+export interface KernelClassEntry {
+  readonly name: string;
+  readonly superclass?: string;
+  readonly provenance: Provenance;
+}
+
+/** Header for a live-indexed installed kernel (version is unknown without gst). */
+const INSTALLED_HEADER: KernelIndexHeader = {
+  dialect: 'gst',
+  library: 'gst',
+  version: 'installed',
+  source: 'installed',
+};
+
+const OFF: KernelIdentity = { source: 'off', label: 'off' };
+
+export class KernelIndexService {
+  private active?: KernelIndexData;
+  private identity_: KernelIdentity = OFF;
+  /** Cache of the last live-indexed directory, to avoid re-indexing on every config event. */
+  private installedCache?: { readonly dir: string; readonly index: KernelIndexData };
+
+  constructor(
+    private readonly bundled: KernelIndexData = bundledIndex,
+    /** Well-known install locations probed in `auto` (overridable for tests). */
+    private readonly commonLocations: readonly string[] = DEFAULT_COMMON_LOCATIONS,
+  ) {}
+
+  /** (Re)resolve the active kernel source from configuration. Never throws. */
+  configure(config: KernelConfig): void {
+    if (config.kernelLibrary === 'off') {
+      this.active = undefined;
+      this.identity_ = OFF;
+      return;
+    }
+    if (config.kernelLibrary === 'auto') {
+      const installed = this.tryInstalled(config);
+      if (installed) {
+        this.active = installed;
+        this.identity_ = {
+          source: 'installed',
+          label: `installed (${installed.dialect})`,
+          library: installed.library,
+          version: installed.version,
+        };
+        return;
+      }
+    }
+    // `bundled`, or `auto` with no usable installation.
+    this.active = this.bundled;
+    this.identity_ = {
+      source: 'bundled',
+      label: `bundled (${this.bundled.dialect} ${this.bundled.version})`,
+      library: this.bundled.library,
+      version: this.bundled.version,
+    };
+  }
+
+  private tryInstalled(config: KernelConfig): KernelIndexData | undefined {
+    const dir = discoverKernelDir(
+      { kernelPath: config.kernelPath, gnuSmalltalkPath: config.gnuSmalltalkPath },
+      this.commonLocations,
+    );
+    if (!dir) {
+      return undefined;
+    }
+    if (this.installedCache?.dir === dir) {
+      return this.installedCache.index;
+    }
+    let index: KernelIndexData;
+    try {
+      index = indexKernelDirectory(dir, INSTALLED_HEADER);
+    } catch {
+      return undefined; // never throw from configuration
+    }
+    if (index.classCount === 0) {
+      return undefined; // empty/non-kernel dir → fall back to bundled
+    }
+    this.installedCache = { dir, index };
+    return index;
+  }
+
+  get identity(): KernelIdentity {
+    return this.identity_;
+  }
+
+  get isEnabled(): boolean {
+    return this.active !== undefined;
+  }
+
+  private get provenance(): Provenance {
+    return this.identity_.source === 'installed' ? Provenance.InstalledKernel : Provenance.BundledKernel;
+  }
+
+  /** Class names in the active kernel (sorted), tagged with provenance. */
+  classes(): KernelClassEntry[] {
+    if (!this.active) {
+      return [];
+    }
+    const prov = this.provenance;
+    return Object.entries(this.active.classes).map(([name, c]) => ({
+      name,
+      provenance: prov,
+      ...(c.superclass !== undefined ? { superclass: c.superclass } : {}),
+    }));
+  }
+
+  /** Unique selectors across every class in the active kernel, with provenance. */
+  selectors(): KernelSelectorEntry[] {
+    if (!this.active) {
+      return [];
+    }
+    const prov = this.provenance;
+    const arities = new Map<string, number>();
+    for (const c of Object.values(this.active.classes)) {
+      for (const s of [...c.instanceSelectors, ...c.classSelectors]) {
+        if (!arities.has(s.selector)) {
+          arities.set(s.selector, s.arity);
+        }
+      }
+    }
+    return [...arities.keys()]
+      .sort()
+      .map((selector) => ({ selector, arity: arities.get(selector) ?? 0, provenance: prov }));
+  }
+}

--- a/server/test/kernelService.test.ts
+++ b/server/test/kernelService.test.ts
@@ -1,0 +1,128 @@
+// Kernel index service + discovery tests (US-413, slice B / AC5+AC6).
+//
+// Pure logic — no real `gst` needed (works in CI). Installed-kernel discovery is
+// exercised against temporary fixture directories created at runtime.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_COMMON_LOCATIONS,
+  deriveKernelDirFromGst,
+  discoverKernelDir,
+  looksLikeKernelDir,
+} from '../src/kernel/discovery.ts';
+import { KernelIndexService } from '../src/kernel/kernelIndexService.ts';
+import { Provenance } from '../src/kernel/model.ts';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+/** Make a throwaway directory containing one parseable kernel-ish `.st` file. */
+function makeFixtureKernel(className = 'Foo'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-kernel-'));
+  fs.writeFileSync(
+    path.join(dir, `${className}.st`),
+    `Object subclass: ${className} [\n  bar [ ^42 ]\n  baz: x [ ^x ]\n]\n`,
+    'utf8',
+  );
+  return dir;
+}
+
+// --- discovery -------------------------------------------------------------
+test('looksLikeKernelDir: true for a dir with .st, false otherwise', () => {
+  const dir = makeFixtureKernel();
+  assert.equal(looksLikeKernelDir(dir), true);
+  assert.equal(looksLikeKernelDir(path.join(dir, 'nope')), false);
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'st-empty-'));
+  assert.equal(looksLikeKernelDir(empty), false);
+});
+
+test('deriveKernelDirFromGst: <prefix>/bin/gst → <prefix>/share/smalltalk/kernel', () => {
+  assert.equal(
+    deriveKernelDirFromGst('/usr/local/bin/gst'),
+    path.join('/usr/local', 'share', 'smalltalk', 'kernel'),
+  );
+  assert.equal(deriveKernelDirFromGst('gst'), undefined); // bare PATH name
+});
+
+test('discoverKernelDir: explicit kernelPath wins', () => {
+  const dir = makeFixtureKernel();
+  assert.equal(discoverKernelDir({ kernelPath: dir }), dir);
+});
+
+test('discoverKernelDir: derives from the gst executable prefix', () => {
+  const prefix = fs.mkdtempSync(path.join(os.tmpdir(), 'st-prefix-'));
+  fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+  fs.writeFileSync(path.join(prefix, 'bin', 'gst'), '', 'utf8');
+  const kernel = path.join(prefix, 'share', 'smalltalk', 'kernel');
+  fs.mkdirSync(kernel, { recursive: true });
+  fs.writeFileSync(path.join(kernel, 'Object.st'), 'Object subclass: Bar [ ]\n', 'utf8');
+  assert.equal(discoverKernelDir({ gnuSmalltalkPath: path.join(prefix, 'bin', 'gst') }), kernel);
+});
+
+test('discoverKernelDir: probes common locations, else undefined', () => {
+  const dir = makeFixtureKernel();
+  assert.equal(discoverKernelDir({}, [dir]), dir);
+  assert.equal(discoverKernelDir({}, [path.join(dir, 'absent')]), undefined);
+  assert.ok(DEFAULT_COMMON_LOCATIONS.length >= 2); // sane default set
+});
+
+// --- service resolution ----------------------------------------------------
+test('off: no active kernel, identity off', () => {
+  const svc = new KernelIndexService(undefined, []);
+  svc.configure({ kernelLibrary: 'off' });
+  assert.equal(svc.isEnabled, false);
+  assert.equal(svc.identity.source, 'off');
+  assert.deepEqual(svc.selectors(), []);
+  assert.deepEqual(svc.classes(), []);
+});
+
+test('bundled: serves the gst-3.2.5 reference index with bundled provenance', () => {
+  const svc = new KernelIndexService(undefined, []);
+  svc.configure({ kernelLibrary: 'bundled' });
+  assert.equal(svc.identity.source, 'bundled');
+  assert.match(svc.identity.label, /bundled \(gst 3\.2\.5\)/);
+  const classNames = svc.classes().map((c) => c.name);
+  assert.ok(classNames.includes('Object'), 'bundled index should contain Object');
+  const sels = svc.selectors();
+  assert.ok(sels.length > 100);
+  assert.ok(sels.every((s) => s.provenance === Provenance.BundledKernel));
+});
+
+test('auto with a discoverable install: indexes it live with installed provenance', () => {
+  const dir = makeFixtureKernel('Widget');
+  const svc = new KernelIndexService(undefined, []);
+  svc.configure({ kernelLibrary: 'auto', kernelPath: dir });
+  assert.equal(svc.identity.source, 'installed');
+  const classNames = svc.classes().map((c) => c.name);
+  assert.ok(classNames.includes('Widget'), 'should index the fixture class');
+  assert.ok(!classNames.includes('Object') || classNames.includes('Widget'));
+  const sels = svc.selectors();
+  assert.ok(sels.some((s) => s.selector === 'baz:' && s.arity === 1));
+  assert.ok(sels.every((s) => s.provenance === Provenance.InstalledKernel));
+});
+
+test('auto with no install: falls back to bundled', () => {
+  const svc = new KernelIndexService(undefined, []);
+  svc.configure({ kernelLibrary: 'auto', kernelPath: path.join(os.tmpdir(), 'definitely-absent-kernel') });
+  assert.equal(svc.identity.source, 'bundled');
+  assert.ok(svc.classes().some((c) => c.name === 'Object'));
+});
+
+test('reconfigure switches sources (auto→off→bundled)', () => {
+  const dir = makeFixtureKernel('Gadget');
+  const svc = new KernelIndexService(undefined, []);
+  svc.configure({ kernelLibrary: 'auto', kernelPath: dir });
+  assert.equal(svc.identity.source, 'installed');
+  svc.configure({ kernelLibrary: 'off' });
+  assert.equal(svc.isEnabled, false);
+  svc.configure({ kernelLibrary: 'bundled' });
+  assert.equal(svc.identity.source, 'bundled');
+});
+
+console.log(`kernelService: ${passed} tests passed.`);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -7,4 +7,5 @@ import './chunk.test.ts';
 import './symbols.test.ts';
 import './kernel.test.ts';
 import './kernelIndex.test.ts';
+import './kernelService.test.ts';
 import './providers.test.ts';

--- a/specs/US-413-Completion-And-Kernel-Index/tasks.md
+++ b/specs/US-413-Completion-And-Kernel-Index/tasks.md
@@ -23,11 +23,15 @@ Mark each task `[x]` as it lands. Tasks map to acceptance criteria and PR slices
   CI watched, merge held. *(awaiting owner go-ahead to push/open PR)*
 
 ## Phase 2 — Slice B: kernel index service (AC5/AC6)
-- [ ] T200 `server/src/kernel/kernelIndexService.ts` — load bundle; discover install
-  (`kernelPath` → `gnuSmalltalkPath` prefix → common locations); resolve `auto|bundled|off`;
-  provenance-tagged lookups; re-resolve on config change.
-- [ ] T201 Unit + discovery tests (temp fixture kernel dir; no-`gst` fallback).
-- [ ] T202 Layers green; PR (B) opened, CI watched, merge held.
+- [x] T200 `server/src/kernel/kernelIndexService.ts` — load bundle (via `bundledIndex.ts`, JSON
+  imported so esbuild inlines it); `discovery.ts` discovers install (`kernelPath` →
+  `gnuSmalltalkPath` prefix → common locations); resolve `auto|bundled|off`; provenance-tagged
+  `selectors()`/`classes()`; re-resolve on config change (`configure`). `resolveJsonModule` enabled.
+- [x] T201 Unit + discovery tests (`kernelService.test.ts`, wired into `run.ts`) — temp fixture
+  kernel dirs; gst-prefix derivation; no-install bundled fallback; reconfigure. Hermetic (common
+  locations injectable).
+- [~] T202 `check-types`/`lint`/`test:parser` (10 new)/`test:server`/`compile` green locally;
+  PR (B) opened, CI watched, merge held. *(VSIX bundling of the JSON verified in slice C / T301.)*
 
 ## Phase 3 — Slice C: completion provider (AC2–AC4, AC7 items)
 - [ ] T300 `server/src/providers/completion.ts` — cursor-context detection over `parseCache`

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,9 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
@@ -12,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "declaration": false,
-    "noEmit": true
+    "noEmit": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
feat(US-413): kernel index service — load, discover, resolve (slice B)

## Summary

Second slice of **US-413**. The runtime **kernel index service** that resolves the active kernel tier from `smalltalk.completion.kernelLibrary` and exposes **provenance-tagged** lookups for the completion provider (**AC5/AC6**). Builds on slice A's neutral model + reusable indexer. **No `gst` spawned** (filesystem-only discovery — honours ADR-0001); no parser/AST change.

**Closes:** _n/a — slice 2 of 4; #1 closes when US-413 ships in 0.5.0_ &nbsp;|&nbsp; **Story:** US-413 (#25) &nbsp;|&nbsp; **ADR:** [docs/decisions/0002-kernel-symbol-sourcing.md](docs/decisions/0002-kernel-symbol-sourcing.md) &nbsp;|&nbsp; Builds on slice A (#51).

### What's here
- **`server/src/kernel/bundledIndex.ts`** — imports `server/data/kernel-index.json` (`resolveJsonModule` enabled) so **esbuild inlines** the bundled index into `dist/server.js` — no cwd/copy concerns at runtime.
- **`server/src/kernel/discovery.ts`** — `discoverKernelDir`: filesystem-only discovery of an installed GST kernel dir, precedence **`kernelPath` → gst-executable prefix** (`<prefix>/bin/gst → <prefix>/share/smalltalk/kernel`) **→ common locations**. Never spawns `gst`.
- **`server/src/kernel/kernelIndexService.ts`** — `KernelIndexService.configure(config)` resolves **`off` | `bundled` | `auto`** (`auto` = installed-first via live `indexKernelDirectory`, else `bundled`). Exposes `identity` (for the slice-D status bar), `isEnabled`, and provenance-tagged `selectors()` / `classes()`. Caches the live index by dir; common locations injectable for hermetic tests.
- **`server/test/kernelService.test.ts`** (wired into `run.ts`) — discovery (`kernelPath`, gst-prefix derivation, common-location probing) + resolution (off / bundled / auto-installed / auto-fallback / reconfigure). **10 tests.**

### Note
The bundled JSON enters the esbuild graph (→ `dist/server.js` → VSIX) when `server.ts` wires the provider in **slice C**; VSIX bundling is verified there (plan T301). This slice is service logic + tests.

### Next
- **Slice C** — completion provider over workspace + kernel (AC2–AC4, AC7 items): ranking workspace > installed > bundled, keyword-selector snippets, provenance in items.

## Output Eval — *is the artifact right?*
- [x] **AC5/AC6** met — strategy resolution + installed-kernel discovery/live-indexing with bundled fallback.
- [ ] Output eval dataset — _n/a for this slice_ (completion eval dataset lands with the provider, slice C).
- [x] CI green on **Linux/macOS/Windows** — all three `build` jobs pass (run 27910022713).
- [ ] Manual QA in an Extension Dev Host — _n/a for this slice_ (no user-visible surface yet; gated at the story `verification.md`).
- [x] Local: `check-types` ✓ · `lint` ✓ · `test:parser` (**10 new**) ✓ · `test:server` ✓ · `compile` ✓.

## Trajectory Eval — *was it produced the right way?*
- [x] Traces to US-413 (#25); slice B in `plan.md`/`tasks.md`; ADR-0002 honoured (installed-first/bundled-fallback, no-runtime discovery).
- [x] Tests with the change (discovery + resolution; hermetic via injectable common locations after catching a non-hermetic test against the dev box's real install); conventional scoped commit.
- [ ] Reviewer sign-off.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice.
