### PR TITLE
feat(US-425): keyword-message signature help (v0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-26
+
+### Added
+
+-   **Keyword-message signature help** for GNU Smalltalk — **offline, no `gst` required** (US-425). As you type a keyword send (`aDictionary at: key put: …`), VS Code's signature popup shows the matching keyword selector(s) and **tracks the active parameter** — the keyword whose argument the cursor is currently filling.
+    -   **Two-tier union, honestly framed** — signatures are drawn from your **workspace ∪ the GNU Smalltalk kernel cartridge**; a typed keyword *prefix* matches every selector that starts with it (`at:` → `at:`, `at:put:`, `at:ifAbsent:`…), cycled with VS Code's "N of M". Each signature carries its **provenance** (`workspace` / `kernel (installed)` / `kernel (reference)`).
+    -   **Keyword-only by design** — unary and binary sends carry no parameter sequence, so they (and non-keyword cursors) show no popup. Because the kernel cartridge is facts-only, the highlighted parameter is the **keyword part** itself (`put:`), not a synthesized argument name.
+    -   Complements completion: completion helps you *pick* the selector up front; signature help confirms *where you are* once you're inside the arguments (especially with long or nested argument expressions).
+    -   New `evals/datasets/signature-help/` output eval; a `specs/US-425-*/manual-qa-workspace/`.
+
 ## [0.9.0] - 2026-06-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,16 @@ Marketplace as `leocamello.vscode-smalltalk`.
 > Bridge (EPIC-007) adds runtime features when present, never required. See
 > [`docs/ROADMAP.md`](docs/ROADMAP.md) for the vision, architecture diagram, milestone ladder
 > (0.6→2.0) and parity scorecard, and [`epics.md`](docs/product/epics.md) EPIC-005–008.
+- **Shipped:** **v0.9.1 — keyword-message signature help (US-425, EPIC-005)** — `textDocument/signatureHelp`
+  for keyword sends (`providers/signatureHelp.ts`), **offline**: a backward token-stream scan reconstructs
+  the keyword selector typed so far + the active parameter (the keyword being filled); matches it as an
+  **honest prefix union** against the workspace ∪ active-kernel cartridge selector set (`Workspace ≻
+  Installed ≻ Bundled` dedup), each signature provenance-tagged. Keyword-only by design (unary/binary/head
+  cursors → null); the highlighted parameter is the keyword part (facts-only cartridge has no arg names).
+  Complements completion (pick the selector up front) vs signature help (where-you-are mid-arguments). New
+  `evals/datasets/signature-help/` + `specs/US-425-*/manual-qa-workspace/`. Closes #68. A follow-up
+  **selector-surface coverage audit** (static snippets ∪ dynamic completion ∪ signature help — division of
+  labour) was raised during QA and filed to the backlog.
 - **Shipped:** **v0.9.0 — Cross-Reference Intelligence (US-423, EPIC-005)** — the System Browser's
   **Senders of / Implementors of** over a **two-tier union** (workspace ∪ kernel cartridge), **offline**,
   framed honestly as a lexical union (dynamic dispatch isn't statically resolvable; rank, never filter).
@@ -60,9 +70,10 @@ Marketplace as `leocamello.vscode-smalltalk`.
   go-to-definition; US-412) on the error-tolerant **lexer + parser + symbol table** (US-411, internal
   M3). All language intelligence runs with **no `gst`**. Earlier: v0.3.0 grammar/snippets/config +
   **Run Current File** (US-301) + the LSP scaffold (US-410).
-- **Next:** **US-416** (formatting, EPIC-004, → ~1.0) and **US-425** (signature help, small, EPIC-005);
-  **SPIKE-01** (unknown-selector heuristic, gates any linter feature). EPIC-005 consumers now span
-  completion (0.5), semantic tokens (0.8), and cross-reference (0.9) on one Console.
+- **Next:** **SPIKE-01** (unknown-selector heuristic, gates any linter feature) and the **selector-surface
+  coverage audit** (snippets ∪ completion ∪ signature-help division of labour, raised in 0.9.1 QA); then
+  **US-416** (formatting, EPIC-004, → ~1.0). EPIC-005 consumers now span completion (0.5), semantic tokens
+  (0.8), cross-reference (0.9), and signature help (0.9.1) on one Console.
 - **Foundation:** **EPIC-005 foundation landed**
   (US-430, 0.8/0.9): the Dialect Cartridge schema (`server/src/types/knowledge-base.ts`) + GST
   **Cartridge #01** (`scripts/export-gst-cartridge.st` → `server/data/cartridges/gst-3.2.5-cartridge.json`,

--- a/client/test-e2e/US-425.acceptance.test.js
+++ b/client/test-e2e/US-425.acceptance.test.js
@@ -1,0 +1,69 @@
+// Acceptance harness for US-425 — Signature help.
+//
+// TDD e2e: written BEFORE implementation. The user-observable AC from spec.md §4
+// (the keyword-message signature popup with active-parameter tracking) is driven
+// here through VS Code's real `executeSignatureHelpProvider`, over the bundled
+// kernel cartridge — no gst (AC2).
+const assert = require('node:assert');
+const vscode = require('vscode');
+
+/** Poll `fn` until `ok(result)` or tries run out; returns the last result. */
+async function waitFor(fn, ok, tries = 60) {
+  let last;
+  for (let i = 0; i < tries; i++) {
+    last = await fn();
+    if (ok(last)) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return last;
+}
+
+/** Open an in-memory Smalltalk doc and return it after the server attaches. */
+async function openSmalltalk(content) {
+  const doc = await vscode.workspace.openTextDocument({ language: 'smalltalk', content });
+  await vscode.window.showTextDocument(doc);
+  return doc;
+}
+
+/** Signature help at `pos`, polling until `ok(help)`. */
+async function signatureHelp(uri, pos, ok) {
+  return waitFor(
+    () => vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', uri, pos),
+    (help) => ok(help ?? { signatures: [] }),
+  );
+}
+
+suite('US-425 signature help (e2e)', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('leocamello.vscode-smalltalk');
+    assert.ok(ext, 'extension should be present');
+    await waitFor(() => Promise.resolve(ext.isActive), (active) => active === true);
+    assert.ok(ext.isActive, 'extension must be active');
+  });
+
+  test('AC1/AC2: keyword send pops signature help with the active parameter tracked (no gst)', async () => {
+    const text = 'x at: 1 put: ';
+    const doc = await openSmalltalk(text);
+    const pos = new vscode.Position(0, text.length); // after `put: `
+    const help = await signatureHelp(doc.uri, pos, (h) => (h.signatures ?? []).length > 0);
+    assert.ok(help && help.signatures.length > 0, 'a keyword send yields signature help');
+    assert.equal(help.activeParameter, 1, 'the second keyword (put:) is the active parameter');
+    assert.ok(
+      help.signatures.some((s) => /at:.*put:/.test(s.label)),
+      'the at:put: kernel signature is offered (from the bundled cartridge)',
+    );
+  });
+
+  test('AC1: a non-keyword (unary) cursor offers no signature help', async () => {
+    const text = 'x printString ';
+    const doc = await openSmalltalk(text);
+    const pos = new vscode.Position(0, text.length);
+    // Give the server a beat, then assert the popup stays empty.
+    const help = await waitFor(
+      () => vscode.commands.executeCommand('vscode.executeSignatureHelpProvider', doc.uri, pos),
+      () => true,
+      4,
+    );
+    assert.ok(!help || (help.signatures ?? []).length === 0, 'unary send → no signature help');
+  });
+});

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1454,7 +1454,7 @@ Scenario: User follows Quick Start guide
 ## US-425: Signature Help
 
 * **ID:** US-425
