### PR TITLE
chore: cycle wrap-up — US-412 navigation QA workspace + rot audit

### DIFF
--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/.vscode/settings.json
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "// US-412 manual QA": "Self-contained navigation QA workspace (US-412 outline/symbols/go-to-def + US-417 folding/highlight). All features run offline with no gst; the kernel setting only affects whether OrderedCollection/Transcript resolve as known classes, not the navigation surface under test.",
+  "smalltalk.completion.kernelLibrary": "auto"
+}

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/Navigation.st
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/Navigation.st
@@ -1,0 +1,47 @@
+"Navigation.st — manual-QA fixture for code navigation (US-412) and navigation
+ polish (US-417). Three classes (one a subclass), instance variables, a class-side
+ constructor, blocks, and a selector (#describe) implemented by TWO classes and
+ sent from a third — so outline, workspace symbols, go-to-definition (plural),
+ folding, and scope-aware highlight all have something to bite on. Must parse with
+ 0 diagnostics."
+
+Object subclass: Shape [
+    | name |
+
+    Shape class >> named: aString [ ^self new setName: aString ]
+
+    setName: aString [ name := aString. ^self ]
+
+    name [ ^name ]
+
+    describe [ ^'a shape named ', name ]
+
+    area [ ^self subclassResponsibility ]
+]
+
+Shape subclass: Circle [
+    | radius |
+
+    radius: aNumber [ radius := aNumber. ^self ]
+
+    describe [ ^'a circle named ', name, ' radius ', radius printString ]
+
+    area [ ^radius * radius * 355 / 113 ]
+]
+
+Object subclass: Gallery [
+    | shapes |
+
+    init [ shapes := OrderedCollection new. ^self ]
+
+    add: aShape [ shapes add: aShape ]
+
+    describeAll [
+        shapes do: [:each | Transcript showCr: each describe ]
+    ]
+]
+
+Gallery new init
+    add: (Circle new radius: 5);
+    add: (Shape named: 'blob');
+    describeAll

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/README.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/manual-qa-workspace/README.md
@@ -1,0 +1,64 @@
+# US-412 — Manual QA workspace (Code Navigation) — also covers US-417
+
+A self-contained, reproducible workspace for the navigation surface, **offline, no `gst`**:
+**outline, workspace symbol search, and go-to-definition** (US-412) plus **semantic folding and
+scope-aware document highlight** (US-417, "navigation polish" built on the same index). Back-filled
+post-0.9.0 to modernize US-412's original corpus-based matrix into the self-contained pattern.
+
+> `Navigation.st` is valid GST and must parse with **0 diagnostics** — any red squiggle is a bug.
+
+## Open it
+1. In the Extension Development Host (`F5` from the repo): **File → Open Folder…** → this folder.
+   The extension auto-activates (the folder has a `.st` file).
+2. Keep the **Developer Tools console** open (Help → Toggle Developer Tools) — confirm **no errors** throughout.
+
+---
+
+## Part A — Outline / Document Symbols (US-412 AC1)
+
+Open `Navigation.st`, then the **Outline** view (and the breadcrumb bar).
+
+| Row | Expect |
+|---|---|
+| **A1** | Three top-level classes: **`Shape`**, **`Circle`**, **`Gallery`**. |
+| **A2** | `Shape` nests: ivar **`name`**, a **class-side** `named:`, and `setName:` / `name` / `describe` / `area`. |
+| **A3** | `Circle` nests ivar **`radius`** + `radius:` / `describe` / `area`; the breadcrumb shows `Circle` subclasses `Shape`. |
+| **A4** | Clicking any entry **jumps the cursor** to its definition. |
+
+## Part B — Workspace Symbols (US-412 AC2)
+
+| Row | Do | Expect |
+|---|---|---|
+| **B1** | `Ctrl/Cmd+T`, type `Circle` | The class `Circle` appears; selecting it opens its definition. |
+| **B2** | `Ctrl/Cmd+T`, type `describe` | **Both** implementors (`Shape>>describe`, `Circle>>describe`) appear; each opens correctly. |
+| **B3** | `Ctrl/Cmd+T`, type `area` | Both `Shape>>area` and `Circle>>area`. |
+
+## Part C — Go to Definition (US-412 AC3; plural is US-423)
+
+| Row | Do | Expect |
+|---|---|---|
+| **C1** | **F12** on `Circle` in `Shape subclass: Circle` (or its use in the bottom cascade) | Jumps to the `Circle` class definition. |
+| **C2** | **F12** on `describe` in `each describe` (inside `describeAll`) | A **picker with both** implementors (`Shape>>describe`, `Circle>>describe`) — never silently one. |
+| **C3** | **F12** on `name` inside `Circle>>describe` | Resolves to the `name` accessor / the inherited ivar (a candidate set, not an error). |
+
+## Part D — Live update (US-412 AC4)
+
+| Row | Do | Expect |
+|---|---|---|
+| **D1** | Add a method `volume [ ^0 ]` to `Circle`, **don't save** | The Outline shows `volume` within ~250 ms (debounced, version-keyed cache — no save needed). |
+| **D2** | Delete it again | The Outline drops `volume`. |
+
+## Part E — Folding + Document Highlight (US-417)
+
+| Row | Do | Expect |
+|---|---|---|
+| **E1** (AC1) | Hover the gutter — fold the `Gallery` **class body**, then the `describeAll` **method body**, then the `do:` **block** | Each folds independently; the comment block at the top folds too. |
+| **E2** (AC2) | Put the cursor on **`describe`** (a selector) | Every **send/definition of `describe`** in the file highlights (scope-aware). |
+| **E3** (AC2) | Put the cursor on the ivar **`radius`** inside `Circle` | Its uses **within `Circle`** highlight — not unrelated names. |
+| **E4** (AC2) | Put the cursor on the temp **`aString`** in `setName:` | Only that parameter's occurrences in that method highlight. |
+
+---
+
+Record results in `../verification.md` §4. `Navigation.st` must stay at **0 diagnostics**; a missing
+outline entry, a collapsed (single-target) go-to-def on `describe`, or a highlight that escapes its
+scope is a bug — note it and stop.

--- a/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
+++ b/specs/US-412-Document-And-Workspace-Symbols-And-Go-To-Definition/verification.md
@@ -30,6 +30,12 @@
 - [x] **TDD**: provider unit + real-server LSP + Electron e2e tests authored with the change.
 
 ## Section 4: Manual Verification — Extension Host matrix (the 0.4.0 gate)
+
+> **Reproducible workspace (back-filled 2026-06-26):** the original matrix below used the external
+> GST 3.2.5 kernel corpus. A **self-contained** `manual-qa-workspace/` (`Navigation.st` + matrix Parts
+> A–E) now reproduces this offline with no corpus and no `gst` — and folds in US-417 folding/highlight.
+> Prefer it for re-runs; the corpus matrix is kept as the original 0.4.0 acceptance record.
+
 Launch with **F5** (Extension Development Host). Record **Pass/Fail + a note** per row; attach a
 screenshot for the headline rows (M1, M2, M4). Keep the Developer Tools console open (Help → Toggle
 Developer Tools) and confirm **no errors/exceptions** throughout.

--- a/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
+++ b/specs/US-417-Navigation-Polish-Folding-And-Document-Highlight/verification.md
@@ -25,6 +25,9 @@
 Launch with **F5**, then open **[`spot-check.st`](./spot-check.st)** (in this folder) — a single
 self-contained file with the exact S1/S2/S3 examples and inline instructions. It parses with **0
 diagnostics**, so any odd behaviour is the feature under test, not a parse error.
+
+> Folding + scope-aware highlight are also exercised (Part E) in the consolidated navigation QA
+> workspace `../US-412-*/manual-qa-workspace/` (back-filled 2026-06-26).
 Tip: to see *only* this extension's output in the console, launch with installed extensions disabled:
 `code --extensionDevelopmentPath="$PWD" --disable-extensions <folder>`.
 


### PR DESCRIPTION
Post-0.9.0 cycle close-out (docs/specs only — no runtime code).

### Rot audit — clean
- All 21 open issues are legitimate future work; nothing shipped-but-open (US-422/#65, US-423/#66 closed).
- Docs already synced to 0.9.0 (0.9.0 doc-rot pass + #98). Only "Coming Soon: Formatting" remains — correct (US-416 unshipped).

### QA-workspace back-fill
- New self-contained `specs/US-412-*/manual-qa-workspace/` (`Navigation.st` + matrix Parts A–E): reproduces the navigation surface **offline, no kernel corpus, no `gst`** — outline, workspace symbols, **plural** go-to-definition, live update — and folds in **US-417** folding + scope-aware highlight.
- Fixture pre-verified: **0 diagnostics**; outline shape matches.
- `US-412` / `US-417` `verification.md` point to it.

Audit outcome recorded: US-410/411 internal (no Extension-Host surface, N/A); US-413/US-430 have an in-`verification.md` matrix; the rest now have a QA artifact.