### PR TITLE
Acceptance Harness (TDD e2e) phase + e2e in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,20 @@ jobs:
       run: npm run deploy
       env:
         VSCE_PAT: ${{ secrets.MARKETPLACE }}
+
+  # End-to-end acceptance tests: launch real VS Code (Electron) with the
+  # extension and drive the LSP providers. Needs a display, so it runs only on
+  # Linux under xvfb. Kept as its own job so the Electron download doesn't slow
+  # the cross-OS unit matrix; gates push/PR as the behavioural circuit breaker.
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+    - run: npm ci
+    - name: e2e (acceptance) tests
+      run: xvfb-run -a npm run test:e2e

--- a/.specify/templates/implementation-verification.md
+++ b/.specify/templates/implementation-verification.md
@@ -8,6 +8,7 @@
 ## Section 1: Acceptance Criteria
 - [ ] All ACs in `tasks.md` are checked?
 - [ ] Each AC has a passing test?
+- [ ] Each user-observable AC's acceptance test was **red before** implementation (TDD e2e)?
 
 ## Section 2: Code Quality
 - [ ] `npm run lint` passes?

--- a/.specify/templates/requirements-validation.md
+++ b/.specify/templates/requirements-validation.md
@@ -25,5 +25,13 @@
 - [ ] Error handling strategy defined?
 - [ ] Testing strategy (Unit vs Integration) defined?
 
+## Section 3.5: Acceptance Harness (TDD e2e plan)
+- [ ] Each AC is **routed** to a verification layer: user-observable → e2e (`client/test-e2e/`);
+  internal contract / data invariant → unit or `evals/` golden dataset; LSP protocol shape → handshake.
+- [ ] User-observable ACs will be pinned by acceptance tests **written before implementation** that fail
+  for the right reason (red), then driven green (`client/test-e2e/{{US_ID}}.acceptance.test.js`).
+- [ ] If the story has **no** user-observable surface, that is stated here and the scaffolded e2e stub
+  is removed.
+
 ## Section 4: Validation Result
 - [ ] PASS - Ready for implementation

--- a/.specify/templates/story/acceptance.test.js
+++ b/.specify/templates/story/acceptance.test.js
@@ -1,0 +1,62 @@
+// Acceptance harness for {{US_ID}} — {{TITLE}}.
+//
+// TDD e2e: written BEFORE implementation. Each user-observable acceptance
+// criterion from spec.md §4 gets a test here that FAILS FOR THE RIGHT REASON
+// (red), then implementation drives it green. A passing test that was never red
+// proves nothing — make it fail first.
+//
+// Routing rule — not every AC is e2e:
+//   • user-observable (completion appears, status bar reads X, folding folds) → assert HERE
+//   • internal contract / data invariant                                      → server/ unit or evals/ golden
+//   • LSP protocol shape                                                       → server/test handshake
+// If this story has NO user-observable surface, delete this file and record the
+// routing in requirements-validation.md §3.5.
+//
+// The entries below are *pending* tests (no callback) — Mocha's TODO slot, so CI
+// stays green until you write the assertion. In the Acceptance Harness phase:
+// give each a body that drives a real VS Code command and asserts the expected
+// behaviour, watch it go red, then implement to green. Run: npm run test:e2e
+const assert = require('node:assert');
+const vscode = require('vscode');
+
+/** Poll `fn` until `ok(result)` or tries run out; returns the last result. */
+async function waitFor(fn, ok, tries = 60) {
+  let last;
+  for (let i = 0; i < tries; i++) {
+    last = await fn();
+    if (ok(last)) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return last;
+}
+
+/** Open an in-memory Smalltalk doc and return it after the server attaches. */
+async function openSmalltalk(content) {
+  const doc = await vscode.workspace.openTextDocument({ language: 'smalltalk', content });
+  await vscode.window.showTextDocument(doc);
+  return doc;
+}
+
+suite('{{US_ID}} acceptance (e2e)', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('leocamello.vscode-smalltalk');
+    assert.ok(ext, 'extension should be present');
+    await waitFor(() => Promise.resolve(ext.isActive), (active) => active === true);
+    assert.ok(ext.isActive, 'extension must be active');
+  });
+
+  // One pending test per user-observable AC. Replace each TODO with a red
+  // assertion derived from spec.md §4, e.g.:
+  //
+  //   test('AC1: kernel selector is offered after a receiver', async () => {
+  //     const doc = await openSmalltalk('x print');
+  //     const pos = new vscode.Position(0, 'x print'.length);
+  //     const result = await waitFor(
+  //       () => vscode.commands.executeCommand('vscode.executeCompletionItemProvider', doc.uri, pos),
+  //       (r) => (r?.items ?? r ?? []).some((i) => i.label === 'printString'),
+  //     );
+  //     assert.ok((result?.items ?? result ?? []).some((i) => i.label === 'printString'));
+  //   });
+  test('AC1: <observable behaviour from spec.md §4>');
+  // test('AC2: …');
+});

