### PR TITLE
test(US-413): completion output-eval dataset + manual verification matrix

### DIFF
--- a/evals/datasets/completion/cases.json
+++ b/evals/datasets/completion/cases.json
@@ -1,0 +1,48 @@
+{
+  "description": "US-413 completion output eval — golden cases over the bundled gst-3.2.5 kernel index. Metric: expected item present within top-k (after sortText ordering) + ranking sanity (workspace > kernel, variable > class) + keyword-snippet insertion + facts-only (no binary selectors offered as words). The `▮` marks the cursor; `workspaceSelectors`/`workspaceClasses` are injected as workspace-provenance candidates alongside the real bundled kernel.",
+  "cases": [
+    {
+      "name": "AC2 selector context after a receiver offers a kernel selector",
+      "text": "x print▮",
+      "expectTopK": { "k": 25, "labels": ["printString"] }
+    },
+    {
+      "name": "AC2 unary selector by camel-hump (dN -> doesNotUnderstand:)",
+      "text": "x dNU▮",
+      "expectTopK": { "k": 10, "labels": ["doesNotUnderstand:"] }
+    },
+    {
+      "name": "AC4 multi-part keyword selector inserts as a snippet",
+      "text": "x at▮",
+      "expectTopK": { "k": 40, "labels": ["at:put:"] },
+      "expectSnippet": { "label": "at:put:", "insertText": "at:${1} put:${2}" }
+    },
+    {
+      "name": "AC2 ranking: workspace selector ranks above the kernel selector",
+      "text": "x pr▮",
+      "workspaceSelectors": ["printOn:"],
+      "expectOrderBefore": [["printOn:", "printString"]]
+    },
+    {
+      "name": "AC3 head context offers a kernel class name (camel-hump OC)",
+      "text": "OC▮",
+      "expectTopK": { "k": 60, "labels": ["OrderedCollection"] }
+    },
+    {
+      "name": "AC3 head context offers in-scope instance variable",
+      "text": "Object subclass: Foo [ | count | bar [ ^c▮ ] ]",
+      "expectTopK": { "k": 30, "labels": ["count"] }
+    },
+    {
+      "name": "AC3 ranking: in-scope variable ranks above a class of the same prefix",
+      "text": "Object subclass: Foo [ bar [ | value | ^v▮ ] ]",
+      "workspaceClasses": ["Value"],
+      "expectOrderBefore": [["value", "Value"]]
+    },
+    {
+      "name": "AC5/off-by-construction: binary selectors are not offered for a typed word",
+      "text": "x print▮",
+      "expectAbsent": ["+", "->", "<="]
+    }
+  ]
+}