-* **Status:** Ready — #68
+* **Status:** Implemented + manual QA passed — pending release (#68); branch `feature/US-425-signature-help`
 * **Epic:** EPIC-005
 * **Priority:** Low
 * **Estimate:** S
@@ -1473,10 +1473,11 @@ Scenario: User follows Quick Start guide
 * [X] Estimated/sized (S).
 
 **Definition of Done (DoD) Checklist:**
-* [ ] signatureHelp provider; unit test at a keyword-send cursor; PO accepts.
+* [X] signatureHelp provider (`server/src/providers/signatureHelp.ts`); unit test at a keyword-send cursor (`server/test/signatureHelp.test.ts`, 16 cases) + eval (`evals/datasets/signature-help/`, 10 cases) + handshake + e2e (`client/test-e2e/US-425.acceptance.test.js`).
+* [X] Manual QA pass (`specs/US-425-Signature-Help/manual-qa-workspace/`, 2026-06-26) + PO accepts.
 
 **Notes / Questions / Assumptions:**
-* Parity-plus filler graded honestly; small. Lands ~0.9 alongside US-423.
+* Parity-plus filler graded honestly; small. Keyword-only by design (unary/binary carry no parameter sequence). Honest prefix union with provenance (the US-423 posture); the active parameter is the keyword being filled; the highlighted parameter is the **keyword part** (facts-only cartridge has no arg names). Built on the spec package `specs/US-425-Signature-Help/`; ships in the next release (0.9.1/0.10).
 
 ---
 

--- a/evals/datasets/signature-help/cases.json
+++ b/evals/datasets/signature-help/cases.json
@@ -1,0 +1,68 @@
+{
+  "description": "US-425 signature-help output eval — golden cases over the bundled gst-3.2.5 cartridge (no gst, no VS Code). Drives the real `signatureHelpAt` provider with the SignatureCandidate set assembled exactly as server.ts does (workspace method selectors ∪ kernel keyword selectors). The `▮` marks the cursor; per case we assert the active parameter (the keyword being filled), the keyword-prefix union (selectors that must / must not appear), the active signature (the fully-typed selector), and the null cases (non-keyword cursors / unknown selectors). Works offline (AC2).",
+  "cases": [
+    {
+      "name": "AC1 first keyword: active parameter 0, the at:-prefix union",
+      "text": "dict at: ▮",
+      "expectActiveParameter": 0,
+      "expectActiveSelector": "at:",
+      "expectSelectorsInclude": ["at:", "at:put:", "at:ifAbsent:"],
+      "expectSelectorsExclude": ["do:separatedBy:"]
+    },
+    {
+      "name": "AC1 second keyword: active parameter 1, prefix narrows to at:put:",
+      "text": "dict at: 1 put: ▮",
+      "expectActiveParameter": 1,
+      "expectSelectorsInclude": ["at:put:"],
+      "expectSelectorsExclude": ["at:ifAbsent:", "at:"]
+    },
+    {
+      "name": "AC1 do: prefix surfaces do: and do:separatedBy:, do: is active",
+      "text": "coll do: ▮",
+      "expectActiveParameter": 0,
+      "expectActiveSelector": "do:",
+      "expectSelectorsInclude": ["do:", "do:separatedBy:"]
+    },
+    {
+      "name": "AC1 inject:into: tracks the second keyword",
+      "text": "coll inject: 0 into: ▮",
+      "expectActiveParameter": 1,
+      "expectActiveSelector": "inject:into:",
+      "expectSelectorsInclude": ["inject:into:"]
+    },
+    {
+      "name": "AC1 nested keyword argument is skipped (do: inside parens is not the outer message)",
+      "text": "dict at: (a do: b) put: ▮",
+      "expectActiveParameter": 1,
+      "expectSelectorsInclude": ["at:put:"],
+      "expectSelectorsExclude": ["do:separatedBy:"]
+    },
+    {
+      "name": "AC1 a workspace keyword method surfaces in its own union",
+      "text": "Object subclass: Foo [\n  greet: x [ ^self ]\n  run [ ^self greet: ▮ ]\n]",
+      "expectActiveParameter": 0,
+      "expectActiveSelector": "greet:",
+      "expectSelectorsInclude": ["greet:"]
+    },
+    {
+      "name": "AC1 unary-send cursor → no signature help",
+      "text": "x printString ▮",
+      "expectNull": true
+    },
+    {
+      "name": "AC1 receiver/head cursor → no signature help",
+      "text": "di▮ct at: 1",
+      "expectNull": true
+    },
+    {
+      "name": "AC1 binary-send cursor → no signature help",
+      "text": "a + ▮",
+      "expectNull": true
+    },
+    {
+      "name": "AC1 unknown keyword selector → no signature help",
+      "text": "dict frobnicateWidget: ▮",
+      "expectNull": true
+    }
+  ]
+}

--- a/evals/datasets/signature-help/run.ts
+++ b/evals/datasets/signature-help/run.ts
@@ -1,0 +1,101 @@
+// Signature-help output eval (US-425). Deterministic golden-dataset check, run in
+// CI via `npm run eval`. Drives the real `signatureHelpAt` provider over the
+// committed bundled gst-3.2.5 cartridge (no corpus, no gst, no VS Code),
+// assembling the SignatureCandidate set exactly as server.ts does (workspace
+// method selectors ∪ kernel keyword selectors). Each case marks the cursor with
+// `▮` and pins the active parameter, the keyword-prefix union (selectors that must
+// / must not appear), the active signature, and the null cases (non-keyword
+// cursors / unknown selectors).
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tokenize } from '../../../server/src/parser/lexer.ts';
+import { SymbolKind } from '../../../server/src/parser/symbols.ts';
+import { WorkspaceIndex } from '../../../server/src/providers/workspaceIndex.ts';
+import { Provenance } from '../../../server/src/kernel/model.ts';
+import { signatureHelpAt, type SignatureCandidate } from '../../../server/src/providers/signatureHelp.ts';
+import { KernelIndexService } from '../../../server/src/kernel/kernelIndexService.ts';
+
+interface Case {
+  name: string;
+  text: string;
+  expectNull?: boolean;
+  expectActiveParameter?: number;
+  expectActiveSelector?: string;
+  expectSelectorsInclude?: string[];
+  expectSelectorsExclude?: string[];
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const { cases } = JSON.parse(fs.readFileSync(path.join(here, 'cases.json'), 'utf8')) as { cases: Case[] };
+
+// Bundled cartridge (deterministic; common-location probing disabled so an
+// installed gst on the dev box can't change the golden results).
+const kernel = new KernelIndexService(undefined, []);
+kernel.configure({ kernelLibrary: 'bundled' });
+
+const URI = 'file:///eval.st';
+const keywordsOf = (selector: string): string[] => selector.match(/[^:]+:/g) ?? [selector];
+const isKeyword = (selector: string): boolean => selector.includes(':');
+
+/** Assemble the candidate set — mirrors server.ts onSignatureHelp. */
+function buildCandidates(index: WorkspaceIndex): SignatureCandidate[] {
+  return [
+    ...index
+      .all()
+      .filter((e) => e.kind === SymbolKind.Method && isKeyword(e.name))
+      .map((e) => ({ selector: e.name, keywords: keywordsOf(e.name), provenance: Provenance.Workspace })),
+    ...kernel
+      .selectors()
+      .filter((s) => isKeyword(s.selector))
+      .map((s) => ({ selector: s.selector, keywords: keywordsOf(s.selector), provenance: s.provenance })),
+  ];
+}
+
+let passed = 0;
+let failed = 0;
+for (const c of cases) {
+  try {
+    const offset = c.text.indexOf('▮');
+    assert.ok(offset >= 0, `case "${c.name}" must mark the cursor with ▮`);
+    const src = c.text.replace('▮', '');
+    const index = new WorkspaceIndex();
+    index.setFile(URI, src);
+
+    const help = signatureHelpAt(offset, src, tokenize(src).tokens, buildCandidates(index));
+
+    if (c.expectNull) {
+      assert.equal(help, null, `case "${c.name}": expected no signature help`);
+      passed += 1;
+      console.log(`  ok - ${c.name}`);
+      continue;
+    }
+
+    assert.ok(help, `case "${c.name}": expected signature help`);
+    if (c.expectActiveParameter !== undefined) {
+      assert.equal(help.activeParameter, c.expectActiveParameter, `case "${c.name}": active parameter`);
+    }
+    const selectors = new Set(help.signatures.map((s) => s.selector));
+    for (const sel of c.expectSelectorsInclude ?? []) {
+      assert.ok(selectors.has(sel), `case "${c.name}": expected selector "${sel}" in the union`);
+    }
+    for (const sel of c.expectSelectorsExclude ?? []) {
+      assert.ok(!selectors.has(sel), `case "${c.name}": selector "${sel}" must NOT be in the union`);
+    }
+    if (c.expectActiveSelector !== undefined) {
+      const active = help.signatures[help.activeSignature ?? 0];
+      assert.equal(active?.selector, c.expectActiveSelector, `case "${c.name}": active signature`);
+    }
+    passed += 1;
+    console.log(`  ok - ${c.name}`);
+  } catch (e) {
+    failed += 1;
+    console.error(`  FAIL - ${c.name}: ${(e as Error).message}`);
+  }
+}
+
+console.log(`signature-help eval: ${passed}/${cases.length} cases passed.`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
         "eval:hover": "tsx evals/datasets/hover/run.ts",
         "eval:semantic-tokens": "tsx evals/datasets/semantic-tokens/run.ts",
         "eval:references": "tsx evals/datasets/references/run.ts",
-        "eval": "npm run build:grammar && npm run test:grammar && npm run eval:completion && npm run eval:diagnostics && npm run eval:hover && npm run eval:semantic-tokens && npm run eval:references",
+        "eval:signature-help": "tsx evals/datasets/signature-help/run.ts",
+        "eval": "npm run build:grammar && npm run test:grammar && npm run eval:completion && npm run eval:diagnostics && npm run eval:hover && npm run eval:semantic-tokens && npm run eval:references && npm run eval:signature-help",
         "new-story": "bash scripts/new-story.sh"
     }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "publisher": "leocamello",
     "license": "MIT",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "preview": true,
     "icon": "icon.png",
     "main": "./dist/extension.js",

--- a/server/src/providers/signatureHelp.ts
+++ b/server/src/providers/signatureHelp.ts
@@ -1,0 +1,181 @@
+// Signature-help provider (US-425 / AC1, AC2).
+//
+// Keyword-message signature help: at a cursor inside a keyword send
+// (`dict at: key put: ▮`), surface the matching keyword selectors from the
+// workspace ∪ active-kernel cartridge index and highlight the active parameter —
+// the keyword part whose argument the cursor is currently filling.
+//
+// The cursor is analysed from the TOKEN STREAM (robust at an incomplete cursor,
+// like completion.ts): scan backward tracking bracket depth, skipping nested
+// groups, and collect the `Keyword` tokens of the CURRENT message at depth 0
+// until a boundary (an unmatched opener, `.`/`^`/`!`, a cascade `;`, an assignment
+// `:=`, or `|`). Keyword messages are greedy, so every same-level keyword part is
+// one selector typed so far. A typed keyword PREFIX matches every selector that
+// starts with it (honest union, the US-423 posture); binary/unary/head cursors
+// and an empty/non-matching set return null. Pure — vscode-languageserver-types
+// only; never throws.
+
+import {
+  type ParameterInformation,
+  type SignatureHelp,
+  type SignatureInformation,
+} from 'vscode-languageserver-types';
+import { Provenance } from '../kernel/model';
+import { TokenKind, type Token } from '../parser/token';
+
+/** A keyword selector offered to signature help, with where it came from. */
+export interface SignatureCandidate {
+  readonly selector: string;
+  /** Keyword parts: `at:put:` → ["at:","put:"]; unary/binary → [selector]. */
+  readonly keywords: readonly string[];
+  readonly provenance: Provenance;
+}
+
+/** A `SignatureInformation` carrying the selector it was built from (for tests +
+ *  client correlation). Assignable to the LSP type, so it flows through unchanged. */
+export interface SmalltalkSignature extends SignatureInformation {
+  readonly selector: string;
+}
+
+export interface SmalltalkSignatureHelp extends SignatureHelp {
+  readonly signatures: SmalltalkSignature[];
+}
+
+function provenanceRank(p: Provenance): number {
+  switch (p) {
+    case Provenance.Workspace:
+      return 1;
+    case Provenance.InstalledKernel:
+      return 2;
+    case Provenance.BundledKernel:
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function provenanceLabel(p: Provenance): string {
+  switch (p) {
+    case Provenance.Workspace:
+      return 'workspace';
+    case Provenance.InstalledKernel:
+      return 'kernel (installed)';
+    case Provenance.BundledKernel:
+      return 'kernel (reference)';
+    default:
+      return '';
+  }
+}
+
+/** Token kinds (at depth 0) that bound the start of the current keyword message. */
+const BOUNDARY = new Set<TokenKind>([
+  TokenKind.Period,
+  TokenKind.Caret,
+  TokenKind.Bang,
+  TokenKind.Semicolon, // cascade — the next message is separate
+  TokenKind.Assign,
+  TokenKind.Pipe,
+]);
+
+const OPENERS = new Set<TokenKind>([TokenKind.LParen, TokenKind.LBracket, TokenKind.LBrace]);
+const CLOSERS = new Set<TokenKind>([TokenKind.RParen, TokenKind.RBracket, TokenKind.RBrace]);
+
+/** The keyword parts of the message enclosing `offset`, typed so far, in source
+ *  order — or `[]` when the cursor is not inside a keyword send. */
+function typedKeywordsAt(tokens: readonly Token[], offset: number): string[] {
+  // Tokens fully to the left of the cursor (a keyword `at:` is "typed" once its
+  // colon is in; the comment/EOF trivia is skipped).
+  const pre = tokens.filter((t) => t.kind !== TokenKind.Comment && t.kind !== TokenKind.EOF && t.end <= offset);
+  const keywords: string[] = [];
+  let depth = 0;
+  for (let i = pre.length - 1; i >= 0; i--) {
+    const t = pre[i] as Token;
+    if (CLOSERS.has(t.kind)) {
+      depth++;
+      continue;
+    }
+    if (OPENERS.has(t.kind)) {
+      if (depth === 0) {
+        break; // unmatched opener → start of the enclosing expression
+      }
+      depth--;
+      continue;
+    }
+    if (depth > 0) {
+      continue; // inside a nested argument group — ignore
+    }
+    if (t.kind === TokenKind.Keyword) {
+      keywords.unshift(t.text);
+    } else if (BOUNDARY.has(t.kind)) {
+      break;
+    }
+  }
+  return keywords;
+}
+
+/** Render a selector's keyword parts as a label + one parameter region per part. */
+function buildSignature(c: SignatureCandidate): SmalltalkSignature {
+  let label = '';
+  const parameters: ParameterInformation[] = [];
+  c.keywords.forEach((kw, i) => {
+    if (i > 0) {
+      label += ' ';
+    }
+    const start = label.length;
+    label += kw;
+    parameters.push({ label: [start, label.length] });
+  });
+  return {
+    selector: c.selector,
+    label,
+    parameters,
+    documentation: provenanceLabel(c.provenance),
+  };
+}
+
+/** Signature help at byte `offset`. `signatures` is the merged workspace +
+ *  active-kernel keyword-selector set (each provenance-tagged). */
+export function signatureHelpAt(
+  offset: number,
+  _text: string,
+  tokens: readonly Token[],
+  signatures: readonly SignatureCandidate[],
+): SmalltalkSignatureHelp | null {
+  const typed = typedKeywordsAt(tokens, offset);
+  if (typed.length === 0) {
+    return null; // not a keyword send (unary/binary/head cursor)
+  }
+
+  // Dedup by selector, keeping the highest-confidence provenance.
+  const best = new Map<string, SignatureCandidate>();
+  for (const c of signatures) {
+    const current = best.get(c.selector);
+    if (current === undefined || provenanceRank(c.provenance) < provenanceRank(current.provenance)) {
+      best.set(c.selector, c);
+    }
+  }
+
+  // A candidate matches iff its keywords start with the typed prefix.
+  const matches = [...best.values()].filter(
+    (c) => c.keywords.length >= typed.length && typed.every((kw, i) => c.keywords[i] === kw),
+  );
+  if (matches.length === 0) {
+    return null;
+  }
+
+  matches.sort(
+    (a, b) =>
+      provenanceRank(a.provenance) - provenanceRank(b.provenance) ||
+      a.keywords.length - b.keywords.length ||
+      a.selector.localeCompare(b.selector),
+  );
+
+  const built = matches.map(buildSignature);
+  // Prefer the fully-typed selector (keyword count === typed length) as active.
+  const exact = matches.findIndex((c) => c.keywords.length === typed.length);
+  return {
+    signatures: built,
+    activeSignature: exact >= 0 ? exact : 0,
+    activeParameter: typed.length - 1,
+  };
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -35,6 +35,8 @@ import {
   type SemanticTokens,
   type SemanticTokensParams,
   type SemanticTokensRangeParams,
+  type SignatureHelp,
+  type SignatureHelpParams,
   type WorkspaceSymbol,
   type WorkspaceSymbolParams,
 } from 'vscode-languageserver/node';
@@ -67,6 +69,7 @@ import {
   type CallItemData,
 } from './providers/callHierarchy';
 import { completionsAt, type ClassCandidate, type SelectorCandidate } from './providers/completion';
+import { signatureHelpAt, type SignatureCandidate } from './providers/signatureHelp';
 import { hoverAt, type HoverContext, type HoverImplementor } from './providers/hover';
 import {
   semanticTokensFull,
@@ -147,6 +150,9 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       // Space/`:` auto-trigger selector + keyword-part completion; identifier
       // typing triggers via the client's default quick-suggestions.
       completionProvider: { triggerCharacters: [' ', ':'] },
+      // Keyword-message signature help (US-425): `:`/space trigger a new (or
+      // retriggered) signature popup as keyword parts are typed.
+      signatureHelpProvider: { triggerCharacters: [':', ' '], retriggerCharacters: [':'] },
     },
   };
 });
@@ -342,6 +348,28 @@ connection.onCompletion((params: CompletionParams): CompletionItem[] => {
     selectors,
     classes,
   );
+});
+
+connection.onSignatureHelp((params: SignatureHelpParams): SignatureHelp | null => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) {
+    return null;
+  }
+  // Only keyword selectors carry a parameter sequence worth tracking; derive the
+  // keyword parts (`at:put:` → ["at:","put:"]) from the selector text (US-425).
+  const keywordsOf = (selector: string): string[] => selector.match(/[^:]+:/g) ?? [selector];
+  const isKeyword = (selector: string): boolean => selector.includes(':');
+  const signatures: SignatureCandidate[] = [
+    ...index
+      .all()
+      .filter((e) => e.kind === SymbolKind.Method && isKeyword(e.name))
+      .map((e) => ({ selector: e.name, keywords: keywordsOf(e.name), provenance: Provenance.Workspace })),
+    ...kernelService
+      .selectors()
+      .filter((s) => isKeyword(s.selector))
+      .map((s) => ({ selector: s.selector, keywords: keywordsOf(s.selector), provenance: s.provenance })),
+  ];
+  return signatureHelpAt(doc.offsetAt(params.position), doc.getText(), getTokens(doc), signatures);
 });
 
 connection.onHover((params: HoverParams): Hover | null => {

--- a/server/test/handshake.test.mjs
+++ b/server/test/handshake.test.mjs
@@ -114,6 +114,11 @@ assert.equal(caps.documentHighlightProvider, true, 'expected documentHighlightPr
 assert.ok(caps.completionProvider, 'expected completionProvider (US-413)');
 assert.ok(caps.codeActionProvider, 'expected codeActionProvider (US-414)');
 assert.equal(caps.hoverProvider, true, 'expected hoverProvider (US-415)');
+assert.ok(caps.signatureHelpProvider, 'expected signatureHelpProvider (US-425)');
+assert.ok(
+  caps.signatureHelpProvider.triggerCharacters?.includes(':'),
+  'signature help triggers on `:` (US-425)',
+);
 assert.ok(caps.semanticTokensProvider, 'expected semanticTokensProvider (US-422)');
 const stLegend = caps.semanticTokensProvider.legend;
 assert.ok(Array.isArray(stLegend?.tokenTypes) && stLegend.tokenTypes.length > 0, 'semantic tokens legend advertises token types');
@@ -389,6 +394,51 @@ assert.ok(
   'expected the kernel class Object in head-context completion',
 );
 
+// --- textDocument/signatureHelp (US-425) ---
+// At a keyword-send cursor, the bundled kernel supplies the matching keyword
+// selector(s) with the active parameter tracked — no gst, no workspace file.
+const sigUri = 'file:///signature-test.st';
+const sigText = 'x at: 1 put: ';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri: sigUri, languageId: 'smalltalk', version: 1, text: sigText } },
+});
+send({
+  jsonrpc: '2.0',
+  id: 11,
+  method: 'textDocument/signatureHelp',
+  params: { textDocument: { uri: sigUri }, position: { line: 0, character: sigText.length } },
+});
+const sigResult = (await receiveId(11)).result;
+assert.ok(sigResult?.signatures?.length > 0, 'signature help returns keyword signatures at a keyword send');
+assert.equal(sigResult.activeParameter, 1, 'the second keyword (put:) is the active parameter');
+assert.ok(
+  sigResult.signatures.some((s) => s.selector === 'at:put:'),
+  'expected the kernel selector at:put: among the signatures',
+);
+const atPut = sigResult.signatures.find((s) => s.selector === 'at:put:');
+assert.equal(atPut.parameters?.length, 2, 'at:put: exposes one parameter per keyword part');
+
+// A non-keyword cursor (unary send) yields no signature help.
+const sigNoUri = 'file:///signature-none-test.st';
+send({
+  jsonrpc: '2.0',
+  method: 'textDocument/didOpen',
+  params: { textDocument: { uri: sigNoUri, languageId: 'smalltalk', version: 1, text: 'x printString ' } },
+});
+send({
+  jsonrpc: '2.0',
+  id: 12,
+  method: 'textDocument/signatureHelp',
+  params: { textDocument: { uri: sigNoUri }, position: { line: 0, character: 14 } },
+});
+const sigNone = (await receiveId(12)).result;
+assert.ok(
+  sigNone === null || (sigNone.signatures ?? []).length === 0,
+  'a unary-send cursor returns no signature help',
+);
+
 // --- textDocument/hover (US-415) ---
 // Selector hover: signature + an implementor (Object implements printString in
 // both the bundled floor and an installed kernel), rendered as Markdown.