--- a/.specify/templates/story/plan.md
+++ b/.specify/templates/story/plan.md
@@ -17,3 +17,6 @@
 
 ## Verification
 <!-- How we'll prove it works: tests, eval dataset (evals/), and manual QA. -->
+- **Acceptance harness (TDD e2e):** user-observable ACs are pinned by failing tests in
+  `client/test-e2e/{{US_ID}}.acceptance.test.js` *before* implementation (red → green); ACs with no
+  user-observable surface are routed to unit/eval. Routing is recorded in `requirements-validation.md` §3.5.

--- a/.specify/templates/story/tasks.md
+++ b/.specify/templates/story/tasks.md
@@ -5,12 +5,17 @@
 Mark each task `[x]` as it lands. Map tasks to acceptance criteria where possible.
 
 ## Phase 1 — Spec & Setup
-- [ ] T001 Spec reviewed; `requirements-validation.md` gate passed.
+- [ ] T001 Spec reviewed; `requirements-validation.md` gate passed (incl. §3.5 AC routing).
 
-## Phase 2 — Implementation
-- [ ] T010
+## Phase 2 — Acceptance Harness (TDD e2e — write tests BEFORE code)
+- [ ] T005 Route each AC to its layer (user-observable → e2e; contract/data → unit or `evals/`; protocol → handshake) per `requirements-validation.md` §3.5.
+- [ ] T006 Write the failing acceptance test(s): user-observable ACs → `client/test-e2e/{{US_ID}}.acceptance.test.js` (else route to unit/eval and delete the stub).
+- [ ] T007 Confirm the new asserts are RED for the right reason (`npm run test:e2e` / unit) — red phase proven before any implementation.
 
-## Phase 3 — Verify
-- [ ] T900 Output eval / tests pass (`npm run eval`).
+## Phase 3 — Implementation
+- [ ] T010 Implement to green.
+
+## Phase 4 — Verify
+- [ ] T900 Acceptance tests now GREEN; Output eval / unit tests pass (`npm run eval`, `npm run test:e2e`).
 - [ ] T901 `verification.md` gate passed.
-- [ ] T902 CI green on Linux/macOS/Windows.
+- [ ] T902 CI green on Linux/macOS/Windows + e2e.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ Marketplace as `leocamello.vscode-smalltalk`.
   CI publishes (`MARKETPLACE` PAT, ~yearly expiry — check before tagging).
 
 ## How we work (spec-driven)
-Per user story (`US-XXX`): **Clarify → Spec → Plan → Task → Implement → Verify**.
+Per user story (`US-XXX`): **Clarify → Spec → Plan → Task → Acceptance Harness → Implement → Verify**.
+The **Acceptance Harness** phase writes the e2e/unit tests for each user-observable AC *before* code (TDD:
+red → green); `new-story` scaffolds the stub at `client/test-e2e/US-XXX.acceptance.test.js` and the AC
+routing is gated in `requirements-validation.md` §3.5.
 - Scaffold the spec package: `npm run new-story -- US-XXX "Title" --branch`
   (creates `specs/US-XXX-Title/` + branch `feature/US-XXX-slug`).
 - Source of truth: `docs/product/user-stories.md` is the backlog; once a story starts, its

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,7 +167,8 @@ stories in [`docs/product/user-stories.md`](product/user-stories.md).
 
 ## How each milestone ships (the repeatable ritual)
 
-Per story: **Clarify → Spec → Plan → Task → Implement → Verify** (`npm run new-story -- US-XXX "…" --branch`).
+Per story: **Clarify → Spec → Plan → Task → Acceptance Harness → Implement → Verify** (`npm run new-story -- US-XXX "…" --branch`).
+The **Acceptance Harness** phase pins each user-observable AC with a failing e2e test before code (TDD).
 Each slice keeps the **three test layers** green (`test:parser`, `test:server`, `test:e2e`) **plus an
 output-eval dataset** in `evals/datasets/<feature>/` (use `completion/` as the template). Then the
 **release ritual**: doc-rot audit + the **manual-QA matrix** (`specs/US-XXX-*/verification.md`, real

--- a/scripts/new-story.sh
+++ b/scripts/new-story.sh
@@ -13,7 +13,10 @@
 # Creates specs/US-XXX-Title-Case/ with the five-file package
 # (spec.md, plan.md, tasks.md, requirements-validation.md, verification.md)
 # from .specify/templates/, substituting {{US_ID}}, {{TITLE}}, {{DATE}}, {{BRANCH}}.
-# With --branch it also creates and checks out feature/US-XXX-slug.
+# Also scaffolds the TDD-e2e acceptance harness stub at
+# client/test-e2e/US-XXX.acceptance.test.js (pending tests; fill it in the
+# Acceptance Harness phase, or delete it if the story has no user-observable
+# surface). With --branch it also creates and checks out feature/US-XXX-slug.
 
 set -euo pipefail
 
@@ -27,7 +30,7 @@ for arg in "$@"; do
   case "$arg" in
     --branch) MAKE_BRANCH=true ;;
     --help|-h)
