### PR TITLE
feat(US-422): cartridge-aware semantic tokens

### DIFF
--- a/client/test-e2e/US-422.acceptance.test.js
+++ b/client/test-e2e/US-422.acceptance.test.js
@@ -1,0 +1,117 @@
+// Acceptance harness for US-422 — Semantic Tokens (Cartridge-Aware).
+//
+// TDD e2e: written BEFORE implementation. Each user-observable acceptance
+// criterion from spec.md §4 gets a test that drives the real
+// `textDocument/semanticTokens` provider via
+// `vscode.executeDocumentSemanticTokensProvider` and asserts on the decoded
+// token stream. RED until the provider ships. Run: npm run test:e2e
+const assert = require('node:assert');
+const vscode = require('vscode');
+
+/** Poll `fn` until `ok(result)` or tries run out; returns the last result. */
+async function waitFor(fn, ok, tries = 60) {
+  let last;
+  for (let i = 0; i < tries; i++) {
+    last = await fn();
+    if (ok(last)) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return last;
+}
+
+/** Open an in-memory Smalltalk doc and return it after the server attaches. */
+async function openSmalltalk(content) {
+  const doc = await vscode.workspace.openTextDocument({ language: 'smalltalk', content });
+  await vscode.window.showTextDocument(doc);
+  return doc;
+}
+
+/** Decode an LSP SemanticTokens `data` buffer + legend into absolute tokens:
+ *  [{ line, char, length, type, modifiers: string[] }]. */
+function decode(legend, tokens) {
+  const data = (tokens && tokens.data) || [];
+  const out = [];
+  let line = 0;
+  let char = 0;
+  for (let i = 0; i + 4 < data.length; i += 5) {
+    const dl = data[i];
+    const dc = data[i + 1];
+    line += dl;
+    char = dl === 0 ? char + dc : dc;
+    const modBits = data[i + 4];
+    const modifiers = legend.tokenModifiers.filter((_, b) => (modBits & (1 << b)) !== 0);
+    out.push({ line, char, length: data[i + 2], type: legend.tokenTypes[data[i + 3]], modifiers });
+  }
+  return out;
+}
+
+/** Fetch + decode semantic tokens for `uri`, polling until `ok(decoded)`. */
+async function semanticTokens(uri, ok) {
+  const legend = await vscode.commands.executeCommand(
+    'vscode.provideDocumentSemanticTokensLegend',
+    uri,
+  );
+  return waitFor(
+    async () => {
+      const raw = await vscode.commands.executeCommand(
+        'vscode.provideDocumentSemanticTokens',
+        uri,
+      );
+      return raw && legend ? decode(legend, raw) : [];
+    },
+    (decoded) => ok(decoded),
+  );
+}
+
+/** The token covering the n-th occurrence of `needle` in `text`. */
+function tokenForNth(decoded, doc, text, needle, occurrence = 0) {
+  let from = -1;
+  for (let i = 0; i <= occurrence; i++) {
+    from = text.indexOf(needle, from + 1);
+    if (from < 0) return undefined;
+  }
+  const pos = doc.positionAt(from);
+  return decoded.find(
+    (t) => t.line === pos.line && t.char <= pos.character && pos.character < t.char + t.length,
+  );
+}
+
+suite('US-422 semantic tokens (e2e)', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('leocamello.vscode-smalltalk');
+    assert.ok(ext, 'extension should be present');
+    await waitFor(() => Promise.resolve(ext.isActive), (active) => active === true);
+    assert.ok(ext.isActive, 'extension must be active');
+  });
+
+  test('AC2: a kernel class is classified as a class (the offline cartridge consumer)', async () => {
+    const text = 'OrderedCollection new';
+    const doc = await openSmalltalk(text);
+    const decoded = await semanticTokens(doc.uri, (d) =>
+      d.some((t) => t.type === 'class'),
+    );
+    const tok = tokenForNth(decoded, doc, text, 'OrderedCollection');
+    assert.ok(tok, 'the class reference is tokenized');
+    assert.equal(tok.type, 'class', 'OrderedCollection is colored as a class with no gst (AC2)');
+  });
+
+  test('AC1/AC3: roles + selector parts + pseudo-variables are classified', async () => {
+    const text = 'Object subclass: Foo [ | count | at: x put: y [ ^self ] ]';
+    const doc = await openSmalltalk(text);
+    const decoded = await semanticTokens(doc.uri, (d) =>
+      d.some((t) => t.type === 'keyword'),
+    );
+
+    const ivar = tokenForNth(decoded, doc, text, 'count');
+    assert.ok(ivar, 'the instance variable declaration is tokenized');
+    assert.equal(ivar.type, 'property', 'an instance variable is a property (AC1)');
+
+    const at = tokenForNth(decoded, doc, text, 'at:');
+    assert.ok(at, 'the keyword selector part is tokenized');
+    assert.equal(at.type, 'method', 'keyword-message part is a method (AC3)');
+
+    const self = tokenForNth(decoded, doc, text, 'self');
+    assert.ok(self, 'the pseudo-variable is tokenized');
+    assert.equal(self.type, 'keyword', 'self is a pseudo-variable / keyword (AC3)');
+  });
+});

--- a/evals/datasets/semantic-tokens/cases.json
+++ b/evals/datasets/semantic-tokens/cases.json
@@ -1,0 +1,53 @@
+{
+  "description": "US-422 semantic-tokens output eval — golden cases over the bundled gst-3.2.5 kernel (no gst, no VS Code). Drives the real collectSemanticTokens provider with a SemanticTokenContext resolved from the bundled KernelIndexService ∪ the snippet's own workspace classes. The `▮` marks the identifier of interest; the metric asserts the semantic token covering that position has `expectType` and (when given) every `expectModifiers` and no `expectAbsentModifiers`. Pins the role classification — and the cartridge-driven class/global distinction (AC2) — that themes color.",
+  "cases": [
+    {
+      "name": "AC2 a kernel class is a class, with defaultLibrary (the cartridge consumer)",
+      "text": "Ordered▮Collection new",
+      "expectType": "class",
+      "expectModifiers": ["defaultLibrary"]
+    },
+    {
+      "name": "AC2 a kernel superclass receiver is a class",
+      "text": "Obj▮ect subclass: Foo [ ]",
+      "expectType": "class",
+      "expectModifiers": ["defaultLibrary"]
+    },
+    {
+      "name": "AC2 a workspace-defined class is a class, without defaultLibrary",
+      "text": "Object subclass: Wid▮get [ ]",
+      "expectType": "class",
+      "expectAbsentModifiers": ["defaultLibrary"]
+    },
+    {
+      "name": "AC2 an unknown capitalized name is a global variable, not a class",
+      "text": "Zo▮rk new",
+      "expectType": "variable"
+    },
+    {
+      "name": "AC1 an instance variable is a property",
+      "text": "Object subclass: Foo [ | count | bar [ ^cou▮nt ] ]",
+      "expectType": "property"
+    },
+    {
+      "name": "AC1 a method parameter is a parameter",
+      "text": "Object subclass: Foo [ bar: x [ ^▮x ] ]",
+      "expectType": "parameter"
+    },
+    {
+      "name": "AC1 a temporary is a variable",
+      "text": "Object subclass: Foo [ bar [ | tmp | ^▮tmp ] ]",
+      "expectType": "variable"
+    },
+    {
+      "name": "AC3 a keyword-message part is a method",
+      "text": "d at: 1 pu▮t: 2",
+      "expectType": "method"
+    },
+    {
+      "name": "AC3 a pseudo-variable is a keyword",
+      "text": "Object subclass: Foo [ bar [ ^se▮lf ] ]",
+      "expectType": "keyword"
+    }
+  ]
+}

