### PR TITLE
feat(US-413): kernel-library settings + status-bar identity (slice D)

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { commands, type ExtensionContext, window } from 'vscode';
+import { commands, StatusBarAlignment, type StatusBarItem, type ExtensionContext, window } from 'vscode';
 import {
   LanguageClient,
   TransportKind,
@@ -10,11 +10,30 @@ import { runCurrentFile } from './commands/runCurrentFile';
 
 let client: LanguageClient | undefined;
 
+/** Custom notification from the server: the resolved kernel-completion source (US-413). */
+const KERNEL_STATUS_NOTIFICATION = 'smalltalk/kernelStatus';
+
+interface KernelStatus {
+  readonly source: 'installed' | 'bundled' | 'off';
+  readonly label: string;
+  /** The configured `kernelLibrary` (`auto` falling back to `bundled` is a fallback). */
+  readonly requested?: 'auto' | 'bundled' | 'off';
+}
+
 export function activate(context: ExtensionContext): void {
   // Commands (workflow features; independent of the language server).
   context.subscriptions.push(
     commands.registerCommand('smalltalk.runCurrentFile', runCurrentFile),
   );
+
+  // Status bar: which kernel-library completions are active (US-413 / AC7).
+  const kernelStatus = window.createStatusBarItem(StatusBarAlignment.Right, 90);
+  kernelStatus.command = {
+    title: 'Configure Smalltalk kernel completions',
+    command: 'workbench.action.openSettings',
+    arguments: ['smalltalk.completion.kernelLibrary'],
+  };
+  context.subscriptions.push(kernelStatus);
 
   // The server is bundled next to the client in dist/.
   const serverModule = context.asAbsolutePath(path.join('dist', 'server.js'));
@@ -38,7 +57,39 @@ export function activate(context: ExtensionContext): void {
     clientOptions,
   );
 
-  void client.start();
+  let fallbackNoticeShown = false;
+  void client.start().then(() => {
+    client?.onNotification(KERNEL_STATUS_NOTIFICATION, (status: KernelStatus) => {
+      updateKernelStatusBar(kernelStatus, status);
+      // One-time notice when `auto` falls back to the bundled reference.
+      if (!fallbackNoticeShown && status.requested === 'auto' && status.source === 'bundled') {
+        fallbackNoticeShown = true;
+        void window
+          .showInformationMessage(
+            'No GNU Smalltalk installation found — kernel completions use a bundled reference ' +
+              '(GNU Smalltalk 3.2.5). Install gst or set "smalltalk.completion.kernelPath" for ' +
+              'version-correct completions.',
+            'Open Settings',
+          )
+          .then((choice) => {
+            if (choice === 'Open Settings') {
+              void commands.executeCommand('workbench.action.openSettings', 'smalltalk.completion');
+            }
+          });
+      }
+    });
+  });
+}
+
+function updateKernelStatusBar(item: StatusBarItem, status: KernelStatus): void {
+  if (status.source === 'off') {
+    item.text = '$(circle-slash) Smalltalk kernel: off';
+    item.tooltip = 'Kernel-library completions are disabled. Click to change.';
+  } else {
+    item.text = `$(library) Smalltalk kernel: ${status.label}`;
+    item.tooltip = `Kernel-library completions: ${status.label}. Click to change.`;
+  }
+  item.show();
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/test-e2e/completion.test.js
+++ b/client/test-e2e/completion.test.js
@@ -70,6 +70,37 @@ suite('US-413 completion (e2e)', () => {
   });
 });
 
+suite('US-413 kernel library setting (e2e)', () => {
+  const cfg = () => vscode.workspace.getConfiguration('smalltalk.completion');
+
+  test('AC5 default kernelLibrary is auto', () => {
+    assert.strictEqual(cfg().get('kernelLibrary'), 'auto');
+  });
+
+  test('AC5 off suppresses kernel completions; bundled restores them', async () => {
+    const doc = await openSmalltalk('x print');
+    const position = new vscode.Position(0, 'x print'.length);
+    const original = cfg().inspect('kernelLibrary').workspaceValue;
+    try {
+      await cfg().update('kernelLibrary', 'off', vscode.ConfigurationTarget.Workspace);
+      const off = await waitFor(
+        () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, position),
+        (r) => !items(r).some((i) => label(i) === 'printString'),
+      );
+      assert.ok(!items(off).some((i) => label(i) === 'printString'), 'off should suppress kernel selectors');
+
+      await cfg().update('kernelLibrary', 'bundled', vscode.ConfigurationTarget.Workspace);
+      const bundled = await waitFor(
+        () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, position),
+        (r) => items(r).some((i) => label(i) === 'printString'),
+      );
+      assert.ok(items(bundled).some((i) => label(i) === 'printString'), 'bundled should provide kernel selectors');
+    } finally {
+      await cfg().update('kernelLibrary', original, vscode.ConfigurationTarget.Workspace);
+    }
+  });
+});
+
 function label(item) {
   return typeof item.label === 'string' ? item.label : item.label && item.label.label;
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,26 @@
                     "default": "",
                     "description": "Absolute path to the GNU Smalltalk executable (gst). If empty, the extension will attempt to find 'gst' in your system PATH."
                 },