--- a/evals/datasets/completion/run.ts
+++ b/evals/datasets/completion/run.ts
@@ -1,0 +1,102 @@
+// Completion output eval (US-413). Deterministic golden-dataset check, run in CI
+// via `npm run eval`. Drives the real completion provider over the committed
+// bundled gst-3.2.5 kernel index (no corpus, no gst, no VS Code) and asserts the
+// metric for each case in cases.json:
+//   - expectTopK:       each label appears within the first k items (sortText order)
+//   - expectSnippet:    a keyword selector inserts as a Snippet with the given text
+//   - expectOrderBefore: label A is ranked before label B (workspace>kernel, var>class)
+//   - expectAbsent:     labels must not appear (e.g. binary selectors for a typed word)
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { InsertTextFormat, type CompletionItem } from 'vscode-languageserver-types';
+import { parse } from '../../../server/src/parser/parser.ts';
+import { buildSymbolTable } from '../../../server/src/parser/symbols.ts';
+import { tokenize } from '../../../server/src/parser/lexer.ts';
+import { completionsAt, type ClassCandidate, type SelectorCandidate } from '../../../server/src/providers/completion.ts';
+import { KernelIndexService } from '../../../server/src/kernel/kernelIndexService.ts';
+import { Provenance } from '../../../server/src/kernel/model.ts';
+
+interface Case {
+  name: string;
+  text: string;
+  workspaceSelectors?: string[];
+  workspaceClasses?: string[];
+  expectTopK?: { k: number; labels: string[] };
+  expectSnippet?: { label: string; insertText: string };
+  expectOrderBefore?: [string, string][];
+  expectAbsent?: string[];
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const { cases } = JSON.parse(fs.readFileSync(path.join(here, 'cases.json'), 'utf8')) as { cases: Case[] };
+
+// Bundled kernel candidates (deterministic; common-location probing disabled).
+const kernel = new KernelIndexService(undefined, []);
+kernel.configure({ kernelLibrary: 'bundled' });
+const kernelSelectors: SelectorCandidate[] = kernel.selectors().map((s) => ({ selector: s.selector, provenance: s.provenance }));
+const kernelClasses: ClassCandidate[] = kernel.classes().map((c) => ({ name: c.name, provenance: c.provenance }));
+
+const labelOf = (i: CompletionItem): string => (typeof i.label === 'string' ? i.label : i.label.label);
+
+function itemsFor(c: Case): CompletionItem[] {
+  const offset = c.text.indexOf('▮');
+  assert.ok(offset >= 0, `case "${c.name}" must mark the cursor with ▮`);
+  const text = c.text.replace('▮', '');
+  const selectors: SelectorCandidate[] = [
+    ...(c.workspaceSelectors ?? []).map((s) => ({ selector: s, provenance: Provenance.Workspace })),
+    ...kernelSelectors,
+  ];
+  const classes: ClassCandidate[] = [
+    ...(c.workspaceClasses ?? []).map((n) => ({ name: n, provenance: Provenance.Workspace })),
+    ...kernelClasses,
+  ];
+  const ast = parse(text).ast;
+  const items = completionsAt(offset, text, tokenize(text).tokens, ast, buildSymbolTable(ast), selectors, classes);
+  // Sort as VS Code does: by sortText (falling back to label).
+  return [...items].sort((a, b) => (a.sortText ?? labelOf(a)).localeCompare(b.sortText ?? labelOf(b)));
+}
+
+let passed = 0;
+let failed = 0;
+for (const c of cases) {
+  try {
+    const items = itemsFor(c);
+    const labels = items.map(labelOf);
+
+    if (c.expectTopK) {
+      for (const label of c.expectTopK.labels) {
+        const idx = labels.indexOf(label);
+        assert.ok(idx >= 0, `expected "${label}" in completions`);
+        assert.ok(idx < c.expectTopK.k, `expected "${label}" within top-${c.expectTopK.k} (got rank ${idx})`);
+      }
+    }
+    if (c.expectSnippet) {
+      const item = items.find((i) => labelOf(i) === c.expectSnippet!.label);
+      assert.ok(item, `expected snippet item "${c.expectSnippet.label}"`);
+      assert.equal(item.insertTextFormat, InsertTextFormat.Snippet, `"${c.expectSnippet.label}" must be a Snippet`);
+      assert.equal(item.insertText, c.expectSnippet.insertText, `"${c.expectSnippet.label}" snippet text`);
+    }
+    for (const [a, b] of c.expectOrderBefore ?? []) {
+      const ia = labels.indexOf(a);
+      const ib = labels.indexOf(b);
+      assert.ok(ia >= 0 && ib >= 0, `expected both "${a}" and "${b}" present`);
+      assert.ok(ia < ib, `expected "${a}" ranked before "${b}" (got ${ia} vs ${ib})`);
+    }
+    for (const label of c.expectAbsent ?? []) {
+      assert.ok(!labels.includes(label), `expected "${label}" to be absent`);
+    }
+
+    passed += 1;
+    console.log(`  ok - ${c.name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`  FAIL - ${c.name}: ${(e as Error).message}`);
+  }
+}
+
+console.log(`completion eval: ${passed}/${cases.length} cases passed (kernel: ${kernelClasses.length} classes).`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
         "gen:kernel-index": "tsx scripts/gen-kernel-index.ts",
         "build:grammar": "js-yaml syntaxes/gnu-smalltalk.YAML-tmLanguage > syntaxes/gnu-smalltalk.tmLanguage.json",
         "test:grammar": "node src/test/grammar-verification.js",
-        "eval": "npm run build:grammar && npm run test:grammar",
+        "eval:completion": "tsx evals/datasets/completion/run.ts",
+        "eval": "npm run build:grammar && npm run test:grammar && npm run eval:completion",
         "new-story": "bash scripts/new-story.sh"
     }
 }

--- a/specs/US-413-Completion-And-Kernel-Index/tasks.md
+++ b/specs/US-413-Completion-And-Kernel-Index/tasks.md
@@ -60,8 +60,9 @@ Mark each task `[x]` as it lands. Tasks map to acceptance criteria and PR slices
   `test:server`/`test:e2e` (12) /`package` green locally; PR (D) opened, CI watched, merge held.
 
 ## Phase 5 — Verify & Release
-- [ ] T900 Output eval extended (`evals/` completion dataset) + `npm run eval` green.
-- [ ] T901 `verification.md` manual-QA matrix executed in the Extension Dev Host (incl. real-corpus +
-  clean-install VSIX) and signed off.
-- [ ] T902 CI green on Linux/macOS/Windows for all slices.
+- [x] T900 Output eval extended — `evals/datasets/completion/` (cases.json + run.ts), wired into
+  `npm run eval` via `eval:completion`; **8/8** cases pass (CI runs `npm run eval` on all 3 OSes).
+- [~] T901 `verification.md` manual-QA matrix **staged** (12-row matrix + automated-evidence table);
+  manual pass in the Extension Dev Host (real-corpus + clean-install VSIX) **held for owner**.
+- [x] T902 CI green on Linux/macOS/Windows for slices A–D (#51–#54).
 - [ ] T903 Issue #1 closed with a demo; doc-rot audit; bump version + CHANGELOG; **owner** cuts v0.5.0.

--- a/specs/US-413-Completion-And-Kernel-Index/verification.md
+++ b/specs/US-413-Completion-And-Kernel-Index/verification.md
@@ -1,29 +1,70 @@
-# Implementation Verification Checklist
+# Implementation Verification — US-413: Completion + Kernel Index
 
-**Purpose**: Verify implementation correctness AFTER coding  
-**Type**: Implementation Verification  
+**Purpose**: Verify the implementation AFTER coding, and gate the **0.5.0** release.
+**Type**: Implementation Verification + Manual-QA release gate
+**Story**: US-413 · **Spec**: ./spec.md · **ADR**: [0002](../../docs/decisions/0002-kernel-symbol-sourcing.md)
+
+> Per PO direction (see memory *manual-qa-before-release*), 0.5.0 does **not** ship on green CI alone:
+> the §3 manual matrix must be executed in the Extension Development Host — favouring **real code**
+> (open `../smalltalk-3.2.5/kernel/`) and a **clean-install VSIX** smoke — and signed off below.
 
 ---
 
-## Section 1: Acceptance Criteria
-- [ ] All ACs in `tasks.md` are checked?
-- [ ] Each AC has a passing test?
+## Section 1: Acceptance Criteria → evidence (automated)
 
-## Section 2: Code Quality
-- [ ] `npm run lint` passes?
-- [ ] `npm test` passes?
-- [ ] No `any` types in TypeScript (unless justified)?
-- [ ] JSDoc provided for public APIs?
+| AC | What | Evidence | Status |
+|---|---|---|---|
+| AC1 | Build-time generator → `server/data/kernel-index.json` (facts only) | `kernelIndex.test.ts` (invariants + **licensing no-prose gate** + drift guard); 250 classes / 4723 selectors | ✅ |
+| AC2 | Selector completion after a receiver; ranking + prefix/camel-hump | `providers.test.ts`, `eval` cases, `handshake`/e2e | ✅ |
+| AC3 | Class names in head position + in-scope variables | `providers.test.ts`, `eval`, e2e | ✅ |
+| AC4 | Multi-part keyword selectors insert as snippets | `providers.test.ts`, `eval` (`at:put:` → `at:${1} put:${2}`), e2e | ✅ |
+| AC5 | `kernelLibrary` (`auto\|bundled\|off`) + `kernelPath` | `kernelService.test.ts`, e2e (`off` suppresses / `bundled` restores) | ✅ |
+| AC6 | Live-index an installed kernel when discoverable, else bundle | `kernelService.test.ts` (discovery + auto-installed + fallback) | ✅ |
+| AC7 | Item provenance + status-bar identity + one-time fallback notice | item `detail`/`sortText` (slice C); status bar + notice (slice D, manual §3 rows 6/8) | ✅ (status: manual) |
 
-## Section 3: Constitutional Compliance
-- [ ] **Native**: Follows VS Code guidelines?
-- [ ] **Zero Config**: Works without manual setup?
-- [ ] **Robustness**: Handles errors gracefully?
-- [ ] **TDD**: Tests were written/exist?
+## Section 2: Code Quality & Automated Gates
 
-## Section 4: Manual Verification
-- [ ] Feature works in Extension Host?
-- [ ] No errors in Developer Tools console?
+- [x] `npm run check-types` (strict) passes.
+- [x] `npm run lint` passes.
+- [x] `npm run test:parser` passes (kernel smoke + kernelIndex 6 + kernelService 10 + providers 23).
+- [x] `npm run test:server` passes (real `textDocument/completion`).
+- [x] `npm run test:e2e` passes — **12/12** (3 completion + 2 setting rows added).
+- [x] `npm run eval` passes — grammar + **completion eval 8/8** (`evals/datasets/completion/`).
+- [x] `npm run package` smoke OK — VSIX ships `dist/server.js` with the **inlined** kernel index.
+- [x] No unjustified `any`; public APIs carry JSDoc (model/indexer/service/provider).
+- [ ] CI green on **Linux / macOS / Windows** for the final merge commit (confirm post-merge).
 
-## Section 5: Sign-Off
-- [ ] Ready for Merge?
+## Section 3: Manual Verification Matrix (Extension Dev Host — 0.5.0 release gate)
+
+Run with **F5** (dev build) and again from a **clean-install VSIX**. Record result + a short note.
+
+| # | Area | Steps | Expected | Result |
+|---|---|---|---|---|
+| 1 | Real-corpus workspace | Open `../smalltalk-3.2.5/kernel/`; in a `.st` file type `x print` and trigger completion | Kernel selectors (`printString`, `printNl`, …) appear after the receiver | ☐ |
+| 2 | Selector ranking | In a workspace defining its own selectors, complete after a receiver | Workspace selectors rank above kernel; prefix **and** camel-hump both filter | ☐ |
+| 3 | Class & variable | Inside a method with a temp + instance var, complete in head position | In-scope variables appear first, then class names; correct icons (Field/Variable/Class) | ☐ |
+| 4 | Keyword snippet | Accept `at:put:` | Inserts `at:${1} put:${2}`; Tab jumps between the two argument stops | ☐ |
+| 5 | Sourcing — installed | With `gst` installed (or `kernelPath` set), reload | Status bar reads **installed (gst)**; completions match that kernel | ☐ |
+| 6 | Sourcing — bundled fallback | With no `gst` and `kernelLibrary=auto` | Status bar reads **bundled (gst 3.2.5)**; one-time fallback notice appears with *Open Settings* | ☐ |
+| 7 | `off` | Set `smalltalk.completion.kernelLibrary=off` | Kernel completions disappear; only workspace symbols remain; status bar reads **off** | ☐ |
+| 8 | Provenance honesty | Inspect a kernel completion's detail | Detail shows `kernel (bundled)` / `kernel (installed)`; status bar agrees | ☐ |
+| 9 | Robustness / live edit | Type into a half-written/malformed method; add a new method then complete | Useful (partial) completions, never a thrown error; new symbols appear within ~debounce | ☐ |
+| 10 | No-`gst` & zero-config | Fresh machine defaults (no settings, no gst) | Useful kernel completions out of the box (bundled) | ☐ |
+| 11 | Cross-platform | Exercise on the dev OS; confirm discovery paths don't glitch | No path/URI issues; CI covers all three OS builds | ☐ |
+| 12 | Clean-install VSIX | `npm run package` → install in clean VS Code → repeat #1, #4, #6 | Shipped artifact behaves like the dev build | ☐ |
+
+**Developer Tools console:** ☐ no errors emitted by *this* extension during the above.
+
+## Section 4: Constitutional Compliance
+
+- [x] **Native**: standard completion widget, snippets, status-bar item — no custom UI.
+- [x] **Zero Config**: `auto` default gives useful completion with no settings and no `gst`.
+- [x] **Robustness**: never-throws front end; indexer/service/provider degrade to empty/bundled.
+- [x] **Dialect Agnostic**: neutral index model + per-dialect source adapter seam (ADR-0002).
+
+## Section 5: Sign-Off (release gate)
+
+- [ ] §3 manual matrix executed (dev host **and** clean VSIX) and notes recorded.
+- [ ] Issue #1 closed with a demo.
+- [ ] Doc-rot audit done (CLAUDE.md, ROADMAP, user-stories, CHANGELOG, README).
+- [ ] PO accepts US-413 (DoD met) → cut **v0.5.0** (verify `MARKETPLACE` PAT first).


### PR DESCRIPTION
test(US-413): completion output-eval dataset + manual verification matrix

## Summary

Stages the **story-close verification artifacts** for US-413 (the manual pass and the release stay **held for the owner**). No product code change — this wires the **Output eval** (DoD requirement) and the **manual-QA release gate**.

**Closes:** _n/a — verification staging; #1 closes at the 0.5.0 release_ &nbsp;|&nbsp; **Story:** US-413 (#25) &nbsp;|&nbsp; **ADR:** [0002](docs/decisions/0002-kernel-symbol-sourcing.md) &nbsp;|&nbsp; Follows slices A–D (#51–#54, merged).

### What's here
- **`evals/datasets/completion/{cases.json,run.ts}`** — a deterministic golden dataset run over the **committed bundled gst-3.2.5 index** (no corpus, no `gst`, no VS Code). Metric: expected item within **top-k** (sortText order) + **ranking sanity** (workspace > kernel, variable > class) + **keyword-snippet** insertion + **facts-only** (binary selectors aren't offered for a typed word). **8/8 cases pass.**
- **`package.json`** — `eval:completion` wired into `npm run eval`, which **CI already runs on all three OSes** → the completion eval now gates merges (closes the evals/README "Completion → CI" row, per the DoD).
- **`specs/US-413-…/verification.md`** — AC→evidence table, the automated-gate checklist, and a **12-row manual-QA matrix** (steps → expected → result) for the Extension Dev Host: real-corpus workspace, installed-vs-bundled sourcing + provenance honesty, `off`, robustness, no-`gst`, and a **clean-install VSIX** smoke — the **0.5.0 release gate**.

### What's intentionally NOT done here (held for owner)
- Executing the manual matrix (dev host + clean VSIX).
- Closing #1 with a demo; doc-rot audit; version bump + CHANGELOG; cutting **v0.5.0** (verify the `MARKETPLACE` PAT first).

## Output Eval — *is the artifact right?*
- [x] Output eval dataset added and **passing** — `evals/datasets/completion/` (8/8), in `npm run eval`.
- [x] CI green on **Linux/macOS/Windows** — all three `build` jobs pass; this run executed `npm run eval` (incl. completion) cross-platform (run 27911843001).
- [ ] Manual QA — staged as `verification.md` matrix; the pass itself is the release gate (owner).
- [x] Local: `npm run eval` ✓ (grammar + completion) · `check-types`/`lint`/`test:parser`/`test:server`/`test:e2e` (12) ✓ from slices A–D.

## Trajectory Eval — *was it produced the right way?*
- [x] Traces to US-413 (#25); satisfies the DoD's "eval dataset exists and passes" + the manual-QA gate (memory: *manual-qa-before-release*).
- [x] Deterministic check first (golden dataset), human pass as the decision; conventional scoped commit.
- [ ] Reviewer sign-off.

## Human sign-off
- [ ] Reviewer approves output **and** trajectory.
- [ ] PO accepts the verification staging.
