### PR TITLE
feat(US-413): completion provider over workspace + kernel (slice C)

### DIFF
--- a/client/test-e2e/completion.test.js
+++ b/client/test-e2e/completion.test.js
@@ -1,0 +1,75 @@
+// End-to-end completion tests (US-413 slice C): launch VS Code with this
+// extension and exercise the real `textDocument/completion` provider through
+// `vscode.executeCompletionItemProvider`. Kernel completions are available with
+// no workspace file (bundled, or installed when gst is present), so these assert
+// stable kernel symbols + workspace symbols. Run via `npm run test:e2e`.
+const assert = require('node:assert');
+const vscode = require('vscode');
+
+async function waitFor(fn, ok, tries = 60) {
+  let last;
+  for (let i = 0; i < tries; i++) {
+    last = await fn();
+    if (ok(last)) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return last;
+}
+
+/** Open an in-memory Smalltalk doc and return its uri after the server attaches. */
+async function openSmalltalk(content) {
+  const doc = await vscode.workspace.openTextDocument({ language: 'smalltalk', content });
+  await vscode.window.showTextDocument(doc);
+  return doc;
+}
+
+const items = (list) => (Array.isArray(list) ? list : (list && list.items) || []);
+
+suite('US-413 completion (e2e)', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('leocamello.vscode-smalltalk');
+    assert.ok(ext, 'extension should be present');
+    await waitFor(() => Promise.resolve(ext.isActive), (active) => active === true);
+    assert.ok(ext.isActive, 'extension must be active');
+  });
+
+  test('AC2 selector context offers a kernel selector after a receiver', async () => {
+    const doc = await openSmalltalk('x print');
+    const position = new vscode.Position(0, 'x print'.length); // after `print`
+    const result = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, position),
+      (r) => items(r).some((i) => label(i) === 'printString'),
+    );
+    const printString = items(result).find((i) => label(i) === 'printString');
+    assert.ok(printString, 'expected the kernel selector printString in selector context');
+  });
+
+  test('AC4 keyword selector inserts as a snippet', async () => {
+    const doc = await openSmalltalk('x at');
+    const position = new vscode.Position(0, 'x at'.length);
+    const result = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, position),
+      (r) => items(r).some((i) => label(i) === 'at:put:'),
+    );
+    const atput = items(result).find((i) => label(i) === 'at:put:');
+    assert.ok(atput, 'expected at:put: among completions');
+    // A Snippet insert is mapped to a vscode.SnippetString (has `.value`).
+    const insert = atput.insertText;
+    const text = insert && insert.value !== undefined ? insert.value : insert;
+    assert.ok(typeof text === 'string' && text.includes('${1}'), 'at:put: inserts as a snippet with tab stops');
+  });
+
+  test('AC3 head context offers a kernel class name', async () => {
+    const doc = await openSmalltalk('Obj');
+    const position = new vscode.Position(0, 'Obj'.length);
+    const result = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, position),
+      (r) => items(r).some((i) => label(i) === 'Object'),
+    );
+    assert.ok(items(result).some((i) => label(i) === 'Object'), 'expected the kernel class Object in head context');
+  });
+});
+
+function label(item) {
+  return typeof item.label === 'string' ? item.label : item.label && item.label.label;
+}