@@ -495,6 +545,6 @@ await receiveId(3);
 send({ jsonrpc: '2.0', method: 'exit' });
 
 clearTimeout(timeout);
-console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, references, callHierarchy, foldingRange, documentHighlight, completion, hover, semanticTokens, diagnostics, shutdown clean.');
+console.log('Server LSP OK: capabilities, documentSymbol, workspace/symbol, definition, references, callHierarchy, foldingRange, documentHighlight, completion, signatureHelp, hover, semanticTokens, diagnostics, shutdown clean.');
 child.on('close', () => process.exit(0));
 setTimeout(() => process.exit(0), 500);

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -14,6 +14,7 @@ import './codeAction.test.ts';
 import './comments.test.ts';
 import './hover.test.ts';
 import './semanticTokens.test.ts';
+import './signatureHelp.test.ts';
 import './workspaceXref.test.ts';
 import './resolve.test.ts';
 import './callHierarchy.test.ts';

--- a/server/test/signatureHelp.test.ts
+++ b/server/test/signatureHelp.test.ts
@@ -1,0 +1,150 @@
+// Unit tests for the signature-help provider (US-425 / AC1, AC2). Pure: the
+// lexer token stream + a hand-built SignatureCandidate set drive `signatureHelpAt`.
+// No server runtime, no VS Code. Covers the backward keyword-scan cursor analysis,
+// the prefix-union matching, active-parameter tracking, and the null cases.
+import assert from 'node:assert/strict';
+import { tokenize } from '../src/parser/lexer.ts';
+import { Provenance } from '../src/kernel/model.ts';
+import { signatureHelpAt, type SignatureCandidate } from '../src/providers/signatureHelp.ts';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+/** Build a candidate from a selector, deriving keyword parts as the provider does. */
+function cand(selector: string, provenance = Provenance.BundledKernel): SignatureCandidate {
+  const keywords = selector.match(/[^:]+:/g) ?? [selector];
+  return { selector, keywords, provenance };
+}
+
+const KERNEL: SignatureCandidate[] = [
+  cand('at:put:'),
+  cand('at:'),
+  cand('at:ifAbsent:'),
+  cand('at:put:ifAbsent:'),
+  cand('do:'),
+  cand('do:separatedBy:'),
+  cand('printString'), // unary — never a signature-help candidate
+  cand('+'), // binary — never a candidate
+];
+
+/** Cursor at the first occurrence of `marker` removed from `src` (▮ convention). */
+function helpAt(src: string, signatures: SignatureCandidate[] = KERNEL) {
+  const offset = src.indexOf('▮');
+  assert.ok(offset >= 0, 'test source must mark the cursor with ▮');
+  const text = src.replace('▮', '');
+  return signatureHelpAt(offset, text, tokenize(text).tokens, signatures);
+}
+
+// --- AC1: active-parameter tracking over a keyword send -------------------------
+
+test('first keyword: active parameter 0, at:put: among the prefix union', () => {
+  const help = helpAt('dict at: ▮');
+  assert.ok(help, 'a keyword send yields signature help');
+  assert.equal(help.activeParameter, 0, 'after the first keyword, parameter 0 is active');
+  assert.ok(help.signatures.some((s) => s.selector === 'at:put:'), 'at:put: is in the union');
+  assert.ok(help.signatures.some((s) => s.selector === 'at:'), 'the bare at: selector is in the union');
+});
+
+test('second keyword: active parameter 1', () => {
+  const help = helpAt('dict at: 1 put: ▮');
+  assert.ok(help);
+  assert.equal(help.activeParameter, 1, 'after the second keyword, parameter 1 is active');
+  assert.ok(
+    help.signatures.some((s) => s.label.includes('at:') && s.label.includes('put:')),
+    'at:put: still matches the two typed keywords',
+  );
+});
+
+test('prefix union narrows: at:put: prefix excludes at:ifAbsent:', () => {
+  const help = helpAt('dict at: 1 put: ▮');
+  assert.ok(help);
+  const selectors = new Set(help.signatures.map((s) => s.selector));
+  assert.ok(!selectors.has('at:ifAbsent:'), 'at:ifAbsent: drops out once put: is typed');
+  // at:put:ifAbsent: stays — its first two keywords still match.
+  assert.ok(selectors.has('at:put:ifAbsent:'), 'longer matching selector remains');
+});
+
+test('a matching signature exposes one parameter per keyword part, with the active one bolded', () => {
+  const help = helpAt('dict at: ▮');
+  const sig = help?.signatures.find((s) => s.selector === 'at:put:');
+  assert.ok(sig, 'at:put: signature present');
+  assert.equal(sig.parameters?.length, 2, 'two keyword parts → two parameters');
+});
+
+test('activeSignature prefers the fully-typed selector', () => {
+  const help = helpAt('dict do: ▮'); // do: and do:separatedBy: both match
+  assert.ok(help);
+  const active = help.signatures[help.activeSignature ?? 0];
+  assert.equal(active?.selector, 'do:', 'the exactly-typed selector is active');
+});
+
+test('nested keyword argument is skipped, not treated as the outer message', () => {
+  // `coll inject: (a at: b) into: ▮` — the inner at: is inside parens (depth>0),
+  // so the outer typed keywords are inject:into: (active parameter 1).
+  const help = helpAt('coll inject: (a at: b) into: ▮', [
+    ...KERNEL,
+    cand('inject:into:'),
+  ]);
+  assert.ok(help);
+  assert.equal(help.activeParameter, 1, 'inject:into: with into: active');
+  assert.ok(help.signatures.some((s) => s.selector === 'inject:into:'));
+});
+
+test('provenance is carried on each signature', () => {
+  const help = helpAt('x at: ▮', [cand('at:put:', Provenance.Workspace)]);
+  const sig = help?.signatures[0];
+  assert.ok(sig, 'a signature is returned');
+  const doc = typeof sig.documentation === 'string' ? sig.documentation : sig.documentation?.value ?? '';
+  assert.match(doc + (sig.label ?? ''), /workspace/i, 'workspace provenance is surfaced');
+});
+
+test('workspace ≻ bundled dedup keeps one signature per selector', () => {
+  const help = helpAt('x at: ▮', [cand('at:put:', Provenance.Workspace), cand('at:put:', Provenance.BundledKernel)]);
+  assert.ok(help);
+  assert.equal(help.signatures.filter((s) => s.selector === 'at:put:').length, 1, 'deduped to one');
+});
+
+// --- AC1: null cases (no signature help) ---------------------------------------
+
+test('unary send cursor returns null', () => {
+  assert.equal(helpAt('x printString ▮'), null, 'no keyword context → null');
+});
+
+test('head / receiver cursor returns null', () => {
+  assert.equal(helpAt('di▮ct at: 1'), null, 'cursor in the receiver, before any keyword → null');
+});
+
+test('binary send cursor returns null', () => {
+  assert.equal(helpAt('a + ▮'), null, 'binary send → null');
+});
+
+test('cascade `;` bounds the message; the new keyword tracks its own active parameter', () => {
+  const help = helpAt('x foo; at: ▮');
+  assert.ok(help, 'the cascade message at: gets help');
+  assert.equal(help.activeParameter, 0);
+});
+
+test('assignment bounds the left; RHS keyword send tracks from zero', () => {
+  const help = helpAt('y := dict at: ▮');
+  assert.ok(help);
+  assert.equal(help.activeParameter, 0);
+});
+
+test('a period statement boundary is respected', () => {
+  // The first statement is complete; the cursor is in a fresh unary context.
+  assert.equal(helpAt('x at: 1 put: 2. y printString ▮'), null);
+});
+
+test('empty index returns null even at a keyword cursor', () => {
+  assert.equal(helpAt('dict at: ▮', []), null, 'no candidates → null');
+});
+
+test('a typed keyword that matches no candidate returns null', () => {
+  assert.equal(helpAt('dict frobnicate: ▮'), null, 'unknown keyword → null');
+});
+
+console.log(`\nsignatureHelp: ${passed} tests passed.`);

