### PR TITLE
docs: link US-424/US-706 backlog entries to their tracking issues

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,7 +167,7 @@ stories in [`docs/product/user-stories.md`](product/user-stories.md).
 
 | Story | What | When to do it | Issue |
 |---|---|---|---|
-| US-424 | Tonel **read-only** wedge (grammar + folding + outline) | **Pull forward to ~1.0** (Stream A, no cartridge/seam — EPIC-006) | TBD |
+| US-424 | Tonel **read-only** wedge (grammar + folding + outline) | **Pull forward to ~1.0** (Stream A, no cartridge/seam — EPIC-006) | #93 |
 | US-418 | Container-format seam (dialect door) — *full* Tonel parsing | **Trigger fires at 1.5** (Pharo/Tonel — EPIC-006) | #58 |
 | US-419 | Kernel-index method categories | Ride with **US-415 hover** (needs the grouping) | #59 |
 | US-420 | Completion pseudo-variables | Near-term — v0.5.1 or front of US-414 | #60 |

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1404,7 +1404,7 @@ Scenario: User follows Quick Start guide
 ## US-424: Tonel Read-Only Editing Experience (the "Trojan Horse")
 
 * **ID:** US-424
-* **Status:** Backlog (vision — pulled forward to **~1.0**, ahead of the rest of EPIC-006) — issue TBD
+* **Status:** Backlog (vision — pulled forward to **~1.0**, ahead of the rest of EPIC-006) — #93
 * **Epic:** EPIC-006 *(but ships as a Stream-A wedge, decoupled from the cartridge/seam work)*
 * **Priority:** High *(cheap go-to-market wedge: wins the Pharo/GemStone/VA crowd before any cartridge exists)*
 * **Estimate:** M
@@ -1766,7 +1766,7 @@ Scenario: User follows Quick Start guide
 ## US-706: Live-Image Virtual FileSystem (writable `smalltalk-image://`)
 
 * **ID:** US-706
-* **Status:** Backlog (vision — milestone 1.6+) — issue TBD
+* **Status:** Backlog (vision — milestone 1.6+) — #94
 * **Epic:** EPIC-007
 * **Priority:** Low *(the most ambitious live feature; ships after the higher-value live items)*
 * **Estimate:** L


### PR DESCRIPTION
Replaces the `issue TBD` placeholders in the backlog docs now that the strategy-review items have GitHub issues:

- **US-424** (read-only Tonel wedge) → #93
- **US-706** (live-image VFS) → #94

US-602's added status-bar-picker scope is tracked on the existing #71. Docs-only.

(Supersedes #95, which was blocked by a stray empty commit during a GitHub Actions outage.)