--- a/server/src/providers/completion.ts
+++ b/server/src/providers/completion.ts
@@ -1,0 +1,351 @@
+// Completion provider (US-413, slice C / AC2–AC4 + AC7 provenance).
+//
+// Offers, at the cursor:
+//   - SELECTOR context (after a receiver / cascade `;`): unary + keyword
+//     selectors from the workspace and the active kernel, ranked
+//     workspace > installed-kernel > bundled-kernel. Keyword selectors insert as
+//     snippets (`at:put:` → `at:${1} put:${2}`).
+//   - HEAD context (statement/expression start, after `^ := ( [ { | , binary` or a
+//     keyword part): in-scope variables (temps/params/instance/class vars from the
+//     symbol-table scopes) followed by class names.
+// Context is decided from the token stream (robust at an incomplete cursor); the
+// AST/symbol table supplies in-scope variables. Pure — vscode-languageserver-types
+// only; never throws (the caller hands in already-parsed inputs).
+
+import { type CompletionItem, CompletionItemKind, InsertTextFormat } from 'vscode-languageserver-types';
+import { Provenance } from '../kernel/model';
+import { NodeKind, type Node, type ProgramNode } from '../parser/ast';
+import { SymbolKind, type SymbolNode } from '../parser/symbols';
+import { TokenKind, type Token } from '../parser/token';
+import { childNodes } from '../parser/walk';
+
+/** A selector offered to completion, with where it came from. */
+export interface SelectorCandidate {
+  readonly selector: string;
+  readonly provenance: Provenance;
+}
+
+/** A class name offered to completion, with where it came from. */
+export interface ClassCandidate {
+  readonly name: string;
+  readonly provenance: Provenance;
+}
+
+type Context = 'selector' | 'head';
+
+const IDENT = /[A-Za-z0-9_]/;
+
+/** Token kinds that end a primary expression → a receiver precedes the cursor. */
+const PRIMARY_END = new Set<TokenKind>([
+  TokenKind.Identifier,
+  TokenKind.RParen,
+  TokenKind.RBracket,
+  TokenKind.RBrace,
+  TokenKind.String,
+  TokenKind.Symbol,
+  TokenKind.Char,
+  TokenKind.Integer,
+  TokenKind.Float,
+  TokenKind.ScaledDecimal,
+]);
+
+function provenanceRank(p: Provenance): number {
+  switch (p) {
+    case Provenance.Workspace:
+      return 1;
+    case Provenance.InstalledKernel:
+      return 2;
+    case Provenance.BundledKernel:
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function provenanceLabel(p: Provenance): string {
+  switch (p) {
+    case Provenance.Workspace:
+      return 'workspace';
+    case Provenance.InstalledKernel:
+      return 'kernel (installed)';
+    case Provenance.BundledKernel:
+      return 'kernel (bundled)';
+    default:
+      return '';
+  }
+}
+
+/** The identifier prefix immediately left of `offset`, plus where it starts. */
+function prefixBefore(text: string, offset: number): { prefix: string; wordStart: number } {
+  let i = offset;
+  while (i > 0 && IDENT.test(text[i - 1] as string)) {
+    i--;
+  }
+  return { prefix: text.slice(i, offset), wordStart: i };
+}
+
+/** The last non-trivia token ending at/before `wordStart`. */
+function prevSignificantToken(tokens: Token[], wordStart: number): Token | undefined {
+  let prev: Token | undefined;
+  for (const t of tokens) {
+    if (t.kind === TokenKind.Comment || t.kind === TokenKind.EOF) {
+      continue;
+    }
+    if (t.end <= wordStart) {
+      prev = t;
+    } else {
+      break;
+    }
+  }
+  return prev;
+}
+
+function contextAt(prev: Token | undefined): Context {
+  if (!prev) {
+    return 'head';
+  }
+  if (prev.kind === TokenKind.Semicolon) {
+    return 'selector'; // cascade — another message to the shared receiver
+  }
+  return PRIMARY_END.has(prev.kind) ? 'selector' : 'head';
+}
+
+/** Camel-hump initials: `OrderedCollection` → `oc`, `ifTrue:ifFalse:` → `itif`. */
+function humpInitials(s: string): string {
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i] as string;
+    if (i === 0 || /[A-Z]/.test(ch) || (i > 0 && s[i - 1] === ':')) {
+      out += ch.toLowerCase();
+    }
+  }
+  return out;
+}
+
+/** Prefix or camel-hump match (empty prefix matches everything). */
+function matches(candidate: string, prefix: string): boolean {
+  if (prefix === '') {
+    return true;
+  }
+  const p = prefix.toLowerCase();
+  return candidate.toLowerCase().startsWith(p) || humpInitials(candidate).startsWith(p);
+}
+
+/** Identifier-led selectors only (unary/keyword); binary selectors aren't typed as words. */
+function isOfferableSelector(selector: string): boolean {
+  return /^[A-Za-z]/.test(selector);
+}
+
+function isKeywordSelector(selector: string): boolean {
+  return selector.includes(':');
+}
+
+/** `at:put:` → `at:${1} put:${2}` (one tab stop per keyword part). */
+function keywordSnippet(selector: string): string {
+  const parts = selector.match(/[^:]+:/g) ?? [selector];
+  return parts.map((part, i) => `${part}\${${i + 1}}`).join(' ');
+}
+
+/** Dedup, keeping the highest-confidence (lowest-rank) provenance per name. */
+function bestByName<T extends { provenance: Provenance }>(
+  candidates: T[],
+  nameOf: (c: T) => string,
+): Map<string, Provenance> {
+  const best = new Map<string, Provenance>();
+  for (const c of candidates) {
+    const name = nameOf(c);
+    const current = best.get(name);
+    if (current === undefined || provenanceRank(c.provenance) < provenanceRank(current)) {
+      best.set(name, c.provenance);
+    }
+  }
+  return best;
+}
+
+interface ScopeVar {
+  readonly name: string;
+  readonly kind: 'temporary' | 'parameter' | 'instanceVariable' | 'classVariable';
+}
+
+/** Root → deepest chain of nodes whose range contains `offset`. */
+function pathToOffset(root: Node, offset: number): Node[] {
+  const path: Node[] = [];
+  let node: Node | undefined = root;
+  while (node) {
+    path.push(node);
+    node = childNodes(node).find((c) => c.start <= offset && offset <= c.end);
+  }
+  return path;
+}
+
+/** A class name from a `Foo` reference or a `Foo class` message. */
+function classNameOf(node: Node): string | undefined {
+  if (node.kind === NodeKind.Variable) {
+    return node.name;
+  }
+  if (node.kind === NodeKind.Message && node.messageType === 'unary' && node.selector === 'class') {
+    return classNameOf(node.receiver);
+  }
+  return undefined;
+}
+
+/** The class owning the cursor, from a method's target or an enclosing definition. */
+function enclosingClassName(path: Node[]): string | undefined {
+  for (let i = path.length - 1; i >= 0; i--) {
+    const node = path[i] as Node;
+    if (node.kind === NodeKind.MethodDefinition && node.target) {
+      const name = classNameOf(node.target);
+      if (name) {
+        return name;
+      }
+    } else if (node.kind === NodeKind.Definition) {
+      if (node.name) {
+        return node.name;
+      }
+      const def = node.definer;
+      if (def.kind === NodeKind.Message) {
+        const name = classNameOf(def.receiver);
+        if (name) {
+          return name;
+        }
+      } else if (def.kind === NodeKind.Variable) {
+        return def.name;
+      }
+    }
+  }
+  return undefined;
+}
+
+function findClassSymbol(nodes: SymbolNode[], name: string): SymbolNode | undefined {
+  for (const node of nodes) {
+    if (node.kind === SymbolKind.Class && node.name === name) {
+      return node;
+    }
+    const inner = findClassSymbol(node.children, name);
+    if (inner) {
+      return inner;
+    }
+  }
+  return undefined;
+}
+
+/** In-scope variables at `offset`: lexical temps/params + the enclosing class's vars. */
+function scopeVariablesAt(ast: ProgramNode, symbols: SymbolNode[], offset: number): ScopeVar[] {
+  const out: ScopeVar[] = [];
+  const seen = new Set<string>();
+  const add = (name: string, kind: ScopeVar['kind']): void => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      out.push({ name, kind });
+    }
+  };
+
+  const path = pathToOffset(ast, offset);
+  for (const node of path) {
+    if (node.kind === NodeKind.MethodDefinition || node.kind === NodeKind.Block) {
+      for (const p of node.parameters) {
+        add(p.name, 'parameter');
+      }
+      for (const t of node.temporaries) {
+        add(t.name, 'temporary');
+      }
+    } else if (
+      node.kind === NodeKind.Program ||
+      node.kind === NodeKind.CompileTimeConstant ||
+      node.kind === NodeKind.DynamicArray
+    ) {
+      for (const t of node.temporaries) {
+        add(t.name, 'temporary');
+      }
+    }
+  }
+
+  const className = enclosingClassName(path);
+  if (className) {
+    const cls = findClassSymbol(symbols, className);
+    if (cls) {
+      for (const child of cls.children) {
+        if (child.kind === SymbolKind.InstanceVariable) {
+          add(child.name, 'instanceVariable');
+        } else if (child.kind === SymbolKind.ClassVariable) {
+          add(child.name, 'classVariable');
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function selectorItem(selector: string, provenance: Provenance): CompletionItem {
+  const item: CompletionItem = {
+    label: selector,
+    kind: CompletionItemKind.Method,
+    detail: provenanceLabel(provenance),
+    sortText: `${provenanceRank(provenance)}-${selector}`,
+  };
+  if (isKeywordSelector(selector)) {
+    item.insertText = keywordSnippet(selector);
+    item.insertTextFormat = InsertTextFormat.Snippet;
+  }
+  return item;
+}
+
+function classItem(name: string, provenance: Provenance): CompletionItem {
+  return {
+    label: name,
+    kind: CompletionItemKind.Class,
+    detail: provenanceLabel(provenance),
+    sortText: `${provenanceRank(provenance)}-${name}`,
+  };
+}
+
+function variableItem(v: ScopeVar): CompletionItem {
+  const isField = v.kind === 'instanceVariable' || v.kind === 'classVariable';
+  return {
+    label: v.name,
+    kind: isField ? CompletionItemKind.Field : CompletionItemKind.Variable,
+    detail: v.kind,
+    sortText: `0-${v.name}`, // in-scope variables rank above classes
+  };
+}
+
+/** Completion items at byte `offset`. `selectors`/`classes` are the merged
+ *  workspace + active-kernel candidates (each already provenance-tagged). */
+export function completionsAt(
+  offset: number,
+  text: string,
+  tokens: Token[],
+  ast: ProgramNode,
+  symbols: SymbolNode[],
+  selectors: SelectorCandidate[],
+  classes: ClassCandidate[],
+): CompletionItem[] {
+  const { prefix, wordStart } = prefixBefore(text, offset);
+  const context = contextAt(prevSignificantToken(tokens, wordStart));
+  const items: CompletionItem[] = [];
+
+  if (context === 'selector') {
+    for (const [selector, provenance] of bestByName(
+      selectors.filter((c) => isOfferableSelector(c.selector)),
+      (c) => c.selector,
+    )) {
+      if (matches(selector, prefix)) {
+        items.push(selectorItem(selector, provenance));
+      }
+    }
+    return items;
+  }
+
+  // head: in-scope variables first, then class names.
+  for (const v of scopeVariablesAt(ast, symbols, offset)) {
+    if (matches(v.name, prefix)) {
+      items.push(variableItem(v));
+    }
+  }
+  for (const [name, provenance] of bestByName(classes, (c) => c.name)) {
+    if (matches(name, prefix)) {
+      items.push(classItem(name, provenance));
+    }
+  }
+  return items;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,8 @@ import {
   DidChangeConfigurationNotification,
   TextDocuments,
   TextDocumentSyncKind,
+  type CompletionItem,
+  type CompletionParams,
   type DefinitionParams,
   type DocumentHighlight,
   type DocumentHighlightParams,
@@ -28,10 +30,15 @@ import { documentHighlightsAt } from './providers/documentHighlight';
 import { WorkspaceIndex, defaultExclude, excludeFromConfig, type ExcludePredicate } from './providers/workspaceIndex';
 import { toWorkspaceSymbols } from './providers/workspaceSymbol';
 import { findDefinitions, resolveDefinitionQuery } from './providers/definition';
+import { completionsAt, type ClassCandidate, type SelectorCandidate } from './providers/completion';
+import { KernelIndexService, type KernelLibrarySetting } from './kernel/kernelIndexService';
+import { Provenance } from './kernel/model';
+import { SymbolKind } from './parser/symbols';
 
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 const index = new WorkspaceIndex();
+const kernelService = new KernelIndexService();
 
 const INDEX_DEBOUNCE_MS = 250;
 const indexTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -47,6 +54,8 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
   workspaceFolders = (params.workspaceFolders ?? [])
     .map((folder) => uriToPath(folder.uri))
     .filter((p): p is string => p !== undefined);
+  // Have a usable kernel immediately (refined from config in onInitialized).
+  kernelService.configure({ kernelLibrary: 'auto' });
   return {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
@@ -55,6 +64,9 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       definitionProvider: true,
       foldingRangeProvider: true,
       documentHighlightProvider: true,
+      // Space/`:` auto-trigger selector + keyword-part completion; identifier
+      // typing triggers via the client's default quick-suggestions.
+      completionProvider: { triggerCharacters: [' ', ':'] },
     },
   };
 });
@@ -68,11 +80,13 @@ connection.onInitialized(async () => {
   } catch {
     // Client without dynamic registration — the initial index still applies files.exclude.
   }
+  await configureKernel();
   await rebuildIndex();
 });
 
-// Re-scan when settings change so edits to `files.exclude` take effect.
+// Re-scan when settings change so edits to `files.exclude` and the kernel settings take effect.
 connection.onDidChangeConfiguration(() => {
+  void configureKernel();
   void rebuildIndex();
 });
 
@@ -102,6 +116,35 @@ connection.onFoldingRanges((params: FoldingRangeParams): FoldingRange[] => {
 connection.onDocumentHighlight((params: DocumentHighlightParams): DocumentHighlight[] => {
   const doc = documents.get(params.textDocument.uri);
   return doc ? documentHighlightsAt(getAst(doc), getTokens(doc), doc.offsetAt(params.position)) : [];
+});
+
+connection.onCompletion((params: CompletionParams): CompletionItem[] => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return [];
+  }
+  const entries = index.all();
+  const selectors: SelectorCandidate[] = [
+    ...entries
+      .filter((e) => e.kind === SymbolKind.Method)
+      .map((e) => ({ selector: e.name, provenance: Provenance.Workspace })),
+    ...kernelService.selectors().map((s) => ({ selector: s.selector, provenance: s.provenance })),
+  ];
+  const classes: ClassCandidate[] = [
+    ...entries
+      .filter((e) => e.kind === SymbolKind.Class || e.kind === SymbolKind.Namespace)
+      .map((e) => ({ name: e.name, provenance: Provenance.Workspace })),
+    ...kernelService.classes().map((c) => ({ name: c.name, provenance: c.provenance })),
+  ];
+  return completionsAt(
+    doc.offsetAt(params.position),
+    doc.getText(),
+    getTokens(doc),
+    getAst(doc),
+    getSymbols(doc),
+    selectors,
+    classes,
+  );
 });
 
 // Keep the workspace index fresh, debounced so rapid typing does not reparse on
@@ -147,6 +190,24 @@ async function rebuildIndex(): Promise<void> {
     indexDoc(doc.uri, doc.getText());
   }
   connection.console.log(`Indexed ${index.size} Smalltalk file(s).`);
+}
+
+/** Pull `smalltalk.completion.*` and re-resolve the kernel tier. Never throws. */
+async function configureKernel(): Promise<void> {
+  let cfg:
+    | { gnuSmalltalkPath?: string; completion?: { kernelLibrary?: KernelLibrarySetting; kernelPath?: string } }
+    | undefined;
+  try {
+    cfg = (await connection.workspace.getConfiguration('smalltalk')) as typeof cfg;
+  } catch {
+    cfg = undefined;
+  }
+  kernelService.configure({
+    kernelLibrary: cfg?.completion?.kernelLibrary ?? 'auto',
+    kernelPath: cfg?.completion?.kernelPath || undefined,
+    gnuSmalltalkPath: cfg?.gnuSmalltalkPath || undefined,
+  });
+  connection.console.log(`Kernel completion: ${kernelService.identity.label}.`);
 }
 
 function scheduleIndex(uri: string, text: string): void {

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -100,6 +100,7 @@ assert.equal(caps.workspaceSymbolProvider, true, 'expected workspaceSymbolProvid
 assert.equal(caps.definitionProvider, true, 'expected definitionProvider (US-412)');
 assert.equal(caps.foldingRangeProvider, true, 'expected foldingRangeProvider (US-417)');
 assert.equal(caps.documentHighlightProvider, true, 'expected documentHighlightProvider (US-417)');
+assert.ok(caps.completionProvider, 'expected completionProvider (US-413)');
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
@@ -208,11 +209,59 @@ send({
 const hlResult = (await receiveId(5)).result ?? [];
 assert.equal(hlResult.length, 2, 'both `foo` sends should be highlighted');
 
+// --- textDocument/completion (US-413 slice C) ---
+// Kernel completions (bundled, or installed when gst is present) are available
+// without any workspace file; assert a stable kernel selector + class appear.
+const cmpUri = 'file:///completion-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: {
+    textDocument: { uri: cmpUri, languageId: 'smalltalk', version: 1, text: 'x print' },
+  },
+});
+// Cursor right after `print` (selector context after the receiver `x`).
+send({
+  jsonrpc: '2.0',
+  id: 6,
+  method: 'textDocument/completion',
+  params: { textDocument: { uri: cmpUri }, position: { line: 0, character: 7 } },
+});
+const cmpRaw = (await receiveId(6)).result ?? [];
+const cmpItems = Array.isArray(cmpRaw) ? cmpRaw : (cmpRaw.items ?? []);
+assert.ok(cmpItems.length > 0, 'completion should return kernel selectors after a receiver');
+assert.ok(
+  cmpItems.some((i) => i.label === 'printString'),
+  'expected the kernel selector printString among completions',
+);
+const printItem = cmpItems.find((i) => i.label === 'printString');
+assert.match(printItem.detail ?? '', /kernel/, 'kernel completion should carry kernel provenance in detail');
+
+// Head context: a class name from the kernel.
+const cmpHeadUri = 'file:///completion-head-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri: cmpHeadUri, languageId: 'smalltalk', version: 1, text: 'Obj' } },
+});
+send({
+  jsonrpc: '2.0',
+  id: 7,
+  method: 'textDocument/completion',
+  params: { textDocument: { uri: cmpHeadUri }, position: { line: 0, character: 3 } },
+});
+const cmpHeadRaw = (await receiveId(7)).result ?? [];
+const cmpHeadItems = Array.isArray(cmpHeadRaw) ? cmpHeadRaw : (cmpHeadRaw.items ?? []);
+assert.ok(
+  cmpHeadItems.some((i) => i.label === 'Object'),
+  'expected the kernel class Object in head-context completion',
+);
+
 send({ jsonrpc: '2.0', id: 3, method: 'shutdown' });
 await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, documentHighlight, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, documentHighlight, completion, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/providers.test.ts