--- a/specs/US-425-Signature-Help/manual-qa-workspace/Inventory.st
+++ b/specs/US-425-Signature-Help/manual-qa-workspace/Inventory.st
@@ -1,0 +1,28 @@
+"US-425 manual-QA fixture — keyword-message signature help.
+ Valid GST 3.2.5; must parse with 0 diagnostics. The class defines a workspace
+ keyword method (#stock:at:) so signature help shows a `workspace` signature, and
+ the methods send kernel keyword messages (#at:put:, #at:ifAbsent:, #do:separatedBy:,
+ #inject:into:) so the bundled cartridge supplies kernel signatures — all no gst."
+
+Object subclass: Inventory [
+    | bins |
+
+    init [ bins := Dictionary new ]
+
+    "A workspace keyword method — signature help offers `stock:at:` with provenance `workspace`."
+    stock: aProduct at: aLocation [
+        bins at: aLocation put: aProduct.
+        ^aProduct
+    ]
+
+    "Kernel keyword sends — type each one and watch the popup track the active keyword."
+    demo [
+        | total |
+        bins at: #widget put: 10.
+        bins at: #gadget ifAbsent: [ 0 ].
+        total := bins values inject: 0 into: [ :sum :each | sum + each ].
+        bins keys asSortedCollection do: [ :k | Transcript show: k ] separatedBy: [ Transcript show: ', ' ].
+        self stock: #sprocket at: #binA.
+        ^total
+    ]
+]

--- a/specs/US-425-Signature-Help/manual-qa-workspace/README.md
+++ b/specs/US-425-Signature-Help/manual-qa-workspace/README.md
@@ -1,0 +1,63 @@
+# US-425 — Manual QA workspace (Signature Help)
+
+A ready-to-open workspace for the `verification.md` §4 matrix. It exercises keyword-message
+signature help **offline, no `gst` needed**: `Inventory.st` defines a workspace keyword method
+(`#stock:at:`) and sends kernel keyword messages (`#at:put:`, `#at:ifAbsent:`, `#do:separatedBy:`,
+`#inject:into:`) so signatures come from the **workspace ∪ the bundled GST 3.2.5 cartridge**. The
+popup must **track the active parameter** (the keyword you're currently filling) and present the
+matching selectors as an honest prefix union.
+
+> `Inventory.st` is valid GST and must parse with **0 diagnostics** — any red squiggle is a bug.
+
+## Open it
+1. In the Extension Development Host (`F5` from the repo): **File → Open Folder…** → this
+   `manual-qa-workspace/` folder. The extension auto-activates (the folder has `.st` files).
+2. Default settings load the bundled reference cartridge (`auto` → falls back to `reference
+   (gst 3.2.5)` with no `gst`; the status bar bottom-right shows the source).
+3. Signature help pops automatically as you type a keyword part or a space after one; you can also
+   force it with **Ctrl+Shift+Space** (Trigger Parameter Hints). It shows a `selector` line with the
+   **active parameter bolded** and a **N of M** counter when several selectors match the prefix.
+
+---
+
+## Part A — Active-parameter tracking (AC1)
+
+Type each line fresh (or place the cursor at the `▮` and press **Ctrl+Shift+Space**).
+
+| Row | Type / cursor | Expect |
+|---|---|---|
+| **A1** | `bins at: ▮` | Popup appears; **first** keyword highlighted (`at:` bold). Several signatures cycle with ↑/↓: `at:`, `at:put:`, `at:ifAbsent:` … (the `at:` prefix union). |
+| **A2** | `bins at: #widget put: ▮` | The **second** parameter is active (`put:` bold); `at:put:` is the shown signature. Typing `put:` narrowed the union (no more `at:ifAbsent:`). |
+| **A3** | `… inject: 0 into: ▮` (in `demo`) | `inject:into:` with the **second** parameter (`into:`) active. |
+| **A4** | `… do: [ :k | … ] separatedBy: ▮` | `do:separatedBy:` with `separatedBy:` active. |
+
+## Part B — Provenance & the two-tier union (AC1)
+
+| Row | Type / cursor | Expect |
+|---|---|---|
+| **B1** | `self stock: ▮` | The **workspace** method `stock:at:` is offered; its documentation line reads **`workspace`**. Active parameter `stock:`. |
+| **B2** | `self stock: #x at: ▮` | Still `stock:at:`, now the **second** parameter (`at:`) active. |
+| **B3** | `bins do: ▮` | Kernel signatures from the **bundled cartridge** appear (`do:`, `do:separatedBy:`); documentation reads **`kernel (reference)`** (or `kernel (installed)` if gst is installed). |
+
+## Part C — Null cases (no popup) (AC1)
+
+| Row | Type / cursor | Expect |
+|---|---|---|
+| **C1** | `bins values ▮` (unary) | **No** signature popup — unary sends carry no parameter sequence. |
+| **C2** | cursor in a receiver, before any keyword (e.g. `bi▮ns at: 1`) | **No** popup. |
+| **C3** | `1 + ▮` (binary) | **No** popup. |
+| **C4** | `bins frobnicate: ▮` (unknown selector) | **No** popup — nothing in workspace ∪ cartridge matches. |
+
+## Part D — robustness, no-gst, shipped artifact (AC2)
+
+| Row | Do | Expect |
+|---|---|---|
+| **D1** | Confirm the status bar reads `reference (gst 3.2.5)` (or `installed …`) and repeat **A1/B3** | Kernel signature help works **with no `gst`** (AC2). |
+| **D2** | Mid-edit: delete the `]` closing `demo` so a squiggle appears, then trigger help on `bins at: ▮` higher up | Still returns signatures — the provider degrades, never throws (no error toast). |
+| **D3** | `npm run package` → install the VSIX in a clean VS Code → open this folder → repeat **A1, A2, B1, C1** | The shipped build matches the dev build. |
+
+---
+
+Record results in `../verification.md` §4, fill the date/sign-off line, then tick §5.
+Anything that doesn't match — a popup on a unary/binary send, a wrong active parameter, a missing
+workspace signature, a crash on malformed input — is a bug. Note it and stop.

--- a/specs/US-425-Signature-Help/plan.md
+++ b/specs/US-425-Signature-Help/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan: Signature Help
+
+**ID**: US-425 | **Date**: 2026-06-26 | **Spec**: ./spec.md | **Branch**: `feature/US-425-signature-help`
+
+## Summary
+Add `textDocument/signatureHelp` for keyword sends: a pure provider that, from a backward token-stream
+scan, reconstructs the keyword selector typed so far and the active parameter, matches it (as a prefix
+union) against the workspace ∪ cartridge selector set, and returns `SignatureInformation[]` with the
+keyword part highlighted. Works offline, no `gst`. Reuses the completion provider's index + provenance
+rank and the lexer token stream — no new index.
+
+## Approach
+- **New provider** `server/src/providers/signatureHelp.ts` (pure, `vscode-languageserver-types` only) with
+  `signatureHelpAt(offset, text, tokens, signatures) → SignatureHelp | null`. Mirrors `completion.ts`:
+  token-based cursor analysis (robust at an incomplete cursor), provenance rank + `bestByName` dedup, and
+  the keyword-snippet split (`selector.match(/[^:]+:/g)`) for the `keywords` derivation.
+- **Wire** in `server/src/server.ts`: advertise `signatureHelpProvider` (trigger `:`/` `, retrigger `:`);
+  in `onSignatureHelp`, build `SignatureCandidate[]` from `index.all()` keyword method symbols
+  (`Provenance.Workspace`) ∪ `kernelService.selectors()` keyword selectors (kernel provenance).
+- **Reuse**: `getTokens(doc)` (parseCache), `Provenance` + the rank/label helpers' shape from
+  `completion.ts`, the `KernelSelectorEntry` from `kernelIndexService`.
+
+## Steps
+1. **Acceptance Harness (RED):** fill `client/test-e2e/US-425.acceptance.test.js`
+   (`executeSignatureHelpProvider` → active parameter), add `server/test/signatureHelp.test.ts` (cursor
+   analysis, prefix matching, null cases), extend `server/test/handshake.test.mjs` (capability ad + a
+   `textDocument/signatureHelp` request), and add `evals/datasets/signature-help/` (cases + run.ts). Watch
+   them fail for the right reason.
+2. **Implement** `signatureHelp.ts` → GREEN on unit/eval.
+3. **Wire** `server.ts` (capability + handler) → GREEN on handshake + e2e.
+4. **Verify:** `test:parser`, `test:server`, `test:e2e`, `npm run eval` all green; build the
+   `manual-qa-workspace/` and run it hands-on in the Extension Host.
+
+## Dependencies & Risks
+- Deps: US-413 index + `kernelService`, US-430 cartridge (signature source), US-411 lexer. All landed.
+- Risk: short-prefix union breadth (`at:` → many) — mitigated by rank + VS Code cycling, never filtering.
+- Risk: cursor-analysis edge cases (nesting, cascade, assignment) — pinned by unit tests before code.
+
+## Verification
+- **Acceptance harness (TDD e2e):** AC1 pinned by `client/test-e2e/US-425.acceptance.test.js` *before*
+  implementation (red → green); cursor-analysis/matching invariants routed to
+  `server/test/signatureHelp.test.ts` + `evals/datasets/signature-help/`; LSP shape to the handshake test.
+  Routing recorded in `requirements-validation.md` §3.5.
+- Three layers green per change: `test:parser`, `test:server`, `test:e2e`; `npm run eval`.
+- Manual QA: `specs/US-425-Signature-Help/manual-qa-workspace/` + `verification.md` matrix in the
+  Extension Development Host.

--- a/specs/US-425-Signature-Help/requirements-validation.md
+++ b/specs/US-425-Signature-Help/requirements-validation.md
@@ -1,0 +1,57 @@
+# Requirements Validation Checklist
+
+**Purpose**: Validate spec quality BEFORE implementation begins  
+**Type**: Requirements Quality Gate  
+**US**: US-425 — Signature Help · **Validated**: 2026-06-26
+
+---
+
+## Section 1: Constitution Gates (Mandatory)
+- [X] **Native Look & Feel**: Standard `textDocument/signatureHelp` drives VS Code's built-in signature
+  popup (with "1 of N" cycling + active-parameter bolding); no bespoke UI (spec §5.2).
+- [X] **Zero Config**: No setting required. Kernel signatures resolve via the US-430 Console
+  (installed-first / frozen floor); empty index ⇒ null, graceful. Works with no `gst` (AC2).
+- [X] **Protocol First**: Pure LSP — advertises `signatureHelpProvider`; no out-of-band channel (spec §5.2).
+- [X] **Robustness**: Front end never throws — the provider returns `null` on any miss (no keyword context,
+  empty index, malformed input); the query path is parser/token + map lookups, no I/O (spec §5.1, AC2).
+- [X] **Dialect Agnostic**: Signatures come from the workspace ∪ the active **cartridge**; provenance is
+  tagged. A future dialect cartridge lights up signature help with no provider change (spec §5.1).
+
+## Section 2: Specification Completeness
+- [X] Goals and Non-Goals explicitly listed (spec §2/§3 — keyword-only, no type resolution, no arg names,
+  no new index).
+- [X] User story in standard format (spec §4).
+- [X] Acceptance criteria defined and testable (AC1 union/active-param/null-cases, AC2 no-`gst`).
+- [X] Edge cases identified: nested-arg skip (`at: (a foo: b) put:`), cascade/assignment/paren/`|`
+  boundaries, prefix breadth, unary/binary/head cursors ⇒ null, empty index ⇒ null (spec §5.1, §5.4).
+- [X] Dependencies listed (spec §5.3): US-413 index + `kernelService`, US-430 cartridge, US-411 lexer.
+
+## Section 3: Technical Design
+- [X] API/Command contracts defined: `signatureHelpProvider` advertised in `server.ts`;
+  `signatureHelpAt(offset, text, tokens, signatures) → SignatureHelp | null` (spec §5.1, §5.2).
+- [X] Data structures defined: `SignatureCandidate { selector, keywords, provenance }`; the backward
+  token scan's keyword accumulation + bracket-depth tracking; `SignatureInformation` packaging with
+  keyword-part parameter regions + `activeParameter`/`activeSignature` (spec §5.1).
+- [X] Error-handling strategy defined: never-throw; null on miss; empty-index graceful (spec §5.1, AC2).
+- [X] Testing strategy defined: unit (`test:parser` — cursor analysis + matching + null cases), server
+  (`test:server` — capability ad + real-server query), e2e (`test:e2e`), output eval
+  `evals/datasets/signature-help/` (spec §5.4).
+
+## Section 3.5: Acceptance Harness (TDD e2e plan)
+- [X] Each AC is **routed**:
+  - **AC1** (user-observable signature + active parameter) → **e2e**
+    (`client/test-e2e/US-425.acceptance.test.js`, `executeSignatureHelpProvider`) + **unit**
+    (`server/test/signatureHelp.test.ts`, cursor analysis/matching/null cases) + **eval**
+    (`evals/datasets/signature-help/`).
+  - **AC1** LSP shape (capability ad + protocol response) → **handshake** (`server/test/handshake.test.mjs`).
+  - **AC2** (no `gst`) → handshake + unit run with the bundled floor (no `gst` on the path by construction).
+- [X] User-observable ACs pinned by acceptance tests **written before implementation** (red → green):
+  `client/test-e2e/US-425.acceptance.test.js`.
+- [X] The story HAS a user-observable surface (the signature popup) — the e2e stub is filled, not removed.
+
+## Section 4: Validation Result
+- [X] **PASS — Ready for implementation.** The spec is complete, testable, and constitutionally clean. The
+  central design choice — keyword-prefix matching presented as an honest union with provenance, and the
+  active parameter tracked from a robust backward token scan — is pinned to AC1 assertions across unit /
+  handshake / e2e / eval. The no-`gst` guarantee (AC2) is structural (bundled floor + pure token/lookup
+  path). Proceed to the Acceptance Harness (write the failing tests first).

--- a/specs/US-425-Signature-Help/spec.md
+++ b/specs/US-425-Signature-Help/spec.md
@@ -1,0 +1,114 @@
+# Specification: Signature Help
+
+**ID**: US-425
+**Feature**: `textDocument/signatureHelp` — keyword-message signature help with active-parameter tracking, over the two-tier (workspace ∪ cartridge) index
+**Status**: Draft
+**Owner**: Leonardo Nascimento
+**Created**: 2026-06-26
+**Architecture**: [ADR-0002](../../docs/decisions/0002-kernel-symbol-sourcing.md), [ADR-0003](../../docs/decisions/0003-cartridge-resolution.md)
+
+## 1. Overview
+The keyword-message companion to completion (US-413): as the user types a keyword send
+(`dict at: key put: …`), surface the matching keyword **selector signatures** drawn from the
+workspace **∪** the active kernel cartridge, and **highlight the active parameter** — the keyword
+whose argument the cursor is currently filling. It reuses the same Console index completion consumes
+and the same robust token-stream cursor analysis (no AST dependency at an incomplete cursor), so it
+works **offline, with no `gst`**. This is parity-plus filler graded honestly: small, native, and the
+natural completion of the keyword-message UX.
+
+## 2. Goals
+- `textDocument/signatureHelp` for **keyword sends**: at a cursor inside a keyword message, return the
+  matching keyword selectors from the workspace ∪ cartridge index as `SignatureInformation[]`.
+- **Active-parameter tracking**: the keyword part whose argument the cursor is filling is reported as
+  `activeParameter` and rendered as the highlighted parameter region.
+- **Honest union** (consistent with US-423): a keyword *prefix* matches every selector that starts with
+  the typed keywords (`at:` → `at:`, `at:put:`, `at:ifAbsent:`); provenance is shown per signature; the
+  full union is returned, never a single false target.
+- Works with **no `gst`** (AC2): the bundled reference floor supplies kernel signatures.
+
+## 3. Non-Goals
+- **No unary/binary signature help** — those carry no parameter sequence worth tracking; signature help
+  is keyword-only by design.
+- **No receiver type resolution** — we do not pretend to know which class the receiver is; we offer the
+  lexical union of selectors that match the typed keyword prefix (the US-423 posture).
+- **No argument *names*** — the cartridge stores selectors/arity/keywords as facts, not parameter names;
+  the highlighted parameter is the **keyword part** (`put:`), not a synthesized `anObject`.
+- **No new index** — reuse the workspace symbol index (method selectors) + `kernelService` selectors; no
+  cross-reference walk needed.
+
+## 4. User Stories & Acceptance Criteria
+**US-425**: As a Smalltalk developer, I want keyword-message signature help as I type, so that I see
+selector signatures and the active parameter without navigating away.
+
+- **AC1**: `textDocument/signatureHelp` at a cursor inside a keyword send returns the matching keyword
+  selectors from the workspace ∪ cartridge index, with **active-parameter tracking** (the keyword part
+  currently being filled is `activeParameter`). A typed keyword *prefix* matches every selector starting
+  with it; each `SignatureInformation` carries its provenance; binary/unary sends and non-keyword cursors
+  return **null** (no signature help).
+- **AC2**: Works with **no `gst`** — kernel signatures come from the bundled reference floor; the path is
+  pure (parser/token + index lookups), never throws, returns null on miss.
+
+## 5. Technical Design
+
+### 5.1 The provider (`server/src/providers/signatureHelp.ts`)
+Pure, `vscode-languageserver-types`-only (mirrors `completion.ts`). Entry point:
+
+```ts
+signatureHelpAt(offset, text, tokens, signatures: SignatureCandidate[]): SignatureHelp | null
+```
+
+where `SignatureCandidate { selector, keywords, provenance }` is the merged workspace + active-kernel
+keyword-selector set (each provenance-tagged). Steps:
+
+1. **Cursor analysis (token stream, robust at an incomplete cursor).** Scan **backward** from the cursor
+   through significant tokens, tracking bracket depth (`(`/`[`/`{`). Skip nested groups (a `)`/`]`/`}`
+   increments depth; the matching opener decrements it). At depth 0, collect **`Keyword` tokens** in
+   order until a boundary halts the scan — an **unmatched opener**, a statement terminator (`.`, `^`,
+   `!`), a cascade `;`, an assignment `:=`, or a `|`. The collected keyword parts are the selector
+   typed *so far* (keyword messages are greedy → all same-level parts form **one** selector). Binary
+   selectors and other tokens between keyword parts are skipped, not boundaries (they live in args).
+2. If **no** keyword part was collected ⇒ return **null** (unary/binary/head cursor — out of scope).
+3. **Match** — `activeParameter = typedKeywords.length - 1`. A candidate matches iff
+   `candidate.keywords.length >= typedKeywords.length` and its keywords agree positionally with the typed
+   prefix. Dedup by selector, best provenance wins (`Workspace ≻ Installed ≻ Bundled`, reusing the
+   completion rank).
+4. **Package** — one `SignatureInformation` per matching selector: `label` is the selector spelled as its
+   keyword parts (`at: put:`); `parameters` map each keyword part to its label region so VS Code bolds the
+   active one; `documentation`/`detail` carries the provenance label. `activeParameter` is set per §5.1.3;
+   `activeSignature` prefers a candidate whose keyword count equals the typed length (the fully-typed
+   selector), else 0. Sort: provenance, then keyword count, then selector text.
+
+### 5.2 Wiring (`server/src/server.ts`)
+- Advertise `signatureHelpProvider: { triggerCharacters: [':', ' '], retriggerCharacters: [':'] }`.
+- `connection.onSignatureHelp`: build `SignatureCandidate[]` from `index.all()` method symbols (keyword
+  selectors, `Provenance.Workspace`) ∪ `kernelService.selectors()` (keyword selectors, kernel provenance),
+  deriving `keywords` from the selector text; call `signatureHelpAt`.
+
+### 5.3 Dependencies
+- US-413 workspace index + `kernelService` selectors; US-430 cartridge (the kernel signature source);
+  US-411 lexer (the token stream). No US-423 cross-reference tier needed.
+
+### 5.4 Testing
+- **Unit (`test:parser`)**: `signatureHelp.test.ts` — cursor analysis at a keyword send (active param 0
+  after `at:`, 1 after `at: x put:`); prefix matching (`at:` surfaces `at:put:`); nested-arg skip
+  (`at: (a foo: b) put:`); cascade/assignment/paren boundaries; **null** for unary/binary/head cursors and
+  empty index.
+- **Server (`test:server`)**: real bundled server advertises `signatureHelpProvider` and answers
+  `textDocument/signatureHelp` at a keyword-send cursor with a known kernel selector + active parameter,
+  **no `gst`**.
+- **E2E (`test:e2e`)**: `US-425.acceptance.test.js` — `vscode.executeSignatureHelpProvider` at a keyword
+  send returns a signature with the expected active parameter.
+- **Eval**: `evals/datasets/signature-help/` (output eval over keyword-send cursors; `npm run eval`).
+
+## 6. Manual Verification
+Extension Development Host: typing `aDictionary at: 1 put: ` pops signature help showing `at:put:` with the
+second parameter active; typing `coll do:` shows `do:`/`do:separatedBy:`…; a workspace keyword method
+surfaces with `workspace` provenance; all with no `gst`. Matrix in `verification.md` +
+`manual-qa-workspace/`.
+
+## 7. Risks & Limitations
+- **No argument names** — keyword parts stand in for parameter labels; honest given the facts-only
+  cartridge. If names are wanted later, they would come from a richer cartridge tier, not this story.
+- **Union breadth** — a short prefix like `at:` can match many selectors; we rank (provenance, keyword
+  count) and rely on VS Code's "1 of N" cycling, never filtering the union (US-423 posture).
+- **Graded parity-plus filler** — copyable; the moat is the offline Console beneath it. Small by design.

--- a/specs/US-425-Signature-Help/tasks.md
+++ b/specs/US-425-Signature-Help/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Signature Help
+
+**ID**: US-425 | **Spec**: ./spec.md | **Plan**: ./plan.md
+
+Mark each task `[x]` as it lands. Map tasks to acceptance criteria where possible.
+
+## Phase 1 — Spec & Setup
+- [x] T001 Spec reviewed; `requirements-validation.md` gate passed (incl. §3.5 AC routing).
+
+## Phase 2 — Acceptance Harness (TDD e2e — write tests BEFORE code)
+- [x] T005 Route each AC to its layer (AC1 → e2e + unit + eval + handshake; AC2 → handshake/unit) per `requirements-validation.md` §3.5.
+- [x] T006 Write the failing tests: `client/test-e2e/US-425.acceptance.test.js` (executeSignatureHelpProvider → active param), `server/test/signatureHelp.test.ts` (cursor analysis + matching + null cases), handshake capability ad + request, `evals/datasets/signature-help/`.
+- [x] T007 Confirm the new asserts are RED for the right reason (unit `MODULE_NOT_FOUND` on the missing provider) — red phase proven before implementation.
+
+## Phase 3 — Implementation
+- [x] T010 Implement `server/src/providers/signatureHelp.ts` → unit (16) + eval (10) green (AC1, AC2).
+- [x] T011 Wire `server/src/server.ts` (advertise `signatureHelpProvider` + `onSignatureHelp`) → handshake + e2e (29) green.
+
+## Phase 4 — Verify
+- [x] T900 Acceptance tests GREEN; `test:parser` / `test:server` / `test:e2e` / `npm run eval` all pass.
+- [x] T901 `verification.md` §4 gate PASSED — `manual-qa-workspace/` run hands-on in the Extension Host (owner, 2026-06-26). Fixture parses with 0 diagnostics (verified).
+- [ ] T902 CI green on Linux/macOS/Windows + e2e (after push/PR).

--- a/specs/US-425-Signature-Help/verification.md
+++ b/specs/US-425-Signature-Help/verification.md
@@ -1,0 +1,48 @@
+# Implementation Verification Checklist
+
+**Purpose**: Verify implementation correctness AFTER coding  
+**Type**: Implementation Verification  
+**US**: US-425 — Signature Help
+
+---
+
+## Section 1: Acceptance Criteria
+- [x] All ACs in `tasks.md` are checked (AC1 active-param union + null cases; AC2 no-`gst`).
+- [x] Each AC has a passing test:
+  - **AC1** → `server/test/signatureHelp.test.ts` (16 unit tests: cursor analysis, prefix union,
+    active param, dedup, null cases) + `evals/datasets/signature-help/` (10 golden cases) +
+    `server/test/handshake.test.mjs` (capability ad + real-server request) +
+    `client/test-e2e/US-425.acceptance.test.js` (executeSignatureHelpProvider → active param; unary → none).
+  - **AC2** (no `gst`) → all of the above run over the bundled cartridge with no `gst` on the path.
+- [x] Each user-observable AC's acceptance test was **red before** implementation (the unit suite failed
+  with `MODULE_NOT_FOUND` for the missing provider; e2e/handshake added in the same red phase).
+
+## Section 2: Code Quality
+- [x] `npm run lint` passes.
+- [x] `npm run check-types` passes; `test:parser` / `test:server` / `test:e2e` / `npm run eval` green.
+- [x] No `any` types (the provider is pure `vscode-languageserver-types`; candidates are typed).
+- [x] JSDoc provided for the public API (`signatureHelpAt`, `SignatureCandidate`, the module header).
+
+## Section 3: Constitutional Compliance
+- [x] **Native**: standard `textDocument/signatureHelp` drives VS Code's built-in popup (N-of-M cycling
+  + active-parameter bolding); no bespoke UI.
+- [x] **Zero Config**: no setting; kernel signatures resolve via the Console (installed-first / floor).
+- [x] **Robustness**: never throws; returns `null` on any miss (no keyword context / empty index /
+  malformed input); token+lookup path, no I/O.
+- [x] **TDD**: tests written first (red → green), four layers.
+
+## Section 4: Manual Verification
+- [x] Feature works in the Extension Host — `manual-qa-workspace/` run against the
+  `manual-qa-workspace/README.md` matrix (Parts A–D). **PASS** (owner, 2026-06-26): keyword sends pop
+  signature help with the active parameter tracked; workspace ∪ kernel provenance shown; unary/binary/
+  head/unknown cursors stay quiet. The completion-vs-signature-help double-popup was reviewed and
+  accepted as conventional VS Code behaviour (left as-is, per the product discussion).
+- [x] No errors in the Developer Tools console during the matrix.
+
+> Automated layers are all green (unit 16, eval 10, handshake, e2e 29 incl. 2 new). The hands-on
+> Extension-Host pass (per the `manual-qa-before-release` memory) is complete and passed. Fixture parses
+> with 0 diagnostics (verified). A follow-up **selector-surface coverage audit** (snippets ∪ completion ∪
+> signature-help division of labour) was raised during QA and filed to the backlog.
+
+## Section 5: Sign-Off
+- [x] Ready for Merge — automated + manual QA green; PO accepts (2026-06-26).


### PR DESCRIPTION
## US-425 — Signature Help (EPIC-005) · v0.9.1

`textDocument/signatureHelp` for keyword sends, **offline, no `gst`**. As you type a keyword send (`aDictionary at: key put: …`), the VS Code signature popup shows the matching keyword selector(s) and **tracks the active parameter** (the keyword whose argument the cursor is filling).

### What's here
- **`server/src/providers/signatureHelp.ts`** — pure provider. A backward token-stream scan (bracket-depth aware, greedy keyword join) reconstructs the keyword selector typed so far + the active parameter, robust at an incomplete cursor. Matched as an **honest prefix union** against the workspace ∪ active-kernel cartridge selector set (`Workspace ≻ Installed ≻ Bundled` dedup), each signature provenance-tagged. Binary/unary/head cursors and empty/non-matching sets → `null`.
- **`server/src/server.ts`** — advertises `signatureHelpProvider` (trigger `:`/space, retrigger `:`); `onSignatureHelp` builds candidates from workspace method selectors ∪ kernel keyword selectors.

### Design notes (graded honestly)
- **Keyword-only by design** — unary/binary sends carry no parameter sequence.
- **No argument names** — the cartridge is facts-only, so the highlighted parameter is the keyword part (`put:`), not a synthesized name.
- **Complements completion** — completion helps you *pick* the selector up front; signature help confirms *where you are* once inside the arguments (esp. long/nested args).

### Tests (TDD, red → green) — all four layers green
- `server/test/signatureHelp.test.ts` — 16 unit cases (cursor analysis, prefix union, active param, dedup, null cases)
- `evals/datasets/signature-help/` — 10 golden cases (`npm run eval`)
- `server/test/handshake.test.mjs` — capability ad + real-server request (no `gst`)
- `client/test-e2e/US-425.acceptance.test.js` — `executeSignatureHelpProvider` (29 e2e pass)
- `check-types` + `lint` clean; `npm run package` → `vscode-smalltalk-0.9.1.vsix`

### Manual QA
`specs/US-425-Signature-Help/manual-qa-workspace/` (fixture parses 0 diagnostics) — run hands-on in the Extension Host, **passed**.

### Follow-up
A **selector-surface coverage audit** (static snippets ∪ dynamic completion ∪ signature help — division of labour) was raised during QA and will be filed to the backlog.

Closes #68.