### PR TITLE
docs: fold in 2026-06-24 strategy review (US-424, US-706, US-602)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,9 +88,10 @@ Legend: 🟢 done · 🔵 planned · 🟣 vision (new) · ➕ optional-runtime �
 | **0.9** 🟣 | **Cross-Reference Intelligence** 🏰 | 005 | **references · senders/implementors · call hierarchy** + signature help; unknown-selector spike (SPIKE-01) | **B** ⚖️ | senders/implementors offline (image-IDE parity, no image) |
 | **0.10** 🔵 | **Hardening & Perf** | 901 | 1k files < 5 s, completion < 100 ms, no-telemetry verified, bug-bash | — | beta quality |
 | **1.0** 🔵 | **Complete Offline GST IDE** | 416/902 | formatting + scope-rename; product polish; remove `preview`; **Open VSX** | A | **parity with image-based extensions for everything that doesn't need a runtime — at zero setup** |
+| **~1.0** 🟣 | **Tonel read-only wedge** ("Trojan Horse") | 006 | **read-only Tonel** grammar + folding + outline (US-424) — *no cartridge, no seam* | A ⚖️ | best-in-class Tonel reading — lands the Pharo/GemStone/VA crowd early |
 | **1.1–1.4** 🟣 | **Image-Grade Workbench** 🏰 | 008 | **System Browser view**, full-text method search, class-hierarchy view, more refactorings (extract method) | A+B | the "feels like Smalltalk" IDE (System Browser parity, offline) |
-| **1.5** 🟣 | **THE SECOND DIALECT (Pharo)** 🏰🏰 | 006 | Pharo cartridge (image export) + Tonel container seam (US-418) + `smalltalk.dialect` auto-detect | **B — vision becomes real** | **multi-dialect — beyond ALL rivals** |
-| **1.6+** 🟣➕ | **The Live Bridge** | 007 | Do-it / Print-it / **Inspect-it** / run-tests / Playground + **runtime compile/semantic diagnostics** (deferred from US-414) — optional, per-dialect | C | live eval/inspect + real compile errors (image-IDE parity) |
+| **1.5** 🟣 | **THE SECOND DIALECT (Pharo)** 🏰🏰 | 006 | Pharo cartridge (image export) + full Tonel container seam (US-418) + `smalltalk.dialect` auto-detect **+ status-bar picker** (US-602) | **B — vision becomes real** | **multi-dialect — beyond ALL rivals** |
+| **1.6+** 🟣➕ | **The Live Bridge** | 007 | Do-it / Print-it / **Inspect-it** / run-tests / Playground + **runtime compile/semantic diagnostics** (US-705) + **writable `smalltalk-image://` VFS** (US-706) — optional, per-dialect | C | live eval/inspect + real compile errors + live-image editing (image-IDE parity) |
 | **1.x** 🟣➕ | **Debugging (DAP)** | sep. ext | `vscode-smalltalk-debugger`: breakpoints, step, stack, frame restart | C | debugging (image-IDE parity) |
 | **2.0** 🟣 | **The Ultimate Multi-Dialect Extension** | all | N cartridges (Squeak/Cuis/GemStone), cartridge registry, full workbench + optional live per dialect, notebooks ➕ | A+B+C | **everything they do, across every dialect, zero-setup by default** |
 