+++ b/server/test/providers.test.ts
@@ -3,7 +3,13 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { SymbolKind as LspSymbolKind, type DocumentSymbol } from 'vscode-languageserver-types';
+import {
+  CompletionItemKind,
+  InsertTextFormat,
+  SymbolKind as LspSymbolKind,
+  type CompletionItem,
+  type DocumentSymbol,
+} from 'vscode-languageserver-types';
 import { parse } from '../src/parser/parser.ts';
 import { buildSymbolTable, SymbolKind } from '../src/parser/symbols.ts';
 import { toDocumentSymbols } from '../src/providers/documentSymbol.ts';
@@ -13,6 +19,8 @@ import { findDefinitions, resolveDefinitionQuery } from '../src/providers/defini
 import { tokenize } from '../src/parser/lexer.ts';
 import { toFoldingRanges } from '../src/providers/foldingRange.ts';
 import { documentHighlightsAt } from '../src/providers/documentHighlight.ts';
+import { completionsAt } from '../src/providers/completion.ts';
+import { Provenance } from '../src/kernel/model.ts';
 
 const FIXTURE_DIR = path.join(process.cwd(), 'docs/research/gst-syntax/test-cases');
 
@@ -212,6 +220,80 @@ test('highlight on a variable includes its declaration and assignment writes', (
   const hs = highlightsAt(src, '^x'); // a use of x
   // declaration x, assignment target x, and ^x — but not y.
   assert.equal(hs.length, 3);
+});
+
+// --- completion (US-413 slice C) -------------------------------------------
+const complete = (
+  src: string,
+  offset: number,
+  selectors: { selector: string; provenance: Provenance }[],
+  classes: { name: string; provenance: Provenance }[],
+): CompletionItem[] =>
+  completionsAt(offset, src, tokenize(src).tokens, parse(src).ast, buildSymbolTable(parse(src).ast), selectors, classes);
+
+test('completion: selector context after a receiver offers selectors + keyword snippet', () => {
+  const src = 'x at';
+  const items = complete(
+    src,
+    src.length,
+    [
+      { selector: 'at:put:', provenance: Provenance.BundledKernel },
+      { selector: 'at:', provenance: Provenance.BundledKernel },
+      { selector: 'add:', provenance: Provenance.Workspace }, // doesn't match "at"
+    ],
+    [],
+  );
+  const labels = items.map((i) => i.label);
+  assert.ok(labels.includes('at:put:') && labels.includes('at:'), 'should offer at:put: and at:');
+  assert.ok(!labels.includes('add:'), 'add: does not match prefix "at"');
+  const atput = items.find((i) => i.label === 'at:put:');
+  assert.equal(atput?.insertTextFormat, InsertTextFormat.Snippet);
+  assert.equal(atput?.insertText, 'at:${1} put:${2}', 'multi-part keyword inserts as a snippet');
+});
+
+test('completion: workspace selectors rank above kernel selectors', () => {
+  const src = 'x pr';
+  const items = complete(
+    src,
+    src.length,
+    [
+      { selector: 'printString', provenance: Provenance.BundledKernel },
+      { selector: 'printOn:', provenance: Provenance.Workspace },
+    ],
+    [],
+  );
+  const ws = items.find((i) => i.label === 'printOn:');
+  const kn = items.find((i) => i.label === 'printString');
+  assert.ok(ws && kn);
+  assert.ok((ws.sortText ?? '') < (kn.sortText ?? ''), 'workspace selector sorts before kernel selector');
+});
+
+test('completion: head context offers in-scope variables (instance vars)', () => {
+  const src = 'Object subclass: Foo [ | count | bar [ | total | ^c ] ]';
+  const offset = src.indexOf('^c') + 2; // just after the `c`
+  const items = complete(src, offset, [], [{ name: 'Collection', provenance: Provenance.Workspace }]);
+  const count = items.find((i) => i.label === 'count');
+  assert.ok(count, 'should offer the in-scope instance variable count');
+  assert.equal(count?.detail, 'instanceVariable');
+  assert.ok(!items.some((i) => i.label === 'total'), 'total does not match prefix "c"');
+});
+
+test('completion: head context offers class names; camel-hump matches', () => {
+  const src = 'OC';
+  const items = complete(src, src.length, [], [{ name: 'OrderedCollection', provenance: Provenance.Workspace }]);
+  const oc = items.find((i) => i.label === 'OrderedCollection');
+  assert.ok(oc, 'camel-hump prefix OC should match OrderedCollection');
+  assert.equal(oc?.kind, CompletionItemKind.Class);
+});
+
+test('completion: variables rank above classes in head context', () => {
+  const src = 'Object subclass: Foo [ bar [ | value | ^v ] ]';
+  const offset = src.indexOf('^v') + 2;
+  const items = complete(src, offset, [], [{ name: 'Value', provenance: Provenance.Workspace }]);
+  const v = items.find((i) => i.label === 'value');
+  const cls = items.find((i) => i.label === 'Value');
+  assert.ok(v && cls);
+  assert.ok((v.sortText ?? '') < (cls.sortText ?? ''), 'in-scope variable sorts before a class');
 });
 
 console.log(`providers: ${passed} tests passed.`);