-      sed -n '3,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '3,19p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) ARGS+=("$arg") ;;
   esac
@@ -90,6 +93,15 @@ render "$TPL/implementation-verification.md" "$DEST/verification.md"
 echo "Created spec package: specs/$DIR_NAME/"
 ls -1 "$DEST" | sed 's/^/  - /'
 
+# --- TDD-e2e acceptance harness stub (client/test-e2e/US-XXX.acceptance.test.js) ---
+E2E_STUB="$REPO_ROOT/client/test-e2e/${US_ID}.acceptance.test.js"
+if [ -e "$E2E_STUB" ]; then
+  echo "Note: $E2E_STUB already exists — left untouched." >&2
+else
+  render "$TPL/story/acceptance.test.js" "$E2E_STUB"
+  echo "Created acceptance harness stub: client/test-e2e/${US_ID}.acceptance.test.js (pending tests)"
+fi
+
 if $MAKE_BRANCH; then
   if git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
     git -C "$REPO_ROOT" checkout -b "$BRANCH"
@@ -101,4 +113,4 @@ else
   echo "Next: git checkout -b $BRANCH   (or re-run with --branch)"
 fi
 
-echo "Then: Clarify -> fill spec.md -> requirements-validation.md gate -> plan.md -> tasks.md -> implement -> verify."
+echo "Then: Clarify -> spec.md -> requirements-validation.md gate (route ACs, §3.5) -> plan.md -> tasks.md -> Acceptance Harness (write RED e2e/unit tests) -> implement to GREEN -> verify."


### PR DESCRIPTION
## What & why

Adds an **Acceptance Harness (TDD e2e)** phase to the per-story cycle and runs e2e in CI so it actually gates. Inspired by the *Test Harness as circuit breaker* idea: each user-observable acceptance criterion is pinned by a **failing e2e test written before code** (red → green), turning the spec into an executable contract and anchoring against intent drift.

The cycle becomes: **Clarify → Spec → Plan → Task → Acceptance Harness → Implement → Verify**.

## Changes

**CI (`ci:` commit)**
- New isolated `e2e` job (`ubuntu-latest`, `xvfb-run`) launches real VS Code and drives the LSP providers. Kept off the cross-OS unit matrix so the Electron download doesn't slow it. Gates `push`/`pull_request` — the behavioural circuit breaker.

**Cycle formalization (`chore:` commit)**
- `new-story.sh` scaffolds `client/test-e2e/US-XXX.acceptance.test.js` from a new template. Stub uses *pending* tests (no callback = Mocha TODO) so a fresh scaffold stays green; the author fills the red asserts in the new phase.
- `tasks.md` template: new **Phase 2 — Acceptance Harness** (route ACs → write red tests → prove red); Implement/Verify renumbered.
- `requirements-validation.md` gate: **Section 3.5** routes each AC to its layer (observable → e2e, contract/data → unit/`evals`, protocol → handshake), with an explicit opt-out for stories with no user-observable surface.
- `implementation-verification.md`: confirm each AC's test was **red before** implementation.
- `CLAUDE.md` / `ROADMAP.md` / `plan.md`: cycle string updated to include the phase — keeps the canonical docs from drifting (the lesson that originated the harness).

## How it composes

During a story's red phase the `US-XXX.acceptance.test.js` fails → e2e CI red → no merge until green. The CI job (commit 1) is what makes the harness (commit 2) bite.

## Follow-ups (not in this PR)
- Mark the `e2e` check **required** in branch protection for `master` (UI-only; can't be scripted here) so it truly blocks merge.
- First CI run may reveal missing Electron libs on the runner; if so, add an `apt-get` step before the e2e tests.

## Testing
- `new-story.sh` smoke-tested with a throwaway id: scaffold renders, tokens substitute, stub passes `node --check`; artifacts cleaned up.
- Workflow YAML validated (`js-yaml`); both `build` and `e2e` jobs parse.