@@ -99,6 +100,18 @@ the old 0.9 hardening becomes **0.10**; **0.8/0.9 become the Console / cross-ref
 (where the vision's architecture goes load-bearing); everything from **1.1** on is net-new vision
 scope (EPIC-006/007/008). The 0.6 → 1.0 line is otherwise unchanged.
 
+**Delta (2026-06-24 strategy review).** Three ideas from an external review are folded into the plan:
+(1) **Tonel as the "Trojan Horse" — resequencing decision:** a **read-only** Tonel experience (grammar +
+folding + outline, **US-424**) is **pulled forward to ~1.0** in **Stream A** — it needs *no* cartridge and
+*no* `ContainerFormat` seam, is cheap, and lands the Pharo/GemStone/VA community long before the Pharo
+cartridge. The **full** Tonel dialect (US-418 seam + Pharo cartridge) stays at **1.5**; US-424 becomes the
+grammar layer beneath it (additive, not thrown away). (2) **Live-image Virtual FileSystem** (`smalltalk-image://`
+via `registerFileSystemProvider`, writable `Ctrl+S`→compile) is captured as **US-706** under the Live
+Bridge (1.6+), and US-801 gains a TreeView-vs-VFS primitive gate. (3) **Status-bar dialect picker:** US-602
+now does **both** — auto-detect *and* a manual override picker. *What we did **not** adopt:* the review's
+"decoupled external-LSP client" framing — our **Console & Cartridges** engine (own offline intelligence,
+not a launcher for other servers) is the moat; an external live server stays an *optional* EPIC-007 bonus.
+
 ## Parity scorecard — vs. the assessed extensions
 
 `✅ have · ⏳ planned-ver · ➕ optional-live · — none`
@@ -106,6 +119,7 @@ scope (EPIC-006/007/008). The 0.6 → 1.0 line is otherwise unchanged.
 | Capability | Us @0.5 | Us →1.0 | Us →2.0 | Image LSP extension | Image IDE extension |
 |---|---|---|---|---|---|
 | Highlight / snippets / config | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Tonel read-only (grammar/fold/outline)** | — | ⏳~1.0 | ✅ | partial | partial |
 | Completion | ✅ | ✅ | ✅ | ✅ (image) | ✅ (image) |
 | Outline / symbols / go-to-def | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Diagnostics | — | ✅0.6 | ✅ | ✅ (image) | ✅ (image) |
@@ -152,7 +166,8 @@ stories in [`docs/product/user-stories.md`](product/user-stories.md).
 
 | Story | What | When to do it | Issue |
 |---|---|---|---|
-| US-418 | Container-format seam (dialect door) | **Trigger fires at 1.5** (Pharo/Tonel — EPIC-006) | #58 |
+| US-424 | Tonel **read-only** wedge (grammar + folding + outline) | **Pull forward to ~1.0** (Stream A, no cartridge/seam — EPIC-006) | TBD |
+| US-418 | Container-format seam (dialect door) — *full* Tonel parsing | **Trigger fires at 1.5** (Pharo/Tonel — EPIC-006) | #58 |
 | US-419 | Kernel-index method categories | Ride with **US-415 hover** (needs the grouping) | #59 |
 | US-420 | Completion pseudo-variables | Near-term — v0.5.1 or front of US-414 | #60 |
 | US-421 | CI vendored kernel smoke fixtures | Near-term — v0.5.1 or front of US-414 | #61 |
@@ -163,7 +178,7 @@ stories in [`docs/product/user-stories.md`](product/user-stories.md).
 |---|---|---|---|
 | EPIC-004 | Language Intelligence — TypeScript LSP (offline, single-dialect) | A | In progress (→1.0) |
 | EPIC-005 | Offline Knowledge Graph — Console & Cartridges | B | In progress (foundation landed — US-430; next US-422/423) |
-| EPIC-006 | Multi-Dialect Expansion (2nd+ cartridges, dialect detection, container seam) | B | Planned (1.5) |
+| EPIC-006 | Multi-Dialect Expansion (2nd+ cartridges, dialect detection, container seam) | A+B | Planned (read-only Tonel wedge US-424 ~1.0; full second dialect 1.5) |
 | EPIC-007 | The Live Bridge (optional runtime delegation) | C | Planned (1.6+) |
 | EPIC-008 | Image-Grade Workbench (System Browser, refactorings, search) | A+B | Planned (1.1–1.4) |
 | — | Debugging (DAP) — separate `vscode-smalltalk-debugger` extension | C | Future |
@@ -184,13 +199,18 @@ opt-in `gst`/runtime compile-diagnostics tier was built then **deferred to EPIC-
 redundant with the parser for syntax, real value (semantic errors) needs a runtime; shipped **v0.6.0**.
 **EPIC-005 foundation landed** earlier: US-430 (Console loader + cartridge
 convergence) merged (#82) — completion runs off GST Cartridge #01. **US-415 hover shipped (v0.7.0).** Next EPIC-005
-consumers: US-422 (semantic tokens) / US-423 (references/senders)._
+consumers: US-422 (semantic tokens) / US-423 (references/senders). **2026-06-24 strategy review folded in:**
+US-424 (read-only Tonel "Trojan Horse" — resequenced to ~1.0, Stream A), US-706 (writable `smalltalk-image://`
+VFS under the Live Bridge), and a status-bar dialect picker on US-602; the external-LSP-client framing was
+considered and declined in favor of the Console & Cartridges moat._
 
-**Dialect scope:** GNU Smalltalk through 1.0 (the complete offline GST IDE). The **second dialect
-(Pharo)** lands at **1.5** (EPIC-006), which is when the *pluggable* `ContainerFormat` seam (US-418)
-is finally built — see [ADR-0001 §Update](decisions/0001-typescript-bundled-lsp-server.md). The
-Console/cartridge architecture (EPIC-005) is what makes that an additive change, not a rewrite
-(Constitution Principle IV, *Dialect Agnostic*).
+**Dialect scope:** GNU Smalltalk through 1.0 (the complete offline GST IDE). A **read-only Tonel
+wedge** (US-424) lands around **~1.0** as a cheap Stream-A grab of the image-based community — it needs
+no cartridge and no seam. The **second dialect (Pharo)** — full Tonel *parsing* + the Pharo cartridge —
+lands at **1.5** (EPIC-006), which is when the *pluggable* `ContainerFormat` seam (US-418) is finally
+built — see [ADR-0001 §Update](decisions/0001-typescript-bundled-lsp-server.md). The Console/cartridge
+architecture (EPIC-005) is what makes that an additive change, not a rewrite (Constitution Principle IV,
+*Dialect Agnostic*).
 
 **Sustainability:** every milestone is independently shippable; work-in-progress is kept to one
 milestone at a time; formatting (1.0) and all optional-runtime features (EPIC-007, debugging) are

--- a/docs/product/epics.md
+++ b/docs/product/epics.md
@@ -186,7 +186,7 @@
 ## EPIC-006: Multi-Dialect Expansion
 
 * **ID:** EPIC-006
-* **Status:** Planned (milestone **1.5** — "The Second Dialect")
+* **Status:** Planned (milestones **~1.0 → 1.5**) — a **read-only Tonel wedge lands early at ~1.0** (US-424), the **full second dialect (Pharo)** at **1.5**
 * **Priority:** High *(this is where the Console & Cartridges vision becomes real)*
 * **Phase:** Phase 3
 * **Date Proposed:** 2026-06-22
@@ -196,6 +196,12 @@
 > Turn the single-dialect engine into a genuinely **multi-dialect** one by adding a *second* dialect (Pharo) — the moment the EPIC-005 architecture pays off. Every offline feature (completion, hover, diagnostics, references, semantic tokens, System Browser) must light up for the new dialect **without a feature rewrite**, proving that adding a dialect is *additive data* (a new Cartridge + adapter), not a fork of the core. This is the differentiator no image-bound competitor can follow: **multi-dialect, zero-runtime by default**.
 
 **Scope & Description:**
+* **Read-only Tonel wedge (US-424, pulled forward to ~1.0 — the "Trojan Horse"):** before any cartridge,
+  ship best-in-class **read-only** Tonel support — TextMate grammar for the `Class { … }` header form,
+  method folding, and a document outline — in **Stream A**, with *no* cartridge and *no* `ContainerFormat`
+  seam. Tonel is the flat-file Git format the Pharo/GemStone/VA community already uses, and current
+  highlighters mangle its headers; fixing that is cheap and wins that audience long before the Pharo
+  cartridge exists. This read-only grammar becomes the grammar layer under the full dialect below.
 * **Second cartridge — Pharo:** build it via an **image reflective export** adapter (run the Pharo VM headless against its image, dump `allSubclasses`/selectors/arity/traits/package-tags to the `DialectCartridge` schema), or ship that export as a `bundled` cartridge. Pharo is MIT, so prose (class/method comments) may be carried (`carriesProse: true`). Per [ADR-0003](../decisions/0003-cartridge-resolution.md), the reflective export runs **opt-in on the user's machine, generated-and-cached** (Tier-1), with a **rich frozen floor** generated in CI from a pinned image for the zero-install case.
 * **Container-format seam (US-418):** finally build the deferred `ContainerFormat` pluggability so Tonel (Pharo/Cuis) parses alongside GST brace/chunk without touching the parser core. **This epic is the trigger for US-418.**
 * **Dialect axis:** a `smalltalk.dialect` setting with **auto-detection** (file extension, Tonel markers, workspace cues) selecting which cartridge(s) load; `kernelLibrary` stays the orthogonal *sourcing* axis (ADR-0002 §5).
@@ -205,12 +211,14 @@
 * Pharo developers using a file-based workflow in VS Code (and, downstream, Squeak/Cuis/GemStone users as further cartridges land in 2.0).
 
 **Related User Stories:**
-* US-418 (#58): Container-Format Seam (Dialect Door) — *trigger fires here*
+* US-424: Tonel read-only editing experience (grammar + folding + outline) — *the wedge, ships ~1.0, Stream A*
+* US-418 (#58): Container-Format Seam (Dialect Door) — *trigger fires here (1.5)*
 * US-601 (#70): Pharo cartridge via image reflective export (adapter)
-* US-602 (#71): `smalltalk.dialect` axis + auto-detection
+* US-602 (#71): `smalltalk.dialect` axis + auto-detection **+ status-bar override picker** (do both)
 * US-603 (#72): Multi-cartridge Console loader (load/rank across active dialects)
 
 **Success Metrics (Optional):**
+* US-424 lands a polished read-only Tonel experience **before** any Pharo cartridge (the early audience grab).
 * Adding Pharo requires a **new cartridge + adapter only** — no change to the Console or feature providers (the architecture test).
 * All EPIC-004/005 features work on a Pharo workspace with no Pharo VM present (offline), VM optional for the live tier.
 
@@ -233,6 +241,9 @@
 * **Inspect-it:** a structured object inspector. **DoR gate:** justify any webview vs. a native tree view against Constitution I (*avoid webviews unless strictly necessary*).
 * **SUnit Test Explorer:** static detection of `TestCase` subclasses + `test*` methods (offline, via the Console) surfaced in the VS Code Testing API + CodeLens; **run/debug via the optional runtime**.
 * **Playground / REPL:** a scratch evaluation surface backed by the optional runtime.
+* **Live-image Virtual FileSystem (US-706):** a `registerFileSystemProvider` (`smalltalk-image://`) that
+  surfaces a connected image's classes as virtual files; `Ctrl+S` compiles back into the image rather
+  than writing disk. The *writable, live* counterpart to the offline System Browser (EPIC-008 / US-801).
 
 **Target Users:**
 * Developers who *do* have a runtime/image installed and want the live loop — without the offline users ever paying for it.
@@ -242,6 +253,8 @@
 * US-702 (#74): SUnit Test Explorer (static detect; optional run/debug)
 * US-703 (#75): Inspect-it (structured inspector)
 * US-704 (#76): Playground / REPL
+* US-705: Runtime compile/semantic diagnostics (deferred from US-414)
+* US-706: Live-image Virtual FileSystem (writable `smalltalk-image://`)
 
 **Success Metrics (Optional):**
 * With no runtime present, the extension behaves **exactly** as the offline build (features silently absent, no errors).
@@ -262,7 +275,7 @@
 > Deliver the *browsing soul* of Smalltalk — the System Browser muscle memory — over the offline Knowledge Graph, with **no running image**. Where EPIC-007 captures the *execution* soul (and needs a runtime), this captures the *navigation/cross-reference* soul (and does not). This is the unique "omniscient cross-reference, instantly, offline" experience that image-bound tools can only offer against a live VM.
 
 **Scope & Description:**
-* **System Browser view:** a VS Code-native tree (packages/namespaces → classes → protocols → methods) over the workspace + cartridge index, with senders/implementors/references panes — the file-based equivalent of the classic multi-pane System Browser.
+* **System Browser view:** a VS Code-native tree (packages/namespaces → classes → protocols → methods) over the workspace + cartridge index, with senders/implementors/references panes — the file-based equivalent of the classic multi-pane System Browser. **Primitive decision (US-801 AC3):** `TreeView` for the offline browser vs a Virtual FileSystem (`registerFileSystemProvider`, `smalltalk-image://`); the VFS is the more native primitive but earns its keep with the *writable* live-image bridge (US-706 / EPIC-007), so the offline view defaults to a tree.
 * **Full-text method search** across workspace + cartridge (extends `workspace/symbol`).
 * **Class-hierarchy view** (super/subclasses, including kernel chains from the cartridge).
 * **Refactorings:** scope-aware rename first (US-426, lands 1.0), then extract method / extract temp and other AST-driven rewrites; selector rename across the system treated with extreme caution (dynamic dispatch).

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1,6 +1,6 @@
 # vscode-smalltalk User Stories
 
-> **Status summary (2026-06-24).** v0.2.0–v0.7.0 are shipped. **Done:** US-101–106 & US-200–203 (declarative foundation, v0.2.0), US-301 (Run Current File, v0.3.0), US-410 (LSP scaffold, v0.3.0), **US-411** (error-tolerant parser + symbol table, internal milestone M3), **US-412** (outline + workspace symbols + go-to-definition, v0.4.0), **US-417** (semantic folding + scope-aware document highlight, v0.4.1), and **US-413** (completion + GNU Smalltalk kernel index, **v0.5.0** — closes #1), and **US-414** (diagnostics — **parser-only**: live squiggles + insert-closer/close-string quick fixes; the opt-in `gst` compile tier was deferred to EPIC-007 / **US-705**, **v0.6.0**), and **US-415** (hover — selectors/classes/variables/literals + provenance-gated comment prose; radix-integer coloring fix, **v0.7.0** — closes #27). **Next:** **US-416** (formatting, EPIC-004) and the **EPIC-005** arc (US-422 cartridge-aware semantic tokens, US-423 references/senders). **Planned:** US-416. **Backlog (0.5.0 plan reconciliation):** US-418 (dialect seam, deferred), US-419 (kernel categories), US-420 (completion pseudo-variables), US-421 (CI kernel fixtures), US-901 (0.10.0 hardening/perf), US-902 (1.0.0 polish + Open VSX). **Superseded by [ADR-0001](../decisions/0001-typescript-bundled-lsp-server.md):** US-401–403 (the server is TypeScript, not Smalltalk). The per-story `Status` fields below reflect this; see [`docs/ROADMAP.md`](../ROADMAP.md) for the live milestone view. **EPIC-005 (Offline Knowledge Graph / "Console & Cartridges")** opens the next arc: US-430 (cartridge schema + GST Cartridge #01 reflective exporter), US-422 (cartridge-aware semantic tokens), US-423 (references/senders/implementors, two-tier engine), SPIKE-01 (unknown-selector heuristic), and US-431 (kernel-sourcing transparency — installed version label + settings UX, deferred from US-430). The post-1.0 vision continues in **EPIC-006** (multi-dialect — US-601–603 + US-418), **EPIC-007** (optional Live Bridge — US-701–705, incl. **US-705 runtime compile/semantic diagnostics deferred from US-414**) and **EPIC-008** (image-grade workbench — US-426, US-801–804).
+> **Status summary (2026-06-24).** v0.2.0–v0.7.0 are shipped. **Done:** US-101–106 & US-200–203 (declarative foundation, v0.2.0), US-301 (Run Current File, v0.3.0), US-410 (LSP scaffold, v0.3.0), **US-411** (error-tolerant parser + symbol table, internal milestone M3), **US-412** (outline + workspace symbols + go-to-definition, v0.4.0), **US-417** (semantic folding + scope-aware document highlight, v0.4.1), and **US-413** (completion + GNU Smalltalk kernel index, **v0.5.0** — closes #1), and **US-414** (diagnostics — **parser-only**: live squiggles + insert-closer/close-string quick fixes; the opt-in `gst` compile tier was deferred to EPIC-007 / **US-705**, **v0.6.0**), and **US-415** (hover — selectors/classes/variables/literals + provenance-gated comment prose; radix-integer coloring fix, **v0.7.0** — closes #27). **Next:** **US-416** (formatting, EPIC-004) and the **EPIC-005** arc (US-422 cartridge-aware semantic tokens, US-423 references/senders). **Planned:** US-416. **Backlog (0.5.0 plan reconciliation):** US-418 (dialect seam, deferred), US-419 (kernel categories), US-420 (completion pseudo-variables), US-421 (CI kernel fixtures), US-901 (0.10.0 hardening/perf), US-902 (1.0.0 polish + Open VSX). **Superseded by [ADR-0001](../decisions/0001-typescript-bundled-lsp-server.md):** US-401–403 (the server is TypeScript, not Smalltalk). The per-story `Status` fields below reflect this; see [`docs/ROADMAP.md`](../ROADMAP.md) for the live milestone view. **EPIC-005 (Offline Knowledge Graph / "Console & Cartridges")** opens the next arc: US-430 (cartridge schema + GST Cartridge #01 reflective exporter), US-422 (cartridge-aware semantic tokens), US-423 (references/senders/implementors, two-tier engine), SPIKE-01 (unknown-selector heuristic), and US-431 (kernel-sourcing transparency — installed version label + settings UX, deferred from US-430). The post-1.0 vision continues in **EPIC-006** (multi-dialect — US-601–603 + US-418, plus **US-424 read-only Tonel — the "Trojan Horse" wedge pulled forward to ~1.0**), **EPIC-007** (optional Live Bridge — US-701–706, incl. **US-705 runtime compile/semantic diagnostics deferred from US-414** and **US-706 writable `smalltalk-image://` VFS**) and **EPIC-008** (image-grade workbench — US-426, US-801–804). Three ideas from a 2026-06-24 strategy review are folded in: US-424 (Tonel-first), US-706 (live-image VFS), and a status-bar dialect picker on US-602.
 
 ---
 
@@ -1401,6 +1401,56 @@ Scenario: User follows Quick Start guide
 
 ---
 
+## US-424: Tonel Read-Only Editing Experience (the "Trojan Horse")
+
+* **ID:** US-424
+* **Status:** Backlog (vision — pulled forward to **~1.0**, ahead of the rest of EPIC-006) — issue TBD
+* **Epic:** EPIC-006 *(but ships as a Stream-A wedge, decoupled from the cartridge/seam work)*
+* **Priority:** High *(cheap go-to-market wedge: wins the Pharo/GemStone/VA crowd before any cartridge exists)*
+* **Estimate:** M
+* **Date Proposed:** 2026-06-24
+* **Owner:** Leonardo Nascimento
+
+**User Story:**
+> As a **Pharo / GemStone / VA Smalltalk developer reviewing Tonel files in Git**, I want **correct syntax highlighting, method folding, and a document outline for Tonel (`.class.st`) files**, so that **VS Code is the best place to read my image-exported code — long before a Pharo cartridge exists.**
+
+**Context / Why now:**
+> Tonel is the modern, human-readable flat-file format image-based Smalltalkers use to export code to
+> Git. Today every Smalltalk highlighter on the Marketplace **mangles Tonel's class-definition headers**
+> (the `Class { #name : … }` STON-ish preamble), so reading Tonel in VS Code is a mediocre experience.
+> A **read-only** Tonel experience is *cheap* — TextMate grammar + a lightweight outline — needs **no
+> cartridge and no parser-core dialect work**, and instantly captures the corporate/Pharo audience.
+> This is deliberately the **read-only** slice: full Tonel *parsing* as a first-class dialect (the
+> `ContainerFormat` seam + Pharo cartridge) stays at **1.5** (US-418 / EPIC-006).
+
+**Acceptance Criteria (AC):**
+* AC1: TextMate grammar for Tonel files (`*.class.st` and the Tonel header form) — the `Class { … }` /
+  `Trait { … }` / `Extension { … }` preamble, method `>>` separators, pragmas, and method bodies all
+  colorize correctly; the header's STON metadata does not bleed into method-body scopes.
+* AC2: **Method folding** — each `Class >> selector [ … ]` method folds independently.
+* AC3: **Document outline** — packages/classes → methods appear in the breadcrumb/outline (a light,
+  Tonel-aware symbol pass; **no full parser-core change**, honoring US-418's deferral).
+* AC4: Read-only scope only — **no** completion/diagnostics/hover claims on Tonel yet; those arrive
+  with the Pharo cartridge (EPIC-006). Existing GST `.st`/`.gst` behavior is unchanged.
+
+**Definition of Ready (DoR) Checklist:**
+* [X] Decoupled from US-418 (no `ContainerFormat` seam needed for read-only grammar + outline).
+* [ ] Tonel header grammar mapped (extend the `docs/research/` grammar work for the STON preamble).
+* [ ] Estimated/sized (M).
+
+**Definition of Done (DoD) Checklist:**
+* [ ] Tonel grammar + folding + outline; grammar-snapshot eval; manual-QA on a real Tonel repo (e.g. a Pharo package export).
+* [ ] PO accepts.
+
+**Notes / Questions / Assumptions:**
+* The friend's sharpest tactical point (2026-06-24 review): a read-only Tonel experience is the
+  **Trojan Horse** that lands the image-based community in Stream A, before the cartridge moat (Stream B)
+  reaches them at 1.5. Resequencing decision recorded in [`docs/ROADMAP.md`](../ROADMAP.md) (milestone ladder + Deltas).
+* When EPIC-006 builds the full Tonel `ContainerFormat` adapter (US-418) and the Pharo cartridge
+  (US-601), this read-only experience becomes the *grammar layer* under the full dialect — additive, not thrown away.
+
+---
+
 ## US-425: Signature Help
 
 * **ID:** US-425
@@ -1510,16 +1560,22 @@ Scenario: User follows Quick Start guide
 **Acceptance Criteria (AC):**
 * AC1: Auto-detect + explicit override; **orthogonal** to `kernelLibrary` sourcing (ADR-0002 §5).
 * AC2: Active dialect shown in status/provenance.
+* AC3: **Do both — auto-detect *and* a manual status-bar picker.** The active dialect is a clickable
+  status-bar item (à la the VS Code Python interpreter switcher); clicking it offers a quick-pick to
+  override the auto-detected dialect for the workspace. Auto-detection is the default; the picker is the
+  escape hatch when detection is ambiguous or the user wants to force a dialect.
 
 **Definition of Ready (DoR) Checklist:**
 * [X] Depends on US-603 (multi-cartridge loader).
 * [X] Estimated/sized (M).
 
 **Definition of Done (DoD) Checklist:**
-* [ ] Dialect detection + override + status; tests; PO accepts.
+* [ ] Dialect detection + status-bar override picker + status; tests; PO accepts.
 
 **Notes / Questions / Assumptions:**
 * `bundled` (sourcing) and `dialect` (which library) are the two orthogonal axes from ADR-0002.
+* The status-bar picker is the friend's suggested UX (2026-06-24 review); we lean on auto-detection but
+  let the user override — detect *and* offer the switcher, not one or the other.
 
 ---
 
@@ -1707,6 +1763,43 @@ Scenario: User follows Quick Start guide
 
 ---
 
+## US-706: Live-Image Virtual FileSystem (writable `smalltalk-image://`)
+
+* **ID:** US-706
+* **Status:** Backlog (vision — milestone 1.6+) — issue TBD
+* **Epic:** EPIC-007
+* **Priority:** Low *(the most ambitious live feature; ships after the higher-value live items)*
+* **Estimate:** L
+* **Date Proposed:** 2026-06-24
+* **Owner:** Leonardo Nascimento
+
+**User Story:**
+> As a **Pharo/Squeak developer with a live image**, I want **the image's classes to appear as virtual files via a `smalltalk-image://` FileSystemProvider**, so that **I browse the living image inside VS Code and `Ctrl+S` compiles a method straight back into the image — the image-based editing loop, natively.**
+
+**Acceptance Criteria (AC):**
+* AC1: A `registerFileSystemProvider` (`smalltalk-image://`) populates a pseudo-directory of
+  packages/classes from the connected live image; opening a class yields a virtual text buffer.
+* AC2: **Saving compiles back** — `Ctrl+S` sends a compile command over the Live Bridge to the image
+  (not a disk write); compile errors surface as diagnostics on the virtual document.
+* AC3: Strictly part of the **optional** Live Bridge — absent with no runtime; never required (ADR-0001).
+* AC4: Complements (does not replace) the offline System Browser (US-801) — that tree stays the
+  zero-runtime experience; this VFS is the *live, writable* counterpart.
+
+**Definition of Ready (DoR) Checklist:**
+* [X] Depends on EPIC-007 Live Bridge (US-701 runtime delegation) + a per-dialect image connection.
+* [ ] Connection/transport to the live image specified (reuses the Live Bridge channel).
+* [ ] Estimated/sized (L).
+
+**Definition of Done (DoD) Checklist:**
+* [ ] `smalltalk-image://` FS provider + compile-on-save + diagnostics; no-runtime no-op; PO accepts.
+
+**Notes / Questions / Assumptions:**
+* The friend's Pillar #3 (2026-06-24 review): image developers browse a living heap, not files — the
+  `FileSystemProvider` API maps that experience natively. Captured as the *writable* sibling of the
+  offline System Browser (US-801 AC3 records the TreeView-vs-VFS primitive decision).
+
+---
+
 > **EPIC-008 — Image-Grade Workbench (milestones 1.1–1.4).** The browsing soul over the offline
 > Console — System Browser, search, hierarchy, refactorings — **no running image**. See
 > [`epics.md`](epics.md) EPIC-008.
@@ -1727,16 +1820,24 @@ Scenario: User follows Quick Start guide
 **Acceptance Criteria (AC):**
 * AC1: Native VS Code tree over workspace + cartridge index; **offline**.
 * AC2: Works identically across every loaded cartridge/dialect (EPIC-006).
+* AC3 **(DoR gate):** decide the surface primitive — a `TreeView` vs a **Virtual FileSystem**
+  (`registerFileSystemProvider`, `smalltalk-image://`) where classes appear as virtual files. The
+  read-only offline browser favors a `TreeView`; the VFS is the more native primitive when paired with
+  the **writable** live-image bridge (see US-706 / EPIC-007). Record the choice.
 
 **Definition of Ready (DoR) Checklist:**
 * [X] Depends on US-423 (cross-reference) + US-603 (multi-cartridge).
+* [ ] TreeView-vs-VFS primitive decided (gate, AC3).
 * [X] Estimated/sized (L).
 
 **Definition of Done (DoD) Checklist:**
-* [ ] System Browser tree + panes; PO accepts.
+* [ ] System Browser tree (or VFS) + panes; PO accepts.
 
 **Notes / Questions / Assumptions:**
 * The signature "feels like Smalltalk" feature, delivered offline (the navigation soul).
+* The friend (2026-06-24 review) flags `registerFileSystemProvider` (`smalltalk-image://`) as arguably
+  the more native primitive than a tree view. For the *offline* browser a tree is simpler; the VFS earns
+  its keep once `Ctrl+S` can compile back into a live image — that writable bridge is **US-706** (EPIC-007).
 
 ---
 


### PR DESCRIPTION
Records three resequencing/scope decisions from the **2026-06-24 external strategy review** across the roadmap, epics, and backlog. Docs-only; no code or behavior change.

## What changed
- **US-424 — read-only Tonel "Trojan Horse" wedge** (TextMate grammar + folding + outline): pulled forward to **~1.0** in **Stream A** — needs *no* cartridge and *no* `ContainerFormat` seam. Becomes the grammar layer under the full Tonel dialect (US-418 + Pharo cartridge) which stays at **1.5**.
- **US-706 — writable `smalltalk-image://` live-image VFS**: captured under the Live Bridge (EPIC-007, 1.6+). US-801 gains a TreeView-vs-VFS primitive gate (AC3).
- **US-602 — status-bar dialect picker**: do **both** auto-detect *and* a manual override picker.

**Declined:** the review's external-LSP-client framing, in favor of the Console & Cartridges moat (recorded in the ROADMAP delta).

## Files
- `docs/ROADMAP.md` — milestone ladder + 2026-06-24 delta + parity scorecard row
- `docs/product/epics.md` — EPIC-006 scope, EPIC-007/008 stories
- `docs/product/user-stories.md` — new US-424 / US-706 entries, US-602 AC3, status summary

## Context
These changes were authored in a prior session and left uncommitted on `master`; committing them here (own branch + PR) per the docs-PR convention before starting US-422 (semantic tokens) from a clean master.