--- a/specs/US-413-Completion-And-Kernel-Index/tasks.md
+++ b/specs/US-413-Completion-And-Kernel-Index/tasks.md
@@ -34,14 +34,19 @@ Mark each task `[x]` as it lands. Tasks map to acceptance criteria and PR slices
   PR (B) opened, CI watched, merge held. *(VSIX bundling of the JSON verified in slice C / T301.)*
 
 ## Phase 3 — Slice C: completion provider (AC2–AC4, AC7 items)
-- [ ] T300 `server/src/providers/completion.ts` — cursor-context detection over `parseCache`
-  (receiver → selectors; head → classes + scope vars); merge workspace + kernel; rank
-  workspace > installed > bundled (prefix + camel-hump); keyword-selector snippets; provenance in items.
-- [ ] T301 Advertise `completionProvider` + wire `onCompletion` in `server.ts`; ensure
-  `kernel-index.json` is bundled into the VSIX.
-- [ ] T302 Provider unit tests at cursor positions; extend `test:server` for completion; e2e fixture
-  asserting kernel + workspace completions.
-- [ ] T303 Layers green; PR (C) opened, CI watched, merge held.
+- [x] T300 `server/src/providers/completion.ts` — token-based cursor-context detection (receiver/`;` →
+  selectors; head → in-scope vars + classes); merge workspace + kernel; rank
+  workspace > installed > bundled (prefix + camel-hump); keyword-selector snippets; provenance in
+  `detail`/`sortText`. In-scope vars via AST path + symbol-table class lookup.
+- [x] T301 Advertise `completionProvider` (`triggerCharacters [' ', ':']`) + wire `onCompletion`,
+  `configureKernel` (pull `smalltalk.completion.*`) in `server.ts`. JSON imported via
+  `bundledIndex.ts` → **esbuild inlines it into `dist/server.js`** (verified: bundle grew, VSIX ships
+  `server.js`; `npm run package` smoke ✓).
+- [x] T302 Provider unit tests (5, in `providers.test.ts`); `handshake.test.mjs` drives real
+  `textDocument/completion` (selector + head); `client/test-e2e/completion.test.js` (selector / snippet
+  / head-class). e2e 10/10.
+- [~] T303 `check-types`/`lint`/`test:parser` (23 providers)/`test:server`/`test:e2e` (10) /`package`
+  green locally; PR (C) opened, CI watched, merge held.
 
 ## Phase 4 — Slice D: settings + status UX (AC5/AC7)
 - [ ] T400 `smalltalk.completion.kernelLibrary` (`auto|bundled|off`) + `smalltalk.completion.kernelPath`


