### PR TITLE
chore(release): 0.7.0 — Hover (US-415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-24
+
 ### Added
 
 -   **Hover information** for GNU Smalltalk, powered by the bundled language engine — **no `gst` required** (US-415):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-smalltalk",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-smalltalk",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "MIT",
             "workspaces": [
                 "client",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "publisher": "leocamello",
     "license": "MIT",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "preview": true,
     "icon": "icon.png",
     "main": "./dist/extension.js",


### PR DESCRIPTION
Release prep for **0.7.0 — Hover** (US-415, merged in #86).

- Bump `version` 0.6.0 → 0.7.0 (`package.json` + `package-lock.json`)
- Finalize CHANGELOG `[0.7.0] - 2026-06-24` (hover; provenance-gated comment prose; radix-integer coloring fix)

After merge: a `v0.7.0` GitHub Release triggers the Marketplace publish (`vsce` via `MARKETPLACE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)