--- a/evals/datasets/semantic-tokens/run.ts
+++ b/evals/datasets/semantic-tokens/run.ts
@@ -1,0 +1,98 @@
+// Semantic-tokens output eval (US-422). Deterministic golden-dataset check, run
+// in CI via `npm run eval`. Drives the real semantic-tokens provider over the
+// committed bundled gst-3.2.5 kernel (no corpus, no gst, no VS Code) and asserts,
+// per case in cases.json, that the token covering the `▮` position carries the
+// expected role (`expectType`) and modifiers. This pins the cartridge-driven
+// known-class vs unknown-global distinction (AC2) offline.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from '../../../server/src/parser/parser.ts';
+import { buildSymbolTable } from '../../../server/src/parser/symbols.ts';
+import { tokenize } from '../../../server/src/parser/lexer.ts';
+import { SymbolKind, type SymbolNode } from '../../../server/src/parser/symbols.ts';
+import {
+  collectSemanticTokens,
+  type RawSemanticToken,
+  type SemanticTokenContext,
+} from '../../../server/src/providers/semanticTokens.ts';
+import { KernelIndexService } from '../../../server/src/kernel/kernelIndexService.ts';
+
+interface Case {
+  name: string;
+  text: string;
+  expectType: string;
+  expectModifiers?: string[];
+  expectAbsentModifiers?: string[];
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const { cases } = JSON.parse(fs.readFileSync(path.join(here, 'cases.json'), 'utf8')) as { cases: Case[] };
+
+// Bundled kernel (deterministic; common-location probing disabled).
+const kernel = new KernelIndexService(undefined, []);
+kernel.configure({ kernelLibrary: 'bundled' });
+
+/** Collect the class names a snippet itself defines (the workspace tier). */
+function workspaceClasses(symbols: SymbolNode[], into = new Set<string>()): Set<string> {
+  for (const s of symbols) {
+    if (s.kind === SymbolKind.Class || s.kind === SymbolKind.Namespace) into.add(s.name);
+    workspaceClasses(s.children, into);
+  }
+  return into;
+}
+
+/** Byte offset → {line, character}. */
+function posAt(src: string, offset: number): { line: number; character: number } {
+  let line = 0;
+  let last = -1;
+  for (let i = 0; i < offset; i++) {
+    if (src[i] === '\n') {
+      line += 1;
+      last = i;
+    }
+  }
+  return { line, character: offset - last - 1 };
+}
+
+function tokenAt(tokens: RawSemanticToken[], pos: { line: number; character: number }): RawSemanticToken | undefined {
+  return tokens.find((t) => t.line === pos.line && t.char <= pos.character && pos.character < t.char + t.length);
+}
+
+let passed = 0;
+let failed = 0;
+for (const c of cases) {
+  try {
+    const offset = c.text.indexOf('▮');
+    assert.ok(offset >= 0, `case "${c.name}" must mark the position with ▮`);
+    const src = c.text.replace('▮', '');
+    const ast = parse(src).ast;
+    const symbols = buildSymbolTable(ast);
+    const ws = workspaceClasses(symbols);
+    const ctx: SemanticTokenContext = {
+      hasCartridge: true,
+      classOrigin: (name) => (ws.has(name) ? 'workspace' : kernel.hasClass(name) ? 'cartridge' : undefined),
+    };
+    const tokens = collectSemanticTokens(ast, symbols, tokenize(src).tokens, ctx);
+    const tok = tokenAt(tokens, posAt(src, offset));
+    assert.ok(tok, `case "${c.name}": expected a semantic token at the marked position`);
+    assert.equal(tok.type, c.expectType, `case "${c.name}": expected type ${c.expectType}, got ${tok.type}`);
+    for (const m of c.expectModifiers ?? []) {
+      assert.ok(tok.modifiers.includes(m), `case "${c.name}": expected modifier "${m}"`);
+    }
+    for (const m of c.expectAbsentModifiers ?? []) {
+      assert.ok(!tok.modifiers.includes(m), `case "${c.name}": expected NO modifier "${m}"`);
+    }
+    passed += 1;
+    console.log(`  ok - ${c.name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`  FAIL - ${c.name}: ${(e as Error).message}`);
+  }
+}
+
+console.log(`semantic-tokens eval: ${passed}/${cases.length} cases passed.`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
         "eval:completion": "tsx evals/datasets/completion/run.ts",
         "eval:diagnostics": "tsx evals/datasets/diagnostics/run.ts",
         "eval:hover": "tsx evals/datasets/hover/run.ts",
-        "eval": "npm run build:grammar && npm run test:grammar && npm run eval:completion && npm run eval:diagnostics && npm run eval:hover",
+        "eval:semantic-tokens": "tsx evals/datasets/semantic-tokens/run.ts",
+        "eval": "npm run build:grammar && npm run test:grammar && npm run eval:completion && npm run eval:diagnostics && npm run eval:hover && npm run eval:semantic-tokens",
         "new-story": "bash scripts/new-story.sh"
     }
 }

--- a/server/src/providers/semanticTokens.ts
+++ b/server/src/providers/semanticTokens.ts
@@ -1,0 +1,395 @@
+// Semantic-tokens provider (US-422).
+//
+// Colors Smalltalk by ROLE — instance var vs class var vs temp vs parameter vs
+// known class vs unknown global vs selector part vs pseudo-variable — from the
+// US-411 AST + symbol-table scopes. The one part that is distinctly ours and
+// offline: a capitalized identifier is a `class` only when it resolves to a
+// known class in workspace ∪ cartridge (AC2) — so kernel classes light up with
+// no `gst`; an unknown capitalized name is a global. With no cartridge loaded we
+// fall back to "capitalized ⇒ class" (AC4).
+//
+// Pure: vscode-languageserver-types only; never throws (the caller hands in
+// already-parsed inputs). Emits the LSP delta-encoded integer stream via
+// `encodeSemanticTokens`; the structured `RawSemanticToken[]` is what the unit
+// tests + eval assert on (readability).
+
+import { NodeKind, type DefinitionNode, type MethodDefinitionNode, type NameRef, type Node, type ProgramNode } from '../parser/ast';
+import { SymbolKind, type SymbolNode } from '../parser/symbols';
+import type { Position, Token } from '../parser/token';
+import { childNodes } from '../parser/walk';
+
+/** The token-type legend (standard LSP types, so themes color with no config). */
+export const SEMANTIC_TOKEN_TYPES = ['class', 'property', 'variable', 'parameter', 'method', 'keyword'] as const;
+/** The token-modifier legend. `static` ⇒ class variable; `defaultLibrary` ⇒ a
+ *  class sourced from the cartridge (kernel) rather than the workspace. */
+export const SEMANTIC_TOKEN_MODIFIERS = ['static', 'defaultLibrary'] as const;
+
+export type SemanticTokenType = (typeof SEMANTIC_TOKEN_TYPES)[number];
+export type SemanticTokenModifier = (typeof SEMANTIC_TOKEN_MODIFIERS)[number];
+
+/** A classified token before LSP delta-encoding (one per identifier/selector). */
+export interface RawSemanticToken {
+  readonly line: number;
+  readonly char: number;
+  readonly length: number;
+  readonly type: SemanticTokenType;
+  readonly modifiers: SemanticTokenModifier[];
+}
+
+/** Lazy lookups the server resolves from the workspace index ∪ active cartridge. */
+export interface SemanticTokenContext {
+  /** Whether a kernel cartridge is loaded. When false, a capitalized identifier
+   *  falls back to `class` (AC4) instead of being treated as an unknown global. */
+  readonly hasCartridge: boolean;
+  /** Where `name` resolves as a class, or undefined when it is not a known class. */
+  readonly classOrigin: (name: string) => 'workspace' | 'cartridge' | undefined;
+}
+
+const PSEUDO_VARIABLES = new Set(['self', 'super', 'nil', 'true', 'false', 'thisContext']);
+
+function isCapitalized(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+/** A class name from a `Foo` reference or a `Foo class` message; else undefined. */
+function classNameOf(node: Node): string | undefined {
+  if (node.kind === NodeKind.Variable) {
+    return node.name;
+  }
+  if (node.kind === NodeKind.Message && node.messageType === 'unary' && node.selector === 'class') {
+    return classNameOf(node.receiver);
+  }
+  return undefined;
+}
+
+/** The class a definition targets (the new class for `subclass:`, the existing
+ *  class for `extend`/`class`-scope), mirroring the symbol builder + hover. */
+function definitionClassName(node: DefinitionNode): string | undefined {
+  if (node.name) {
+    return node.name;
+  }
+  const def = node.definer;
+  if (def.kind === NodeKind.Message) {
+    return classNameOf(def.receiver);
+  }
+  if (def.kind === NodeKind.Variable) {
+    return def.name;
+  }
+  return undefined;
+}
+
+/** className → (field name → instance/class variable), from the symbol table. */
+function collectFields(symbols: SymbolNode[]): Map<string, Map<string, 'instance' | 'class'>> {
+  const out = new Map<string, Map<string, 'instance' | 'class'>>();
+  const walk = (nodes: SymbolNode[]): void => {
+    for (const n of nodes) {
+      if (n.kind === SymbolKind.Class) {
+        const fields = out.get(n.name) ?? new Map<string, 'instance' | 'class'>();
+        for (const child of n.children) {
+          if (child.kind === SymbolKind.InstanceVariable) fields.set(child.name, 'instance');
+          else if (child.kind === SymbolKind.ClassVariable) fields.set(child.name, 'class');
+        }
+        out.set(n.name, fields);
+      }
+      walk(n.children);
+    }
+  };
+  walk(symbols);
+  return out;
+}
+
+/** The first token in [from, to) whose exact text is `text`. */
+function findToken(tokens: Token[], from: number, to: number, text: string): Token | undefined {
+  for (const t of tokens) {
+    if (t.start >= from && t.end <= to && t.text === text) {
+      return t;
+    }
+  }
+  return undefined;
+}
+
+/** The selector token(s) of a send/method/pragma, derived from the gaps between
+ *  the start offset and each argument (so a nested selector isn't matched). */
+function selectorTokens(
+  selector: string,
+  messageType: 'unary' | 'binary' | 'keyword',
+  from: number,
+  args: ReadonlyArray<{ start: number; end: number }>,
+  end: number,
+  tokens: Token[],
+): Token[] {
+  const out: Token[] = [];
+  if (messageType === 'keyword') {
+    const parts = selector.match(/[^:]+:/g) ?? [];
+    let cursor = from;
+    for (let i = 0; i < parts.length; i++) {
+      const arg = args[i];
+      const to = arg ? arg.start : end;
+      const tok = findToken(tokens, cursor, to, parts[i] as string);
+      if (tok) out.push(tok);
+      cursor = arg ? arg.end : to;
+    }
+  } else if (messageType === 'binary') {
+    const arg = args[0];
+    const to = arg ? arg.start : end;
+    const tok = findToken(tokens, from, to, selector);
+    if (tok) out.push(tok);
+  } else {
+    const tok = findToken(tokens, from, end, selector);
+    if (tok) out.push(tok);
+  }
+  return out;
+}
+
+/** The offset at which a method's body begins (first temp/pragma/statement), so
+ *  selector extraction never reaches into the body. */
+function methodBodyStart(m: MethodDefinitionNode): number {
+  let start = m.end;
+  for (const n of [...m.temporaries, ...m.pragmas, ...m.statements]) {
+    if (n.start < start) start = n.start;
+  }
+  return start;
+}
+
+class Collector {
+  private readonly out: RawSemanticToken[] = [];
+  private readonly seen = new Set<string>();
+
+  constructor(
+    private readonly tokens: Token[],
+    private readonly fields: Map<string, Map<string, 'instance' | 'class'>>,
+    private readonly ctx: SemanticTokenContext,
+  ) {}
+
+  collect(program: ProgramNode): RawSemanticToken[] {
+    const scope = new Map<string, 'parameter' | 'temporary'>();
+    for (const t of program.temporaries) {
+      scope.set(t.name, 'temporary');
+      this.emitDecl(t, 'variable');
+    }
+    for (const stmt of program.statements) {
+      this.walk(stmt, [scope], undefined);
+    }
+    return this.out;
+  }
+
+  private push(line: number, char: number, length: number, type: SemanticTokenType, modifiers: SemanticTokenModifier[] = []): void {
+    if (length <= 0) return;
+    const key = `${line}:${char}`;
+    if (this.seen.has(key)) return;
+    this.seen.add(key);
+    this.out.push({ line, char, length, type, modifiers });
+  }
+
+  private emitRange(start: Position, end: Position, type: SemanticTokenType, modifiers: SemanticTokenModifier[] = []): void {
+    if (start.line !== end.line) return; // identifiers/selectors never span lines
+    this.push(start.line, start.character, end.character - start.character, type, modifiers);
+  }
+
+  private emitDecl(ref: NameRef, type: SemanticTokenType, modifiers: SemanticTokenModifier[] = []): void {
+    this.emitRange(ref.startPos, ref.endPos, type, modifiers);
+  }
+
+  private emitToken(tok: Token, type: SemanticTokenType, modifiers: SemanticTokenModifier[] = []): void {
+    this.emitRange(tok.startPos, tok.endPos, type, modifiers);
+  }
+
+  /** Classify a variable/identifier reference by scope, class field, then class/global. */
+  private classifyVariable(
+    name: string,
+    scopes: Map<string, 'parameter' | 'temporary'>[],
+    className: string | undefined,
+  ): { type: SemanticTokenType; modifiers: SemanticTokenModifier[] } {
+    if (PSEUDO_VARIABLES.has(name)) {
+      return { type: 'keyword', modifiers: [] };
+    }
+    for (let i = scopes.length - 1; i >= 0; i--) {
+      const bound = scopes[i]?.get(name);
+      if (bound) {
+        return { type: bound === 'parameter' ? 'parameter' : 'variable', modifiers: [] };
+      }
+    }
+    if (className) {
+      const field = this.fields.get(className)?.get(name);
+      if (field === 'instance') return { type: 'property', modifiers: [] };
+      if (field === 'class') return { type: 'property', modifiers: ['static'] };
+    }
+    const origin = this.ctx.classOrigin(name);
+    if (origin === 'cartridge') return { type: 'class', modifiers: ['defaultLibrary'] };
+    if (origin === 'workspace') return { type: 'class', modifiers: [] };
+    if (isCapitalized(name)) {
+      // Unknown capitalized: a class fallback with no cartridge (AC4), else a global.
+      return this.ctx.hasCartridge ? { type: 'variable', modifiers: [] } : { type: 'class', modifiers: [] };
+    }
+    return { type: 'variable', modifiers: [] };
+  }
+
+  private emitSelector(
+    selector: string,
+    messageType: 'unary' | 'binary' | 'keyword',
+    from: number,
+    args: ReadonlyArray<{ start: number; end: number }>,
+    end: number,
+  ): void {
+    if (selector === '') return;
+    for (const tok of selectorTokens(selector, messageType, from, args, end, this.tokens)) {
+      this.emitToken(tok, 'method');
+    }
+  }
+
+  private walk(node: Node, scopes: Map<string, 'parameter' | 'temporary'>[], className: string | undefined): void {
+    switch (node.kind) {
+      case NodeKind.Variable: {
+        const { type, modifiers } = this.classifyVariable(node.name, scopes, className);
+        this.emitRange(node.startPos, node.endPos, type, modifiers);
+        return;
+      }
+      case NodeKind.Message: {
+        this.emitSelector(node.selector, node.messageType, node.receiver.end, node.arguments, node.end);
+        for (const child of childNodes(node)) this.walk(child, scopes, className);
+        return;
+      }
+      case NodeKind.Pragma: {
+        this.emitSelector(node.selector, selectorTypeOf(node.selector), node.start, node.arguments, node.end);
+        for (const child of childNodes(node)) this.walk(child, scopes, className);
+        return;
+      }
+      case NodeKind.Definition: {
+        const inner = definitionClassName(node) ?? className;
+        this.walk(node.definer, scopes, className);
+        for (const item of node.body) this.walk(item, scopes, inner);
+        return;
+      }
+      case NodeKind.MethodDefinition: {
+        const inner = node.target ? classNameOf(node.target) ?? className : className;
+        this.emitSelector(
+          node.selector,
+          node.messageType,
+          node.target ? node.target.end : node.start,
+          node.parameters,
+          methodBodyStart(node),
+        );
+        const local = new Map<string, 'parameter' | 'temporary'>();
+        for (const p of node.parameters) {
+          local.set(p.name, 'parameter');
+          this.emitDecl(p, 'parameter');
+        }
+        for (const t of node.temporaries) {
+          local.set(t.name, 'temporary');
+          this.emitDecl(t, 'variable');
+        }
+        const childScopes = [...scopes, local];
+        if (node.target) this.walk(node.target, scopes, className);
+        for (const pr of node.pragmas) this.walk(pr, childScopes, inner);
+        for (const s of node.statements) this.walk(s, childScopes, inner);
+        return;
+      }
+      case NodeKind.Block: {
+        const local = new Map<string, 'parameter' | 'temporary'>();
+        for (const p of node.parameters) {
+          local.set(p.name, 'parameter');
+          this.emitDecl(p, 'parameter');
+        }
+        for (const t of node.temporaries) {
+          local.set(t.name, 'temporary');
+          this.emitDecl(t, 'variable');
+        }
+        const childScopes = [...scopes, local];
+        for (const s of node.statements) this.walk(s, childScopes, className);
+        return;
+      }
+      case NodeKind.CompileTimeConstant:
+      case NodeKind.DynamicArray: {
+        const local = new Map<string, 'parameter' | 'temporary'>();
+        for (const t of node.temporaries) {
+          local.set(t.name, 'temporary');
+          this.emitDecl(t, 'variable');
+        }
+        const childScopes = node.temporaries.length > 0 ? [...scopes, local] : scopes;
+        for (const child of childNodes(node)) this.walk(child, childScopes, className);
+        return;
+      }
+      case NodeKind.InstanceVariables: {
+        for (const name of node.names) {
+          const field = className ? this.fields.get(className)?.get(name.name) : undefined;
+          this.emitDecl(name, 'property', field === 'class' ? ['static'] : []);
+        }
+        return;
+      }
+      default: {
+        for (const child of childNodes(node)) this.walk(child, scopes, className);
+        return;
+      }
+    }
+  }
+}
+
+/** Whether a selector reads as unary/binary/keyword (for pragmas, which carry no messageType). */
+function selectorTypeOf(selector: string): 'unary' | 'binary' | 'keyword' {
+  if (selector.includes(':')) return 'keyword';
+  return /^[A-Za-z_]/.test(selector) ? 'unary' : 'binary';
+}
+
+/** Classify every identifier/selector in `program` into role-tagged tokens. */
+export function collectSemanticTokens(
+  program: ProgramNode,
+  symbols: SymbolNode[],
+  tokens: Token[],
+  ctx: SemanticTokenContext,
+): RawSemanticToken[] {
+  return new Collector(tokens, collectFields(symbols), ctx).collect(program);
+}
+
+const TYPE_INDEX: Record<string, number> = Object.fromEntries(SEMANTIC_TOKEN_TYPES.map((t, i) => [t, i]));
+const MODIFIER_INDEX: Record<string, number> = Object.fromEntries(SEMANTIC_TOKEN_MODIFIERS.map((m, i) => [m, i]));
+
+/** LSP delta-encode classified tokens into the `(deltaLine, deltaStartChar,
+ *  length, tokenType, tokenModifiers)` integer stream. */
+export function encodeSemanticTokens(raw: RawSemanticToken[]): number[] {
+  const sorted = [...raw].sort((a, b) => a.line - b.line || a.char - b.char);
+  const data: number[] = [];
+  let prevLine = 0;
+  let prevChar = 0;
+  for (const t of sorted) {
+    const deltaLine = t.line - prevLine;
+    const deltaChar = deltaLine === 0 ? t.char - prevChar : t.char;
+    let mods = 0;
+    for (const m of t.modifiers) mods |= 1 << (MODIFIER_INDEX[m] ?? 0);
+    data.push(deltaLine, deltaChar, t.length, TYPE_INDEX[t.type] ?? 0, mods);
+    prevLine = t.line;
+    prevChar = t.char;
+  }
+  return data;
+}
+
+interface LspRange {
+  readonly start: Position;
+  readonly end: Position;
+}
+
+function withinRange(t: RawSemanticToken, range: LspRange): boolean {
+  const afterStart = t.line > range.start.line || (t.line === range.start.line && t.char + t.length > range.start.character);
+  const beforeEnd = t.line < range.end.line || (t.line === range.end.line && t.char < range.end.character);
+  return afterStart && beforeEnd;
+}
+
+/** Encoded semantic tokens for a whole document (AC1). */
+export function semanticTokensFull(
+  program: ProgramNode,
+  symbols: SymbolNode[],
+  tokens: Token[],
+  ctx: SemanticTokenContext,
+): number[] {
+  return encodeSemanticTokens(collectSemanticTokens(program, symbols, tokens, ctx));
+}
+
+/** Encoded semantic tokens within `range` (the large-file variant; spec §7). */
+export function semanticTokensRange(
+  program: ProgramNode,
+  symbols: SymbolNode[],
+  tokens: Token[],
+  ctx: SemanticTokenContext,
+  range: LspRange,
+): number[] {
+  return encodeSemanticTokens(collectSemanticTokens(program, symbols, tokens, ctx).filter((t) => withinRange(t, range)));
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,9 @@ import {
   type InitializeParams,
   type InitializeResult,
   type Location,
+  type SemanticTokens,
+  type SemanticTokensParams,
+  type SemanticTokensRangeParams,
   type WorkspaceSymbol,
   type WorkspaceSymbolParams,
 } from 'vscode-languageserver/node';
@@ -39,6 +42,13 @@ import { toWorkspaceSymbols } from './providers/workspaceSymbol';
 import { findDefinitions, resolveDefinitionQuery } from './providers/definition';
 import { completionsAt, type ClassCandidate, type SelectorCandidate } from './providers/completion';
 import { hoverAt, type HoverContext, type HoverImplementor } from './providers/hover';
+import {
+  semanticTokensFull,
+  semanticTokensRange,
+  SEMANTIC_TOKEN_TYPES,
+  SEMANTIC_TOKEN_MODIFIERS,
+  type SemanticTokenContext,
+} from './providers/semanticTokens';
 import { KernelIndexService, type KernelLibrarySetting } from './kernel/kernelIndexService';
 import { Provenance } from './kernel/model';
 import { SymbolKind } from './parser/symbols';
@@ -82,6 +92,16 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       documentHighlightProvider: true,
       // Hover over selectors/classes/variables/numeric literals (US-415).
       hoverProvider: true,
+      // Cartridge-aware semantic highlighting (US-422): role-accurate token
+      // classification, incl. the known-class vs unknown-global distinction.
+      semanticTokensProvider: {
+        legend: {
+          tokenTypes: [...SEMANTIC_TOKEN_TYPES],
+          tokenModifiers: [...SEMANTIC_TOKEN_MODIFIERS],
+        },
+        full: true,
+        range: true,
+      },
       // Trivial quick fixes (US-414 AC4): insert a missing closer (`]`/`)`/`}`/`>`)
       // or close an unterminated string.
       codeActionProvider: { codeActionKinds: [CodeActionKind.QuickFix] },
@@ -219,6 +239,39 @@ connection.onHover((params: HoverParams): Hover | null => {
     },
   };
   return hoverAt(doc.offsetAt(params.position), doc.getText(), getTokens(doc), getAst(doc), getSymbols(doc), ctx);
+});
+
+/** Build the semantic-token context (US-422): a class is `class` iff known in
+ *  workspace ∪ the active cartridge, with the source recorded so a cartridge
+ *  (kernel) class can carry the `defaultLibrary` modifier; otherwise a global. */
+function semanticContext(): SemanticTokenContext {
+  const workspaceClasses = new Set(
+    index
+      .all()
+      .filter((e) => e.kind === SymbolKind.Class || e.kind === SymbolKind.Namespace)
+      .map((e) => e.name),
+  );
+  return {
+    hasCartridge: kernelService.isEnabled,
+    classOrigin: (name) =>
+      workspaceClasses.has(name) ? 'workspace' : kernelService.hasClass(name) ? 'cartridge' : undefined,
+  };
+}
+
+connection.languages.semanticTokens.on((params: SemanticTokensParams): SemanticTokens => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return { data: [] };
+  }
+  return { data: semanticTokensFull(getAst(doc), getSymbols(doc), getTokens(doc), semanticContext()) };
+});
+
+connection.languages.semanticTokens.onRange((params: SemanticTokensRangeParams): SemanticTokens => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return { data: [] };
+  }
+  return { data: semanticTokensRange(getAst(doc), getSymbols(doc), getTokens(doc), semanticContext(), params.range) };
 });
 
 // Keep the workspace index fresh, debounced so rapid typing does not reparse on

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -112,6 +112,11 @@ assert.equal(caps.documentHighlightProvider, true, 'expected documentHighlightPr
 assert.ok(caps.completionProvider, 'expected completionProvider (US-413)');
 assert.ok(caps.codeActionProvider, 'expected codeActionProvider (US-414)');
 assert.equal(caps.hoverProvider, true, 'expected hoverProvider (US-415)');
+assert.ok(caps.semanticTokensProvider, 'expected semanticTokensProvider (US-422)');
+const stLegend = caps.semanticTokensProvider.legend;
+assert.ok(Array.isArray(stLegend?.tokenTypes) && stLegend.tokenTypes.length > 0, 'semantic tokens legend advertises token types');
+assert.ok(stLegend.tokenTypes.includes('class'), 'legend includes the `class` token type (AC2)');
+assert.ok(caps.semanticTokensProvider.full, 'semantic tokens advertises the `full` document request (AC1)');
 
 send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
@@ -307,6 +312,41 @@ const hovLit = (await receiveId(9)).result;
 const hovLitValue = typeof hovLit?.contents === 'string' ? hovLit.contents : hovLit?.contents?.value ?? '';
 assert.match(hovLitValue, /255/, 'radix literal hover decodes 16rFF to 255');
 
+// --- textDocument/semanticTokens/full (US-422) ---
+// A kernel class is classified as a `class` token off the bundled cartridge
+// (no gst). Decode the delta-encoded stream and assert OrderedCollection's role.
+const stUri = 'file:///semantic-tokens-test.st';
+const stText = 'OrderedCollection new';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri: stUri, languageId: 'smalltalk', version: 1, text: stText } },
+});
+send({
+  jsonrpc: '2.0',
+  id: 10,
+  method: 'textDocument/semanticTokens/full',
+  params: { textDocument: { uri: stUri } },
+});
+const stResult = (await receiveId(10)).result;
+assert.ok(Array.isArray(stResult?.data) && stResult.data.length > 0, 'semanticTokens/full returns a non-empty token stream');
+assert.equal(stResult.data.length % 5, 0, 'semantic tokens data is a flat run of 5-tuples');
+// Decode and find the token at column 0 (OrderedCollection); assert its type is `class`.
+const classTypeIndex = stLegend.tokenTypes.indexOf('class');
+let stLine = 0;
+let stChar = 0;
+let foundClassAtZero = false;
+for (let i = 0; i + 4 < stResult.data.length; i += 5) {
+  const dl = stResult.data[i];
+  const dc = stResult.data[i + 1];
+  stLine += dl;
+  stChar = dl === 0 ? stChar + dc : dc;
+  if (stLine === 0 && stChar === 0 && stResult.data[i + 3] === classTypeIndex) {
+    foundClassAtZero = true;
+  }
+}
+assert.ok(foundClassAtZero, 'OrderedCollection (col 0) is classified as a `class` from the bundled cartridge (AC2)');
+
 // --- textDocument/publishDiagnostics (US-414 slice A) — parser tier ---
 // Open a malformed doc; the server publishes parser diagnostics (debounced).
 const diagUri = 'file:///diagnostics-test.st';
@@ -339,6 +379,6 @@ await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, documentHighlight, completion, diagnostics, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, foldingRange, documentHighlight, completion, hover, semanticTokens, diagnostics, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -13,3 +13,4 @@ import './diagnostics.test.ts';
 import './codeAction.test.ts';
 import './comments.test.ts';
 import './hover.test.ts';
+import './semanticTokens.test.ts';

--- a/server/test/semanticTokens.test.ts
+++ b/server/test/semanticTokens.test.ts
@@ -1,0 +1,206 @@
+// Unit tests for the semantic-tokens provider (US-422). Runs in Node via tsx —
+// uses only the pure front end + the provider (no server runtime, no VS Code).
+// Written BEFORE the provider (Acceptance Harness phase): RED until
+// server/src/providers/semanticTokens.ts ships.
+//
+// Pins user-observable CLASSIFICATION per role (US-414 lesson: assert the
+// observable result, not just shape). The one differentiator is AC2 — a
+// capitalized name is `class` iff it resolves in workspace ∪ cartridge, else a
+// global — and AC4, the capitalization fallback when no cartridge is loaded.
+import assert from 'node:assert/strict';
+import { parse } from '../src/parser/parser.ts';
+import { tokenize } from '../src/parser/lexer.ts';
+import { buildSymbolTable } from '../src/parser/symbols.ts';
+import {
+  collectSemanticTokens,
+  encodeSemanticTokens,
+  SEMANTIC_TOKEN_TYPES,
+  SEMANTIC_TOKEN_MODIFIERS,
+  type RawSemanticToken,
+  type SemanticTokenContext,
+} from '../src/providers/semanticTokens.ts';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+/** A context whose known classes come from a fixed origin map; everything else
+ *  is unknown. `hasCartridge` toggles the AC4 capitalization fallback. */
+function ctxOf(
+  classes: Record<string, 'workspace' | 'cartridge'>,
+  hasCartridge = true,
+): SemanticTokenContext {
+  return { hasCartridge, classOrigin: (name) => classes[name] };
+}
+
+/** Byte offset → {line, character} (0-based, matching the token positions). */
+function posAt(src: string, offset: number): { line: number; character: number } {
+  let line = 0;
+  let last = -1;
+  for (let i = 0; i < offset; i++) {
+    if (src[i] === '\n') {
+      line += 1;
+      last = i;
+    }
+  }
+  return { line, character: offset - last - 1 };
+}
+
+/** Collect tokens for `src` under `ctx`. */
+function tokensFor(src: string, ctx: SemanticTokenContext): RawSemanticToken[] {
+  const ast = parse(src).ast;
+  return collectSemanticTokens(ast, buildSymbolTable(ast), tokenize(src).tokens, ctx);
+}
+
+/** The semantic token whose span (on its line) covers the n-th occurrence of
+ *  `needle` in `src`, or undefined. */
+function tokenForNth(
+  tokens: RawSemanticToken[],
+  src: string,
+  needle: string,
+  occurrence = 0,
+): RawSemanticToken | undefined {
+  let from = -1;
+  for (let i = 0; i <= occurrence; i++) {
+    from = src.indexOf(needle, from + 1);
+    if (from < 0) return undefined;
+  }
+  const p = posAt(src, from);
+  return tokens.find(
+    (t) => t.line === p.line && t.char <= p.character && p.character < t.char + t.length,
+  );
+}
+
+// --- AC1: role classification from the AST + symbol scopes -------------------
+
+test('AC1 instance variable is a property', () => {
+  const src = 'Object subclass: Foo [ | count | bar [ ^count ] ]';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  const ref = tokenForNth(toks, src, 'count', 1); // the use in `^count`
+  assert.ok(ref, 'the ivar use is tokenized');
+  assert.equal(ref.type, 'property', 'an instance variable is a property');
+});
+
+test('AC1 temporary is a variable', () => {
+  const src = 'Object subclass: Foo [ bar [ | tmp | ^tmp ] ]';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  const tok = tokenForNth(toks, src, 'tmp', 1); // the use in `^tmp`
+  assert.ok(tok, 'the temp use is tokenized');
+  assert.equal(tok.type, 'variable', 'a temporary is a variable');
+});
+
+test('AC1 method parameter is a parameter', () => {
+  const src = 'Object subclass: Foo [ bar: x [ ^x ] ]';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  const ref = tokenForNth(toks, src, 'x', 1); // the use in `^x`
+  assert.ok(ref, 'the parameter use is tokenized');
+  assert.equal(ref.type, 'parameter', 'a method argument is a parameter');
+});
+
+test('AC1 block parameter is a parameter', () => {
+  const src = 'Object subclass: Foo [ bar [ ^[ :y | y ] ] ]';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  const ref = tokenForNth(toks, src, 'y', 1); // the use inside the block body
+  assert.ok(ref, 'the block parameter use is tokenized');
+  assert.equal(ref.type, 'parameter', 'a block argument is a parameter');
+});
+
+// --- AC2: cartridge-driven known-class vs unknown-global --------------------
+
+test('AC2 a known kernel class is a class, with defaultLibrary', () => {
+  const src = 'OrderedCollection new';
+  const toks = tokensFor(src, ctxOf({ OrderedCollection: 'cartridge' }));
+  const tok = tokenForNth(toks, src, 'OrderedCollection');
+  assert.ok(tok, 'the class reference is tokenized');
+  assert.equal(tok.type, 'class', 'a known kernel class is a class (the cartridge consumer)');
+  assert.ok(tok.modifiers.includes('defaultLibrary'), 'a cartridge class carries defaultLibrary');
+});
+
+test('AC2 a workspace class is a class, without defaultLibrary', () => {
+  const src = 'Object subclass: Widget [ ]\nWidget new';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Widget: 'workspace' }));
+  const tok = tokenForNth(toks, src, 'Widget', 1); // the use on line 2
+  assert.ok(tok, 'the workspace class reference is tokenized');
+  assert.equal(tok.type, 'class', 'a known workspace class is a class');
+  assert.ok(!tok.modifiers.includes('defaultLibrary'), 'a workspace class is not defaultLibrary');
+});
+
+test('AC2 an unknown capitalized name is a global variable, not a class', () => {
+  const src = 'Zork new';
+  const toks = tokensFor(src, ctxOf({ OrderedCollection: 'cartridge' })); // Zork is unknown
+  const tok = tokenForNth(toks, src, 'Zork');
+  assert.ok(tok, 'the unknown global is tokenized');
+  assert.equal(tok.type, 'variable', 'an unknown capitalized name is a global variable, not a class');
+});
+
+// --- AC3: keyword-message parts + pseudo-variables --------------------------
+
+test('AC3 keyword-message parts are methods', () => {
+  const src = 'd at: 1 put: 2';
+  const toks = tokensFor(src, ctxOf({}));
+  const at = tokenForNth(toks, src, 'at:');
+  const put = tokenForNth(toks, src, 'put:');
+  assert.ok(at && put, 'both keyword parts are tokenized');
+  assert.equal(at.type, 'method', 'at: is a method (selector part)');
+  assert.equal(put.type, 'method', 'put: is a method (selector part)');
+});
+
+test('AC3 pseudo-variables are keywords, distinct from selectors', () => {
+  const src = 'Object subclass: Foo [ bar [ ^self ] baz [ ^super ] qux [ ^thisContext ] ]';
+  const toks = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  for (const pv of ['self', 'super', 'thisContext']) {
+    const tok = tokenForNth(toks, src, pv);
+    assert.ok(tok, `${pv} is tokenized`);
+    assert.equal(tok.type, 'keyword', `${pv} is a pseudo-variable (keyword)`);
+  }
+});
+
+test('AC3 nil/true/false are keywords', () => {
+  const src = '{ nil. true. false }';
+  const toks = tokensFor(src, ctxOf({}));
+  for (const pv of ['nil', 'true', 'false']) {
+    const tok = tokenForNth(toks, src, pv);
+    assert.ok(tok, `${pv} is tokenized`);
+    assert.equal(tok.type, 'keyword', `${pv} is a reserved literal (keyword)`);
+  }
+});
+
+// --- AC4: no-cartridge capitalization fallback ------------------------------
+
+test('AC4 with no cartridge, a capitalized name falls back to class', () => {
+  const src = 'Zork new';
+  const toks = tokensFor(src, ctxOf({}, /* hasCartridge */ false));
+  const tok = tokenForNth(toks, src, 'Zork');
+  assert.ok(tok, 'the capitalized name is tokenized');
+  assert.equal(tok.type, 'class', 'with no cartridge, capitalized ⇒ class (AC4 fallback)');
+});
+
+test('AC4 empty input yields no tokens and never throws', () => {
+  assert.deepEqual(tokensFor('   ', ctxOf({})), [], 'no tokens for whitespace-only input');
+});
+
+// --- Encoding: LSP delta-encoded integer stream -----------------------------
+
+test('encodeSemanticTokens emits 5 integers per token, sorted + delta-encoded', () => {
+  const src = 'Object subclass: Foo [ bar: x [ ^x ] ]';
+  const raw = tokensFor(src, ctxOf({ Object: 'cartridge', Foo: 'workspace' }));
+  const data = encodeSemanticTokens(raw);
+  assert.equal(data.length % 5, 0, 'data is a flat run of 5-tuples');
+  assert.equal(data.length / 5, raw.length, 'one 5-tuple per raw token');
+  // First tuple: deltaLine is absolute for the first token (prev line 0).
+  assert.ok(data[0] >= 0 && data[1] >= 0, 'first token has non-negative deltas');
+  // Every type index is within the legend.
+  for (let i = 3; i < data.length; i += 5) {
+    assert.ok(data[i] >= 0 && data[i] < SEMANTIC_TOKEN_TYPES.length, 'type index within legend');
+  }
+});
+
+test('legend modifiers include static + defaultLibrary', () => {
+  assert.ok(SEMANTIC_TOKEN_MODIFIERS.includes('static'), 'static modifier (class variable)');
+  assert.ok(SEMANTIC_TOKEN_MODIFIERS.includes('defaultLibrary'), 'defaultLibrary modifier (cartridge class)');
+});
+
+console.log(`semanticTokens.test: ${passed} passed`);

--- a/specs/US-422-Semantic-Tokens/manual-qa-workspace/.vscode/settings.json
+++ b/specs/US-422-Semantic-Tokens/manual-qa-workspace/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  // US-422 manual QA — the kernel-sourcing knob drives the AC2/AC4 cartridge rows.
+  // After changing it, RELOAD the Extension Dev Host window (Ctrl+R / Cmd+R) so the
+  // server re-resolves the kernel source, then re-inspect the tokens.
+  //
+  // DEFAULT below = "auto". This box has gst, so auto resolves to an INSTALLED
+  // cartridge (status bar: "installed (gst)") — a cartridge IS loaded.
+  //
+  // Swap the value for the AC2/AC4 matrix (README rows C1–C3):
+  //   C1 "auto"     cartridge present → Zork is `variable` (unknown global); kernel classes `class`+defaultLibrary
+  //   C2 "bundled"  cartridge present → same classification as auto (reference floor)
+  //   C3 "off"      NO cartridge → AC4 fallback: Zork (any capitalized) becomes `class`
+  //
+  // Turn ON semantic highlighting so these tokens actually paint (some themes default it off):
+  "editor.semanticHighlighting.enabled": true,
+  "smalltalk.completion.kernelLibrary": "auto"
+}

--- a/specs/US-422-Semantic-Tokens/manual-qa-workspace/README.md
+++ b/specs/US-422-Semantic-Tokens/manual-qa-workspace/README.md
@@ -1,0 +1,91 @@
+# US-422 — Manual QA workspace (Semantic Tokens)
+
+A ready-to-open workspace for the `verification.md` §4 matrix. It exercises every role
+the provider classifies (AC1), the headline **cartridge-driven class vs unknown-global**
+distinction (AC2), pseudo-variables and keyword-selector parts (AC3), and the **no-cartridge
+capitalization fallback** (AC4) — all offline, **no `gst` needed**.
+
+> Semantic tokens are *invisible without the right tool*: they only re-tint what the TextMate
+> grammar already colored, and only when a theme maps the token type. **Verify with the token
+> inspector, not your eyes** — it reports the exact semantic type.
+
+## Open it
+1. In the Extension Development Host (`F5` from the repo): **File → Open Folder…** → this
+   `manual-qa-workspace/` folder. The extension auto-activates (the folder has `.st` files).
+2. Run **Developer: Inspect Editor Tokens and Scopes** (Command Palette). A hover panel
+   follows the cursor; under **semantic token type** it shows the type + any modifiers
+   (e.g. `class` / `defaultLibrary`). That field is the source of truth for this story.
+3. The status bar (bottom-right) shows `Smalltalk kernel: …`. After editing
+   `.vscode/settings.json`, **reload the window** (`Ctrl+R` / `Cmd+R`).
+
+`Roles.st` is valid GST and must parse with **0 diagnostics** — any red squiggle is a bug.
+
+---
+
+## Part A — role classification (default settings: `auto`, a cartridge is loaded)
+
+Put the cursor on each token in `Roles.st`; read **semantic token type** in the inspector.
+
+| Row | Token (where) | Expect type | Modifier |
+|---|---|---|---|
+| **AC1-ivar** | `balance` / `entries` (in `init`/`deposit:`) | `property` | — |
+| **AC1-classvar** | `DefaultLimit` (in `limit`/`setLimit:`) | `property` | **`static`** |
+| **AC1-temp** | `receipt` (in `deposit:`) | `variable` | — |
+| **AC1-param** | `amount` (in `deposit:`), `n` (in `setLimit:`) | `parameter` | — |
+| **AC1-blockarg** | `each` (in `report`'s block) | `parameter` | — |
+| **AC2-kernel** | `OrderedCollection` (in `init`), `Object` (header) | `class` | **`defaultLibrary`** |
+| **AC2-workspace** | `Vault` (use site, last lines) | `class` | *(no `defaultLibrary`)* |
+| **AC2-global** | `Transcript` (in `report`) | `variable` | — *(not a known class ⇒ global)* |
+| **AC2-unknown** | `Zork` (use site) | `variable` | — *(unknown capitalized ⇒ global, not class)* |
+| **AC3-keyword** | `deposit:` / `setLimit:` parts, `do:` (selectors) | `method` | — |
+| **AC3-unary** | `printString`, `new`, `isNil` (selectors) | `method` | — |
+| **AC3-binary** | `+`, `*`, `\|` (selectors) | `method` | — |
+| **AC3-pseudo** | `self` / `super` / `nil` / `true` / `false` / `thisContext` | `keyword` | — |
+
+> **AC1-shadowing spot-check:** there is no shadow in this fixture, but the rule (a lexical
+> param/temp wins over a same-named class field) matches the hover scope rule — trust the
+> unit test `AC1` rows for that edge.
+
+---
+
+## Part B — selectors vs everything else (AC3, a TextMate-interaction check)
+
+This is where US-415 found a grammar bug, so look carefully:
+
+| Row | Do | Expect |
+|---|---|---|
+| **B1** | Inspect `deposit:` in `Vault new deposit: 16rFF` | `method` — the keyword part is a selector, **not** colored like the `amount` parameter beside it |
+| **B2** | Inspect the `16rFF` next to it | **no** semantic token (literals are left to the grammar) — and its trailing `.` stays the separator color, not the number color (radix-integer grammar regression from US-415) |
+| **B3** | Inspect `each printString` in the block | `each` → `parameter`, `printString` → `method` — adjacent tokens get **distinct** types |
+
+---
+
+## Part C — AC2/AC4 cartridge matrix (`.vscode/settings.json` → reload)
+
+Change `smalltalk.completion.kernelLibrary`, **reload the window**, re-inspect. The
+**workspace** rows (AC2-workspace `Vault`, all AC1 roles) must be **unchanged** in every tier —
+only the unknown-capitalized rows move.
+
+| Row | Setting | Status bar | `Zork` (unknown) | `OrderedCollection` (kernel) |
+|---|---|---|---|---|
+| **C1** | `"auto"` | `installed (gst)` | `variable` (global) | `class` + `defaultLibrary` |
+| **C2** | `"bundled"` | `reference (gst 3.2.5)` | `variable` (global) | `class` + `defaultLibrary` |
+| **C3** | `"off"` | `off` | **`class`** (AC4 capitalization fallback) | **`class`** (no cartridge — fallback) |
+
+This is the whole differentiator: **with the cartridge, the extension knows `OrderedCollection`
+is a class and `Zork` is not — offline, no `gst`.** With the cartridge off, it can only guess by
+capitalization (AC4).
+
+---
+
+## Part D — robustness & shipped artifact
+
+| Row | Do | Expect |
+|---|---|---|
+| **R1** | Mid-edit: delete the closing `]` of `deposit:` so a squiggle appears, then inspect `balance`/`OrderedCollection` higher up | still classified correctly — the provider degrades, never throws (no error toast, no missing-token cascade) |
+| **V1** | `npm run package` → install the VSIX in a clean VS Code → open this folder | repeat **AC2-kernel**, **AC2-unknown (C1)**, and **C3** — the shipped build matches the dev build |
+
+---
+
+Record results in `../verification.md` §4, fill the date/sign-off line, then tick §5.
+Anything that doesn't match the expected type above is a bug — note it and stop.

--- a/specs/US-422-Semantic-Tokens/manual-qa-workspace/Roles.st
+++ b/specs/US-422-Semantic-Tokens/manual-qa-workspace/Roles.st
@@ -1,0 +1,59 @@
+"US-422 manual QA fixture. Valid GST — parses with 0 diagnostics, so any red
+ squiggle here is a bug. See README.md for the token-by-token color script.
+ Verify with: Developer: Inspect Editor Tokens and Scopes (puts the cursor on a
+ token and shows its `semantic token type` + modifiers, below the TextMate scopes)."
+
+Object subclass: Vault [
+    | balance entries |
+
+    <comment: 'A tiny vault for the US-422 semantic-token tests.'>
+
+    Vault class [
+        | DefaultLimit |
+
+        "ROW classvar: DefaultLimit -> property + `static` modifier."
+        limit [ ^DefaultLimit ]
+        setLimit: n [ DefaultLimit := n ]
+    ]
+
+    "ROW ivar: balance / entries -> property.
+     ROW class (cartridge): OrderedCollection -> class + `defaultLibrary`."
+    init [
+        balance := 0.
+        entries := OrderedCollection new.
+        ^self
+    ]
+
+    "ROW param: amount -> parameter.   ROW temp: receipt -> variable.
+     ROW selector: deposit: / add: / + -> method (keyword / unary / binary)."
+    deposit: amount [
+        | receipt |
+        receipt := amount * 2.
+        entries add: receipt.
+        balance := balance + amount.
+        ^receipt
+    ]
+
+    "ROW block param: each -> parameter.
+     ROW global (known, not a class): Transcript -> variable, NOT class.
+     ROW selector: do: / showCr: / printString -> method."
+    report [
+        entries do: [ :each | Transcript showCr: each printString ].
+        ^self
+    ]
+
+    "ROW pseudo-variables: self / super / nil / true / false / thisContext -> keyword."
+    printOn: aStream [
+        super printOn: aStream.
+        balance isNil ifTrue: [ ^nil ].
+        (true | false) ifTrue: [ thisContext ].
+        ^self
+    ]
+]
+
+"Use site.
+ ROW class (workspace): Vault -> class, NO defaultLibrary modifier.
+ ROW global / AC4: Zork is unknown. With a cartridge loaded (auto/bundled) it is a
+ `variable` (unknown global); with `off` (no cartridge) it falls back to `class`."
+Vault new deposit: 16rFF.
+Zork new frobnicate.

--- a/specs/US-422-Semantic-Tokens/requirements-validation.md
+++ b/specs/US-422-Semantic-Tokens/requirements-validation.md
@@ -2,28 +2,41 @@
 
 **Purpose**: Validate spec quality BEFORE implementation begins  
 **Type**: Requirements Quality Gate  
+**US**: US-422 — Semantic Tokens (Cartridge-Aware) · **Validated**: 2026-06-25
 
 ---
 
 ## Section 1: Constitution Gates (Mandatory)
-- [ ] **Native Look & Feel**: Uses standard VS Code APIs?
-- [ ] **Zero Config**: Defaults provided? Auto-detection planned?
-- [ ] **Protocol First**: LSP/DAP used where applicable?
-- [ ] **Robustness**: Error handling defined?
-- [ ] **Dialect Agnostic**: Architecture supports future dialects?
+- [X] **Native Look & Feel**: Uses the standard `textDocument/semanticTokens` LSP API + the standard
+  token-type/modifier legend, so the user's theme colors roles with no custom config (spec §5).
+- [X] **Zero Config**: No setting required; degrades to a capitalization fallback with no cartridge
+  (AC4). Works with no `gst`.
+- [X] **Protocol First**: Pure LSP (`semanticTokens/full` + `range`); no bespoke channel.
+- [X] **Robustness**: Front end never throws — the provider returns an (empty) token set, never an error
+  (spec §5, §7); reuses `parseCache`, honors cancellation.
+- [X] **Dialect Agnostic**: The known-class set is `workspace ∪ cartridge` via the US-430 Console facade
+  (`kernelService.hasClass`); a future dialect cartridge lights up AC2 with no provider change.
 
 ## Section 2: Specification Completeness
-- [ ] Goals and Non-Goals explicitly listed?
-- [ ] User stories in standard format?
-- [ ] Acceptance scenarios (Given/When/Then) defined?
-- [ ] Edge cases identified?
-- [ ] Dependencies listed?
+- [X] Goals and Non-Goals explicitly listed (spec §2/§3 — no new parsing, no theming, layers on TextMate).
+- [X] User story in standard format (spec §4).
+- [X] Acceptance criteria defined and testable (AC1–AC5); each maps to a role/behavior assertion.
+- [X] Edge cases identified: no-cartridge fallback (AC4); pseudo-variables; unknown global vs class;
+  shadowing (lexical param/temp wins over a class field, per the US-415 hover scope rule).
+- [X] Dependencies listed (spec §Dependencies): US-430 loader class set, US-411 AST + symbol scopes.
 
 ## Section 3: Technical Design
-- [ ] API/Command contracts defined?
-- [ ] Data structures defined?
-- [ ] Error handling strategy defined?
-- [ ] Testing strategy (Unit vs Integration) defined?
+- [X] API/Command contracts defined: `semanticTokensProvider` (full + range) with an explicit legend
+  advertised in `server.ts` (spec §5).
+- [X] Data structures defined: LSP delta-encoded `(deltaLine, deltaStartChar, length, type, modifiers)`;
+  token-type + modifier legend (`class`, `property`, `variable`, `parameter`, `method`, `keyword`;
+  modifiers `static`, `defaultLibrary`).
+- [X] Error-handling strategy defined: never-throw; empty result on miss; cancellation/`range` for perf.
+- [X] Testing strategy defined: unit (per-role classification + AC2 cartridge-vs-unknown + AC4 fallback),
+  `test:server` (capability + a token assertion), e2e token-range assertion, and an output-eval dataset
+  `evals/datasets/semantic-tokens/` (AC5).
 
 ## Section 4: Validation Result
-- [ ] PASS - Ready for implementation
+- [X] **PASS — Ready for implementation.** The spec is complete, testable, and constitutionally clean;
+  the one differentiator (AC2, cartridge-driven class/global) and the fallback (AC4) are both pinned to
+  assertions. Proceed to the Acceptance Harness (write the failing tests first).

--- a/specs/US-422-Semantic-Tokens/spec.md
+++ b/specs/US-422-Semantic-Tokens/spec.md
@@ -2,7 +2,7 @@
 
 **ID**: US-422
 **Feature**: `textDocument/semanticTokens` — role-accurate highlighting, including a cartridge-driven known-class vs unknown-global distinction
-**Status**: Draft
+**Status**: Implemented — automated layers green (pending Extension-Host manual QA + CI)
 **Owner**: Leonardo Nascimento
 **Created**: 2026-06-22
 **Architecture**: [ADR-0003](../../docs/decisions/0003-cartridge-resolution.md)

--- a/specs/US-422-Semantic-Tokens/tasks.md
+++ b/specs/US-422-Semantic-Tokens/tasks.md
@@ -3,17 +3,28 @@
 **ID**: US-422 | **Spec**: ./spec.md | **Plan**: ./plan.md
 
 ## Phase 1 — Spec & Setup
-- [ ] T001 Spec reviewed; `requirements-validation.md` gate passed.
-- [ ] T002 Confirm US-430 loader exposes a `knownClass(name)` / class set.
+- [X] T001 Spec reviewed; `requirements-validation.md` gate passed (PASS, 2026-06-25).
+- [X] T002 Confirm US-430 loader exposes a known-class lookup — `KernelIndexService.hasClass(name)`
+  (workspace classes ∪ cartridge), used by `semanticContext()` in `server.ts`.
 
 ## Phase 2 — Implementation
-- [ ] T010 Legend (token types/modifiers); advertise `semanticTokensProvider` (full + range) in `server.ts`.
-- [ ] T011 `providers/semanticTokens.ts`: AST walk + symbol-scope role resolution (ivar/classvar/temp/args). (AC1)
-- [ ] T012 Keyword-message parts + pseudo-variables as distinct tokens. (AC3)
-- [ ] T013 Cartridge `knownClass` lookup for capitalized identifiers; capitalization fallback. (AC2/AC4)
-- [ ] T014 Reuse `parseCache`; honor cancellation; range variant.
+- [X] T010 Legend (`class`/`property`/`variable`/`parameter`/`method`/`keyword`; modifiers
+  `static`/`defaultLibrary`); advertise `semanticTokensProvider` (full + range) in `server.ts`.
+- [X] T011 `providers/semanticTokens.ts`: single-pass scope-tracking AST walk + symbol-scope role
+  resolution (ivar→property, classvar→property+static, temp→variable, params→parameter). (AC1)
+- [X] T012 Keyword/binary/unary message + method-pattern + pragma selector parts → `method`; the six
+  pseudo-variables → `keyword`. (AC3)
+- [X] T013 Cartridge known-class lookup for capitalized identifiers (cartridge ⇒ `defaultLibrary`);
+  unknown-capitalized ⇒ global `variable` with a cartridge, ⇒ `class` capitalization fallback without
+  one. (AC2/AC4)
+- [X] T014 Reuses `parseCache` (`getAst`/`getSymbols`/`getTokens`); `range` variant implemented.
+  *(Cancellation: computation is synchronous and sub-ms for typical files, so the handler returns
+  directly rather than polling a token — revisit only if a perf budget regresses on huge files.)*
 
 ## Phase 3 — Verify
-- [ ] T900 `evals/datasets/semantic-tokens/` added + green. (AC5)
-- [ ] T901 `verification.md` gate passed (roles distinct; kernel classes colored with no gst; pseudo-vars).
-- [ ] T902 CI green on Linux/macOS/Windows.
+- [X] T900 `evals/datasets/semantic-tokens/` added + green (9/9; `npm run eval`). (AC5)
+- [X] T901 Automated layers green: `test:parser` (14 new unit rows), `test:server` (capability +
+  decoded `class` token off the bundled cartridge), `test:e2e` (23 passing, incl. 2 US-422 rows).
+  Manual-QA workspace authored (`manual-qa-workspace/`, fixture verified to parse 0-diagnostics and
+  match every README role); **Extension-Host run pending** before release sign-off.
+- [ ] T902 CI green on Linux/macOS/Windows (pending push/PR).

--- a/specs/US-422-Semantic-Tokens/verification.md
+++ b/specs/US-422-Semantic-Tokens/verification.md
@@ -2,28 +2,36 @@
 
 **Purpose**: Verify implementation correctness AFTER coding  
 **Type**: Implementation Verification  
+**US**: US-422 — Semantic Tokens (Cartridge-Aware) · **Updated**: 2026-06-25
 
 ---
 
 ## Section 1: Acceptance Criteria
-- [ ] All ACs in `tasks.md` are checked?
-- [ ] Each AC has a passing test?
+- [X] All ACs in `tasks.md` are checked (T010–T014, T900).
+- [X] Each AC has a passing test:
+  - **AC1** (roles) — `semanticTokens.test.ts` ivar/temp/param/block-arg rows; eval ivar/param/temp.
+  - **AC2** (class iff known; cartridge ⇒ defaultLibrary) — unit `AC2` rows; eval kernel-vs-workspace-vs-unknown; `test:server` decodes a `class` token for `OrderedCollection` off the bundled cartridge; e2e AC2.
+  - **AC3** (keyword parts + pseudo-vars distinct) — unit `AC3` rows; eval; e2e `AC1/AC3`.
+  - **AC4** (no-cartridge capitalization fallback) — unit `AC4 with no cartridge …`.
+  - **AC5** (works with no `gst`; output eval) — `evals/datasets/semantic-tokens/` (9/9, run by `npm run eval`, no `gst`).
 
 ## Section 2: Code Quality
-- [ ] `npm run lint` passes?
-- [ ] `npm test` passes?
-- [ ] No `any` types in TypeScript (unless justified)?
-- [ ] JSDoc provided for public APIs?
+- [X] `npm run lint` passes (eslint clean).
+- [X] `npm test` passes — `test:parser` (incl. 14 new), `test:server`, `test:e2e` (23 passing), full `eval`.
+- [X] No `any` types (provider is fully typed; legend/types exported as `const` tuples).
+- [X] JSDoc provided for the public API (`collectSemanticTokens`, `semanticTokensFull/Range`, `encodeSemanticTokens`, `SemanticTokenContext`, legend).
 
 ## Section 3: Constitutional Compliance
-- [ ] **Native**: Follows VS Code guidelines?
-- [ ] **Zero Config**: Works without manual setup?
-- [ ] **Robustness**: Handles errors gracefully?
-- [ ] **TDD**: Tests were written/exist?
+- [X] **Native**: standard `textDocument/semanticTokens` (full + range) + the standard token legend.
+- [X] **Zero Config**: no setting required; degrades to capitalization with no cartridge (AC4); no `gst`.
+- [X] **Robustness**: never throws — empty token set on a missing doc; reuses `parseCache`.
+- [X] **TDD**: unit + e2e + handshake + eval written BEFORE the provider (RED confirmed, then GREEN).
 
 ## Section 4: Manual Verification
-- [ ] Feature works in Extension Host?
-- [ ] No errors in Developer Tools console?
+- [ ] Feature works in Extension Host (run `manual-qa-workspace/` per its README — token-inspector
+  matrix Parts A–D). **Pending** — required before release sign-off (US-415 lesson: the Extension-Host
+  pass catches grammar/coloring bugs the four automated layers miss).
+- [ ] No errors in Developer Tools console.
 
 ## Section 5: Sign-Off
-- [ ] Ready for Merge?
+- [ ] Ready for Merge? *(automated layers green; awaiting the Extension-Host manual-QA pass + CI on 3 OSes.)*


### PR DESCRIPTION
Closes #65

Adds a `textDocument/semanticTokens` provider (full + range) that colors Smalltalk by **role** from the US-411 AST + symbol-table scopes, reusing `parseCache` — the first visible consumer of the EPIC-005 Console & Cartridges foundation (US-430), **offline, no `gst`**.

## Roles
| Role | Token type |
|---|---|
| instance var | `property` |
| class var | `property` + `static` |
| temporary | `variable` |
| method/block arg | `parameter` |
| known class | `class` (+ `defaultLibrary` from the cartridge) |
| message/method/pragma selector parts | `method` |
| `self super nil true false thisContext` | `keyword` |

## The differentiator (AC2 / AC4)
A capitalized identifier is `class` **iff** it resolves in `workspace ∪ cartridge` — kernel classes light up with no `gst`; an unknown capitalized name is a global `variable`. With **no** cartridge loaded it falls back to "capitalized ⇒ class" (AC4).

## Tests (TDD: RED → GREEN)
- **Unit** `server/test/semanticTokens.test.ts` — 14 rows (per-role, AC2 cartridge-vs-unknown, AC4 fallback, encoder).
- **Handshake** `test:server` — advertises the legend + full/range; decodes a real `class` token for `OrderedCollection` off the bundled cartridge over LSP.
- **E2E** `client/test-e2e/US-422.acceptance.test.js` — 2 rows (23 passing total).
- **Output eval** `evals/datasets/semantic-tokens/` — 9/9, no `gst`.
- `check-types` + `lint` clean.

## Spec package
`requirements-validation.md` PASS, `tasks.md`/`verification.md` updated, and a `manual-qa-workspace/` (token-inspector matrix) whose fixture is verified to parse 0-diagnostics and match every documented role.