### PR DESCRIPTION
feat(US-413): completion provider over workspace + kernel (slice C)

## Summary

Third slice of **US-413** — `textDocument/completion` (**AC2–AC4 + AC7 item provenance**), the **first user-visible surface** of 0.5.0 and the direct answer to #1. Offers **selectors after a receiver** and **class names + in-scope variables in head position**, merging the workspace index with the active kernel tier (slice B). **No `gst` required**; no parser/AST change.

**Closes:** _n/a — slice 3 of 4; #1 closes when US-413 ships in 0.5.0_ &nbsp;|&nbsp; **Story:** US-413 (#25) &nbsp;|&nbsp; **ADR:** [docs/decisions/0002-kernel-symbol-sourcing.md](docs/decisions/0002-kernel-symbol-sourcing.md) &nbsp;|&nbsp; Builds on slices A (#51) + B (#52).

### What's here
- **`server/src/providers/completion.ts`** — `completionsAt`: **token-based context detection** (receiver / cascade `;` → selectors; head → in-scope vars + classes), robust at an incomplete cursor. Candidates are merged workspace + kernel, **deduped keeping the highest-confidence provenance**, ranked **workspace > installed > bundled** via `sortText`; **prefix + camel-hump** matching. Keyword selectors insert as **snippets** (`at:put:` → `at:${1} put:${2}`). In-scope variables = AST-path temps/params + the enclosing class's instance/class vars (symbol table).
- **`server/src/server.ts`** — advertises `completionProvider` (`triggerCharacters [' ', ':']`) + `onCompletion`; `configureKernel` pulls `smalltalk.completion.*` + `gnuSmalltalkPath` on init and config change (sync `auto` default at init so completion is ready immediately). The bundled index enters the esbuild graph via `bundledIndex.ts` and is **inlined into `dist/server.js`**.
- **Tests at all three layers:** `providers.test.ts` (5 — selector+snippet, workspace>kernel ranking, in-scope vars, class camel-hump, var>class ranking); `handshake.test.mjs` drives real `textDocument/completion` (selector + head); `client/test-e2e/completion.test.js` (selector / snippet / head-class).

