### PR TITLE
docs: doc-rot audit after v0.8.0 (semantic tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Powered by a bundled language engine — **no GNU Smalltalk (`gst`) installation
 *   **Highlight Occurrences:** put the cursor on a selector or variable to highlight its other uses in the file (scope-aware).
 *   **Auto Completion:** selectors after a receiver, class names, and in-scope variables — including **standard kernel-library** classes/selectors. Multi-part keyword selectors insert as snippets (`at:put:` → `at:⟨1⟩ put:⟨2⟩`). Kernel completions come from your **installed** GNU Smalltalk when found, otherwise a **bundled** reference (GNU Smalltalk 3.2.5); the active source is shown in the status bar. Configurable via [`smalltalk.completion.kernelLibrary`](#configuration).
 *   **Diagnostics (Error Checking):** syntax errors are flagged with squiggles **as you type** — no `gst` needed — badged `smalltalk(parse)`, with severity as the parser reports it; they clear as you fix the code. Quick fixes insert a missing closer (`]`, `)`, `}`, `>`) or close an unterminated string.
-*   _(Coming Soon)_ Hover Information
+*   **Hover Information:** hover a selector (signature + implementors), a class (superclass chain), a variable (kind + declaration site), or a numeric literal (e.g. `16rFF` → `255`). Class/method comments are shown from your own workspace source and your installed kernel; the bundled reference stays facts-only.
+*   **Semantic Highlighting:** role-accurate coloring — instance/class variables, temporaries, parameters, selectors, and pseudo-variables are each colored by meaning, and a capitalized name is colored as a **class** only when it's a real class in your workspace or the kernel (otherwise a global). Enable `editor.semanticHighlighting.enabled` if your theme defaults it off.
+*   _(Coming Soon)_ References / Senders & Implementors
 *   _(Coming Soon)_ Formatting
 
 <!-- Configuration (US-105) -->

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,7 +178,7 @@ stories in [`docs/product/user-stories.md`](product/user-stories.md).
 | Epic | Theme | Stream | Status |
 |---|---|---|---|
 | EPIC-004 | Language Intelligence — TypeScript LSP (offline, single-dialect) | A | In progress (→1.0) |
-| EPIC-005 | Offline Knowledge Graph — Console & Cartridges | B | In progress (foundation landed — US-430; next US-422/423) |
+| EPIC-005 | Offline Knowledge Graph — Console & Cartridges | B | In progress (US-430 foundation + US-422 semantic tokens shipped; next US-423) |
 | EPIC-006 | Multi-Dialect Expansion (2nd+ cartridges, dialect detection, container seam) | A+B | Planned (read-only Tonel wedge US-424 ~1.0; full second dialect 1.5) |
 | EPIC-007 | The Live Bridge (optional runtime delegation) | C | Planned (1.6+) |
 | EPIC-008 | Image-Grade Workbench (System Browser, refactorings, search) | A+B | Planned (1.1–1.4) |
@@ -199,8 +199,9 @@ squiggles + insert-closer/close-string quick fixes; new `evals/datasets/diagnost
 opt-in `gst`/runtime compile-diagnostics tier was built then **deferred to EPIC-007** (Live Bridge) —
 redundant with the parser for syntax, real value (semantic errors) needs a runtime; shipped **v0.6.0**.
 **EPIC-005 foundation landed** earlier: US-430 (Console loader + cartridge
-convergence) merged (#82) — completion runs off GST Cartridge #01. **US-415 hover shipped (v0.7.0).** Next EPIC-005
-consumers: US-422 (semantic tokens) / US-423 (references/senders). **2026-06-24 strategy review folded in:**
+convergence) merged (#82) — completion runs off GST Cartridge #01. **US-415 hover shipped (v0.7.0); US-422
+cartridge-aware semantic tokens shipped (v0.8.0)** — the first user-facing cartridge consumer. Next EPIC-005
+consumer: US-423 (references/senders). **2026-06-24 strategy review folded in:**
 US-424 (read-only Tonel "Trojan Horse" — resequenced to ~1.0, Stream A), US-706 (writable `smalltalk-image://`
 VFS under the Live Bridge), and a status-bar dialect picker on US-602; the external-LSP-client framing was
 considered and declined in favor of the Console & Cartridges moat._


### PR DESCRIPTION
Post-release doc-rot sweep for **v0.8.0** (the items the release PR #91 didn't cover).

- **README** — Hover moves from *Coming Soon* to a shipped feature; **Semantic Highlighting** added; the "coming soon" list now reads References/Senders + Formatting.
- **docs/ROADMAP.md** — the EPIC-005 epic-table row and the narrative status note drop US-422 from "next" (it shipped v0.8.0) and point the next consumer at **US-423**.

Docs-only.