### PR TITLE
chore: US-423 PO sign-off + CI actions bump (Node 24)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
     - run: npm ci
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 22.x
     - run: npm ci

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1359,7 +1359,7 @@ Scenario: User follows Quick Start guide
 * [X] **Language Server:** unit tests (merge/dedup/precedence, union packaging, dev-box overlap, ranking) — `workspaceXref`/`resolve`/`callHierarchy`/`crossReference` suites + `test:server`.
 * [X] **End-to-End:** peek references + plural definition + call hierarchy + command-result assertions (`US-423.acceptance.test.js`, 27-test suite green).
 * [X] Output eval `evals/datasets/references/` (5/5); no-`gst` verified.
-* [ ] PO accepts the story (hands-on manual-QA pass pending; see `verification.md` §4/§5).
+* [X] PO accepts the story — **accepted 2026-06-26**, shipped **v0.9.0** (see `verification.md` §4/§5).
 
 **Notes / Questions / Assumptions:**
 * Graded honestly as a **Transient Lead** — copyable, and a static shadow of the image's whole-world query — but the highest-value navigation win and the most visible proof of the offline knowledge graph. **Sequencing (resolved):** lands at **0.9.0** (Cross-Reference Intelligence) in the evolved ladder; formatting (US-416) moves to 1.0.

--- a/specs/US-423-References-Senders-Implementors/tasks.md
+++ b/specs/US-423-References-Senders-Implementors/tasks.md
@@ -31,5 +31,5 @@ Mark each task `[x]` as it lands. Map tasks to acceptance criteria where possibl
 
 ## Phase 3 — Verify
 - [x] T900 `evals/datasets/references/` added + green — 5/5 cases (union, provenance, ranking, AC6 never-filter), wired into `npm run eval` (now 5 datasets, all green).
-- [~] T901 `verification.md` filled; AC→test mapping + code-quality + constitutional all checked. Manual-QA workspace prepared + offline pre-verified (0 diagnostics; engine outputs match the matrix). **Hands-on Extension Host pass + PO sign-off pending** (release gate).
-- [ ] T902 CI green on Linux/macOS/Windows (on push/PR).
+- [x] T901 `verification.md` filled + **PO-accepted 2026-06-26**; the hands-on Extension Host pass caught 5 real issues (all fixed pre-release).
+- [x] T902 CI green on Linux/macOS/Windows + e2e (PR #97); shipped v0.9.0.

--- a/specs/US-423-References-Senders-Implementors/verification.md
+++ b/specs/US-423-References-Senders-Implementors/verification.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Verify implementation correctness AFTER coding  
 **Type**: Implementation Verification  
-**US**: US-423 — References + Senders/Implementors (Two-Tier Engine) · **Updated**: 2026-06-25
+**US**: US-423 — References + Senders/Implementors (Two-Tier Engine) · **Updated**: 2026-06-26 · **Shipped**: v0.9.0
 
 ---
 
@@ -56,12 +56,16 @@
   checked to match every expected value in the matrix (Implementors/Senders of `#greet`/`#do:`/`#new`,
   the `(top level)` sender label, the class-side `Stage class` implementor ranked first, and the
   receiver-hint badges).
-- [ ] **Hands-on Extension Host pass + PO sign-off — PENDING.** The §-A–E click-through (peek, the
-  command tree + header tooltip, plural F12, call hierarchy, the `smalltalk-cartridge:` virtual doc,
-  and the clean-VSIX `npm run package` spot-check) must be run in the Extension Development Host before
-  release, per the `manual-qa-before-release` discipline.
-- [ ] No errors in the Developer Tools console (to confirm during the hands-on pass).
+- [X] **Hands-on Extension Host pass + PO sign-off — DONE (2026-06-26).** The §A–E click-through was run
+  in the Extension Development Host. It caught **five** real issues the automated layers missed, all fixed
+  before release: (1) provenance vocabulary leaked the internal `cartridge:…` term — unified with the
+  status-bar identity; (2) the cartridge virtual-doc copy mislabeled the installed tier — made
+  tier-accurate; (3) the installed tier had no senders — gained its own `crossReference` tier (parity with
+  bundled); (4) installed rows opened a stub instead of the real source — now carry a `SourceLocation` and
+  open the actual `.st`; (5) a kernel file opened to *view* was indexed as `workspace` and shadowed the
+  cartridge — open docs are now indexed only when under a workspace folder.
+- [X] No errors in the Developer Tools console during the pass.
 
 ## Section 5: Sign-Off
-- [ ] Ready for Merge — **pending** the hands-on manual-QA pass (§4), PO acceptance, and CI green on
-  Linux/macOS/Windows (`test:e2e` is local; CI runs `test:parser` + `test:server` + `eval`).
+- [X] **Ready for Merge — PO-accepted 2026-06-26**; merged via PR #97 (closes #66), CI green on
+  Linux/macOS/Windows + e2e, and **shipped in v0.9.0** (published to the Marketplace).


### PR DESCRIPTION
Post-0.9.0 housekeeping (docs + CI only — no runtime/extension code changes).

### PO sign-off (US-423)
- `verification.md` §4/§5 ticked: hands-on Extension Host pass **PO-accepted 2026-06-26**, shipped **v0.9.0**. Records the 5 real issues the hands-on pass caught and that were fixed pre-release (provenance vocabulary, virtual-doc copy, installed-tier senders parity, real-source navigation, workspace-scoped indexing).
- `tasks.md` T901/T902 and the `user-stories.md` DoD PO-accept box closed.

### CI maintenance
- `actions/checkout@v4 → v5` and `actions/setup-node@v4 → v5` (both target Node 24), clearing the recurring **"Node.js 20 is deprecated"** workflow annotation. The bump is validated by this PR's own CI run.