### Provenance & honesty (AC7, items)
Each item carries provenance in `detail` (`workspace` / `kernel (installed)` / `kernel (bundled)`) and ranking via `sortText`. The ambient **status-bar indicator + one-time fallback notice** land in **slice D**.

### Next
- **Slice D** — `smalltalk.completion.kernelLibrary`/`kernelPath` in `package.json` + status-bar identity + one-time bundle-fallback notice (AC5/AC7 UX).

## Output Eval — *is the artifact right?*
- [x] **AC2/AC3/AC4** + **AC7 (item provenance)** met.
- [ ] Output eval dataset — _completion dataset lands with slice D / story close (plan T900)._
- [x] CI green on **Linux/macOS/Windows** — all three `build` jobs pass (run 27911335219).
- [ ] Manual QA in an Extension Dev Host — _gated at the story `verification.md` matrix before 0.5.0._
- [x] Local: `check-types` ✓ · `lint` ✓ · `test:parser` (23 providers) ✓ · `test:server` ✓ · `test:e2e` **10/10** ✓ · `package` smoke ✓ (VSIX ships the inlined index).

## Trajectory Eval — *was it produced the right way?*
- [x] Traces to US-413 (#25); slice C in `plan.md`/`tasks.md`; ADR-0002 honoured (ranking + provenance).
- [x] Tests with the change at all three layers; chose token-based context detection (robust mid-edit) over fragile AST-at-incomplete-cursor; conventional scoped commit.
- [ ] Reviewer sign-off.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice.