+                "smalltalk.completion.kernelLibrary": {
+                    "type": "string",
+                    "enum": [
+                        "auto",
+                        "bundled",
+                        "off"
+                    ],
+                    "enumDescriptions": [
+                        "Index the kernel of an installed GNU Smalltalk if one is found (version-correct); otherwise use the bundled reference.",
+                        "Always use the bundled reference library (GNU Smalltalk 3.2.5).",
+                        "No kernel-library completions; only symbols from your workspace."
+                    ],
+                    "default": "auto",
+                    "markdownDescription": "Source for standard kernel-library completions (classes/selectors). `auto` prefers your **installed** GNU Smalltalk kernel and falls back to the **bundled** reference (**GNU Smalltalk 3.2.5**). The active source is shown in the status bar. Workspace symbols are always available regardless of this setting."
+                },
+                "smalltalk.completion.kernelPath": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Optional path to a GNU Smalltalk **kernel source directory** (the folder of `.st` files, e.g. `…/share/smalltalk/kernel`) used by `auto`. If empty, the kernel directory is discovered from `#smalltalk.gnuSmalltalkPath#` and common install locations."
+                },
                 "smalltalk.trace.server": {
                     "type": "string",
                     "enum": [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -40,6 +40,9 @@ const documents = new TextDocuments(TextDocument);
 const index = new WorkspaceIndex();
 const kernelService = new KernelIndexService();
 
+/** Custom notification: the resolved kernel-completion source (for the status bar). */
+const KERNEL_STATUS_NOTIFICATION = 'smalltalk/kernelStatus';
+
 const INDEX_DEBOUNCE_MS = 250;
 const indexTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let workspaceFolders: string[] = [];
@@ -202,12 +205,17 @@ async function configureKernel(): Promise<void> {
   } catch {
     cfg = undefined;
   }
+  const requested = cfg?.completion?.kernelLibrary ?? 'auto';
   kernelService.configure({
-    kernelLibrary: cfg?.completion?.kernelLibrary ?? 'auto',
+    kernelLibrary: requested,
     kernelPath: cfg?.completion?.kernelPath || undefined,
     gnuSmalltalkPath: cfg?.gnuSmalltalkPath || undefined,
   });
-  connection.console.log(`Kernel completion: ${kernelService.identity.label}.`);
+  const identity = kernelService.identity;
+  connection.console.log(`Kernel completion: ${identity.label}.`);
+  // Tell the client so it can show the active source in the status bar and, on a
+  // fallback to the bundle, a one-time notice (AC7).
+  connection.sendNotification(KERNEL_STATUS_NOTIFICATION, { ...identity, requested });
 }
 
 function scheduleIndex(uri: string, text: string): void {

--- a/specs/US-413-Completion-And-Kernel-Index/tasks.md
+++ b/specs/US-413-Completion-And-Kernel-Index/tasks.md
@@ -49,11 +49,15 @@ Mark each task `[x]` as it lands. Tasks map to acceptance criteria and PR slices
   green locally; PR (C) opened, CI watched, merge held.
 
 ## Phase 4 — Slice D: settings + status UX (AC5/AC7)
-- [ ] T400 `smalltalk.completion.kernelLibrary` (`auto|bundled|off`) + `smalltalk.completion.kernelPath`
-  in `package.json` (descriptions name the bundled dialect/version).
-- [ ] T401 Status-bar item showing resolved kernel identity (click → setting); one-time bundle-fallback
-  notice.
-- [ ] T402 e2e for the setting/status paths; layers green; PR (D) opened, CI watched, merge held.
+- [x] T400 `smalltalk.completion.kernelLibrary` (`auto|bundled|off`, default `auto`) +
+  `smalltalk.completion.kernelPath` in `package.json` (markdownDescription names the bundled dialect/
+  version: GNU Smalltalk 3.2.5; `kernelPath` cross-links `#smalltalk.gnuSmalltalkPath#`).
+- [x] T401 Status-bar item (`client/src/extension.ts`) showing resolved kernel identity (click → opens
+  the setting); one-time bundle-fallback notice on `auto`→`bundled`. Server pushes
+  `smalltalk/kernelStatus` from `configureKernel` (identity + requested setting).
+- [~] T402 e2e for the setting path (`AC5 default auto`; `off` suppresses / `bundled` restores kernel
+  completions — full setting→reconfigure→completion round-trip). `check-types`/`lint`/`test:parser`/
+  `test:server`/`test:e2e` (12) /`package` green locally; PR (D) opened, CI watched, merge held.
 
 ## Phase 5 — Verify & Release
 - [ ] T900 Output eval extended (`evals/` completion dataset) + `npm run eval` green.


### PR DESCRIPTION
feat(US-413): kernel-library settings + status-bar identity (slice D)

## Summary

Final slice of **US-413** — the user-facing **settings** and **ambient status** that make kernel sourcing explicit and controllable (**AC5 + AC7 status/notice**). **Completes the story's acceptance criteria (AC1–AC7).**

**Closes:** _n/a — completes US-413; #1 closes at the 0.5.0 release_ &nbsp;|&nbsp; **Story:** US-413 (#25) &nbsp;|&nbsp; **ADR:** [docs/decisions/0002-kernel-symbol-sourcing.md](docs/decisions/0002-kernel-symbol-sourcing.md) &nbsp;|&nbsp; Builds on slices A (#51) + B (#52) + C (#53).

### What's here
- **`package.json`** — `smalltalk.completion.kernelLibrary` (`auto` | `bundled` | `off`, default `auto`) + `smalltalk.completion.kernelPath`. The enum value stays the stable `bundled`, but the markdown descriptions name the **bundled identity (GNU Smalltalk 3.2.5)** and cross-link `#smalltalk.gnuSmalltalkPath#` — so dialect/version is explicit to the user.
- **`server/src/server.ts`** — after resolving, pushes a `smalltalk/kernelStatus` notification (identity + the requested setting) to the client.
- **`client/src/extension.ts`** — a **status-bar item** showing the resolved kernel identity (`bundled (gst 3.2.5)` / `installed (gst)` / `off`); click opens the setting. A **one-time notice** when `auto` falls back to the bundle (with an *Open Settings* action). Keeps completion honest about provenance.
- **`client/test-e2e/completion.test.js`** — AC5 e2e: default is `auto`; `off` suppresses kernel completions and `bundled` restores them (full setting → server reconfigure → completion round-trip).

### Anti-confusion (the original concern)
Provenance now appears in three places: completion item `detail` (slice C), the ambient **status bar**, and a **one-time fallback notice** — so a bundled suggestion is never mistaken for a guaranteed-installed one. `off` disables the kernel tier entirely.

### Next (story close, held for owner)
- Output eval dataset (`evals/`); the **`verification.md` manual-QA matrix** in the Extension Dev Host (real-corpus workspace, installed vs bundled, clean-install VSIX); close #1 with a demo; doc-rot audit; bump version + CHANGELOG; cut **v0.5.0**.

## Output Eval — *is the artifact right?*
- [x] **AC5 + AC7** met — settings control the kernel tier; status bar + notice surface the active source. **US-413 AC1–AC7 complete.**
- [ ] Output eval dataset — _completion dataset added at story close (plan T900)._
- [x] CI green on **Linux/macOS/Windows** — all three `build` jobs pass (run 27911617168).
- [ ] Manual QA in an Extension Dev Host — _the `verification.md` matrix is the 0.5.0 release gate (held for owner)._
- [x] Local: `check-types` ✓ · `lint` ✓ · `test:parser` ✓ · `test:server` ✓ · `test:e2e` **12/12** ✓ · `package` smoke ✓.

## Trajectory Eval — *was it produced the right way?*
- [x] Traces to US-413 (#25); slice D in `plan.md`/`tasks.md`; ADR-0002 honoured (`bundled` strategy value + explicit identity in status/descriptions, not the enum).
- [x] Tests with the change (AC5 round-trip e2e); conventional scoped commit.
- [ ] Reviewer sign-off.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the slice (and the completed story).
