### PR TITLE
spike(SPIKE-01): unknown-selector heuristic — measure + SHELVE (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,16 @@ Marketplace as `leocamello.vscode-smalltalk`.
   go-to-definition; US-412) on the error-tolerant **lexer + parser + symbol table** (US-411, internal
   M3). All language intelligence runs with **no `gst`**. Earlier: v0.3.0 grammar/snippets/config +
   **Run Current File** (US-301) + the LSP scaffold (US-410).
-- **Next:** **SPIKE-01** (unknown-selector heuristic, gates any linter feature) and the **selector-surface
-  coverage audit** (snippets ∪ completion ∪ signature-help division of labour, raised in 0.9.1 QA); then
-  **US-416** (formatting, EPIC-004, → ~1.0). EPIC-005 consumers now span completion (0.5), semantic tokens
-  (0.8), cross-reference (0.9), and signature help (0.9.1) on one Console.
+- **Next:** the **selector-surface coverage audit** (snippets ∪ completion ∪ signature-help division of
+  labour, raised in 0.9.1 QA); then **US-416** (formatting, EPIC-004, → ~1.0). EPIC-005 consumers now span
+  completion (0.5), semantic tokens (0.8), cross-reference (0.9), and signature help (0.9.1) on one Console.
+- **Spike done (SPIKE-01, SHELVE):** the unknown-selector heuristic was built behind a flag + measured on
+  the GST kernel (21.7k sends): naive 58 false positives → **12** after the `self` subclass-union (Template
+  Method) insight; zero-FP bar **unmet** (~7-8 residual cartridge-gap FPs) + low closed-world coverage
+  (~27%) → **shelved**. Gate code parked (`server/src/diagnostics/unknownSelectorGate.ts` +
+  `cartridgeClassWorld.ts`, tree-shaken, unit-tested); harness `scripts/spike-unknown-selector.ts`; memo +
+  `corpus-report.txt` in `specs/SPIKE-01-*/`. Reconsider only after cartridge completeness + scope
+  restriction. (It also surfaced a real kernel typo — `primtiveFailed` — to report upstream.)
 - **Foundation:** **EPIC-005 foundation landed**
   (US-430, 0.8/0.9): the Dialect Cartridge schema (`server/src/types/knowledge-base.ts`) + GST
   **Cartridge #01** (`scripts/export-gst-cartridge.st` → `server/data/cartridges/gst-3.2.5-cartridge.json`,

--- a/docs/product/user-stories.md
+++ b/docs/product/user-stories.md
@@ -1369,7 +1369,7 @@ Scenario: User follows Quick Start guide
 ## SPIKE-01: Unknown-Selector Heuristic — False-Positive Validation
 
 * **ID:** SPIKE-01
-* **Status:** Ready — #67 *(time-boxed research; gates any feature story)*
+* **Status:** Done — **SHELVE** (#67); memo in `specs/SPIKE-01-*/verification.md`. Naive 58 FPs → 12 after the `self` subclass-union (Template Method) fix; zero-FP bar unmet (~7-8 cartridge-gap FPs on the GST kernel) + low closed-world coverage (~27%). Gate code parked (flagged off, tree-shaken). Reconsider only after cartridge completeness (capture primitive + class-side methods) + scope restriction. Found a real kernel typo (`Object>>checkIndexableBounds:put:` `primtiveFailed`) to report upstream.
 * **Epic:** EPIC-005
 * **Priority:** Medium
 * **Estimate:** S *(time-box: 2–3 days)*

--- a/scripts/spike-unknown-selector.ts
+++ b/scripts/spike-unknown-selector.ts
@@ -1,0 +1,230 @@
+// SPIKE-01 corpus harness — measure the unknown-selector gate's false-positive
+// rate + closed-world coverage on real code, to inform the go/no-go memo (AC3).
+//
+// Drives the pure gate (`server/src/diagnostics/unknownSelectorGate.ts`) over the
+// bundled GST 3.2.5 cartridge ∪ a workspace class map parsed from the corpus,
+// walking every message send (via the shared `forEachSend`) and tallying the
+// outcome histogram. Every `emit` is printed for manual triage: on KNOWN-GOOD
+// corpus code, an emit is a FALSE POSITIVE unless it is a genuine latent typo.
+//
+// Run: npx tsx scripts/spike-unknown-selector.ts [--corpus all|kernel|learning]
+//      [--list-emits] [--emit-context]
+// No gst, no VS Code; deterministic over the committed cartridge.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from '../server/src/parser/parser.ts';
+import { tokenize } from '../server/src/parser/lexer.ts';
+import { SymbolKind } from '../server/src/parser/symbols.ts';
+import { WorkspaceIndex } from '../server/src/providers/workspaceIndex.ts';
+import { forEachSend } from '../server/src/xref/workspaceXref.ts';
+import { KernelIndexService } from '../server/src/kernel/kernelIndexService.ts';
+import { bundledCartridge, loadCartridge } from '../server/src/kernel/cartridgeLoader.ts';
+import { cartridgeClassWorld, type WorkspaceClass } from '../server/src/diagnostics/cartridgeClassWorld.ts';
+import { evaluateMissingSelector, type GateOutcome, type SendContext } from '../server/src/diagnostics/unknownSelectorGate.ts';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+const args = process.argv.slice(2);
+const corpusArg = (args[args.indexOf('--corpus') + 1] && args.includes('--corpus')) ? args[args.indexOf('--corpus') + 1] : 'all';
+const LIST_EMITS = args.includes('--list-emits') || true; // emits are the whole point — always list
+const EMIT_CONTEXT = args.includes('--emit-context');
+
+interface Corpus {
+  readonly name: string;
+  readonly dir: string;
+}
+const CORPORA: Corpus[] = [
+  { name: 'kernel', dir: path.resolve(repoRoot, '../smalltalk-3.2.5/kernel') },
+  { name: 'learning', dir: path.resolve(repoRoot, '../learning-smalltalk') },
+].filter((c) => corpusArg === 'all' || c.name === corpusArg);
+
+/** Every `.st`/`.gst` file under `dir`, recursively. */
+function stFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...stFiles(full));
+    } else if (/\.(st|gst)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+interface FileRec {
+  readonly corpus: string;
+  readonly file: string;
+  readonly text: string;
+  readonly clean: boolean;
+}
+
+// ---- 1. Load every file; build the union workspace class map ------------------
+const files: FileRec[] = [];
+const wsClasses = new Map<string, { superclass?: string; instance: Set<string>; classSel: Set<string> }>();
+
+for (const corpus of CORPORA) {
+  for (const file of stFiles(corpus.dir)) {
+    const text = fs.readFileSync(file, 'utf8');
+    const { diagnostics } = parse(text);
+    files.push({ corpus: corpus.name, file, text, clean: diagnostics.length === 0 });
+
+    const index = new WorkspaceIndex();
+    index.setFile(file, text);
+    for (const e of index.all()) {
+      if (e.kind === SymbolKind.Class || e.kind === SymbolKind.Namespace) {
+        const cls = wsClasses.get(e.name) ?? { instance: new Set<string>(), classSel: new Set<string>() };
+        if (e.superclass !== undefined && cls.superclass === undefined) {
+          cls.superclass = e.superclass;
+        }
+        wsClasses.set(e.name, cls);
+      }
+    }
+    // Second pass: attach methods to their container class.
+    for (const e of index.all()) {
+      if (e.kind === SymbolKind.Method && e.containerName !== undefined) {
+        const cls = wsClasses.get(e.containerName) ?? { instance: new Set<string>(), classSel: new Set<string>() };
+        (e.classSide ? cls.classSel : cls.instance).add(e.name);
+        wsClasses.set(e.containerName, cls);
+      }
+    }
+  }
+}
+
+const workspace = new Map<string, WorkspaceClass>();
+for (const [name, c] of wsClasses) {
+  workspace.set(name, { ...(c.superclass !== undefined ? { superclass: c.superclass } : {}), instance: c.instance, classSel: c.classSel, extensionOnly: false });
+}
+
+// ---- 2. Build the ClassWorld over the bundled cartridge ∪ workspace ------------
+const kernelService = new KernelIndexService(undefined, []);
+kernelService.configure({ kernelLibrary: 'bundled' });
+const loaded = loadCartridge(bundledCartridge);
+const world = cartridgeClassWorld(loaded, workspace);
+
+// ---- 3. Walk every send; tally outcomes; collect emits ------------------------
+interface Emit {
+  readonly corpus: string;
+  readonly file: string;
+  readonly line: number;
+  readonly targetClass: string;
+  readonly targetSide: string;
+  readonly selector: string;
+  readonly enclosing?: string;
+  readonly snippet: string;
+}
+const emits: Emit[] = [];
+const histByCorpus = new Map<string, Map<GateOutcome, number>>();
+const sendsByCorpus = new Map<string, number>();
+
+function bump(corpus: string, outcome: GateOutcome): void {
+  const h = histByCorpus.get(corpus) ?? new Map<GateOutcome, number>();
+  h.set(outcome, (h.get(outcome) ?? 0) + 1);
+  histByCorpus.set(corpus, h);
+}
+
+for (const rec of files) {
+  const ast = parse(rec.text).ast;
+  forEachSend(ast, (send) => {
+    const ctx: SendContext = {
+      node: send.node,
+      ...(send.className !== undefined ? { enclosingClass: send.className } : {}),
+      enclosingSide: send.side,
+      methodClean: rec.clean,
+      optedOut: false, // no <lint:> opt-out pragmas in these corpora (hatch unit-tested separately)
+    };
+    const result = evaluateMissingSelector(ctx, world);
+    bump(rec.corpus, result.outcome);
+    sendsByCorpus.set(rec.corpus, (sendsByCorpus.get(rec.corpus) ?? 0) + 1);
+    if (result.outcome === 'emit') {
+      const line = send.node.startPos.line;
+      emits.push({
+        corpus: rec.corpus,
+        file: path.relative(repoRoot, rec.file),
+        line: line + 1,
+        targetClass: result.targetClass ?? '?',
+        targetSide: result.targetSide ?? '?',
+        selector: send.node.selector,
+        ...(send.inSelector !== undefined ? { enclosing: `${send.className ?? '?'}»${send.inSelector}` } : {}),
+        snippet: rec.text.slice(send.node.start, Math.min(send.node.end, send.node.start + 60)).replace(/\s+/g, ' '),
+      });
+    }
+  });
+}
+
+// ---- 4. Report ----------------------------------------------------------------
+const ORDER: GateOutcome[] = [
+  'emit',
+  'understood',
+  'unknown-receiver',
+  'escape-incomplete',
+  'escape-dnu',
+  'escape-proxy',
+  'escape-allowlist',
+  'escape-perform',
+  'escape-optout',
+  'method-not-clean',
+];
+
+console.log('='.repeat(78));
+console.log('SPIKE-01 — Unknown-Selector Heuristic — corpus report');
+console.log('='.repeat(78));
+console.log(`cartridge: ${bundledCartridge.header.dialectLabel} ${bundledCartridge.header.version} (${Object.keys(bundledCartridge.classes).length} classes)`);
+console.log(`workspace classes parsed: ${workspace.size}`);
+console.log(`files: ${files.length}  (clean: ${files.filter((f) => f.clean).length})`);
+console.log('');
+
+let totalSends = 0;
+let totalEmit = 0;
+let totalResolved = 0;
+let totalSpeakable = 0; // understood + emit — the gate actually consulted a table
+for (const corpus of CORPORA) {
+  const h = histByCorpus.get(corpus.name) ?? new Map<GateOutcome, number>();
+  const sends = sendsByCorpus.get(corpus.name) ?? 0;
+  const get = (o: GateOutcome): number => h.get(o) ?? 0;
+  const resolved = sends - get('unknown-receiver');
+  const speakable = get('understood') + get('emit');
+  totalSends += sends;
+  totalEmit += get('emit');
+  totalResolved += resolved;
+  totalSpeakable += speakable;
+  console.log(`── corpus: ${corpus.name} ────────────────────────────────`);
+  console.log(`  total sends:            ${sends}`);
+  for (const o of ORDER) {
+    if (get(o) > 0) {
+      console.log(`    ${o.padEnd(20)} ${get(o)}`);
+    }
+  }
+  console.log(`  closed-world coverage:  ${resolved}/${sends} = ${pct(resolved, sends)}  (receiver resolved)`);
+  console.log(`  table-consulted:        ${speakable}/${sends} = ${pct(speakable, sends)}  (definite understood/emit)`);
+  console.log(`  EMITS (candidate FPs):  ${get('emit')}`);
+  console.log('');
+}
+
+console.log('── TOTAL ────────────────────────────────');
+console.log(`  sends: ${totalSends}  resolved: ${totalResolved} (${pct(totalResolved, totalSends)})  table-consulted: ${totalSpeakable} (${pct(totalSpeakable, totalSends)})  emits: ${totalEmit}`);
+console.log('');
+
+if (LIST_EMITS) {
+  console.log('── EMITS (triage each: false positive vs genuine latent typo) ──');
+  if (emits.length === 0) {
+    console.log('  (none) — zero emits on known-good corpus code.');
+  } else {
+    for (const e of emits) {
+      console.log(`  [${e.corpus}] ${e.file}:${e.line}  ${e.targetClass}(${e.targetSide}) ⊬ #${e.selector}   in ${e.enclosing ?? '(top level)'}`);
+      if (EMIT_CONTEXT) {
+        console.log(`       ${e.snippet}`);
+      }
+    }
+  }
+  console.log('');
+}
+
+function pct(n: number, d: number): string {
+  return d === 0 ? 'n/a' : `${((100 * n) / d).toFixed(1)}%`;
+}

--- a/server/src/diagnostics/cartridgeClassWorld.ts
+++ b/server/src/diagnostics/cartridgeClassWorld.ts
@@ -1,0 +1,210 @@
+// SPIKE-01 — a `ClassWorld` over a loaded cartridge ∪ a workspace class map.
+//
+// Resolves the closed-world facts the unknown-selector gate queries: the union of
+// the workspace's parsed method tables and the cartridge's resolved tables
+// (own ∪ inherited ∪ traits), walking the superclass chain to a known root. The
+// crucial correctness point: a *class object* responds not only to its class-side
+// methods but to the metaclass protocol (`Behavior`/`ClassDescription`/`Class`
+// instance methods — `new`, `name`, `category`, …), so class-side resolution
+// unions `methodTableOf(Class, instance)`; without this, `Foo new` itself would be
+// a false positive. Pure data — no `vscode`, no Node `fs`.
+
+import type { LoadedCartridge } from '../kernel/cartridgeLoader';
+import type { ClassId, MethodSide } from '../types/knowledge-base';
+import type { ClassWorld } from './unknownSelectorGate';
+
+/** A workspace class as parsed from corpus source (facts only). */
+export interface WorkspaceClass {
+  readonly superclass?: string;
+  readonly instance: ReadonlySet<string>;
+  readonly classSel: ReadonlySet<string>;
+  /** True when the class is known ONLY through an `extend`/`methodsFor:` chunk
+   *  (no full `subclass:` definition seen) — its table may be incomplete. */
+  readonly extensionOnly: boolean;
+}
+
+/** Simple name from a (possibly namespaced) ClassId: `Smalltalk.Object` → `Object`. */
+function simpleName(id: ClassId): string {
+  const dot = id.lastIndexOf('.');
+  return dot >= 0 ? id.slice(dot + 1) : id;
+}
+
+/** The GST dialect root carrying the default error `doesNotUnderstand:`. */
+const ROOT_DNU_CLASS = 'Object';
+
+export function cartridgeClassWorld(
+  loaded: LoadedCartridge,
+  workspace: ReadonlyMap<string, WorkspaceClass> = new Map(),
+): ClassWorld {
+  // simple name → ClassId (simple names are unique within a cartridge, ADR-0003).
+  const nameToId = new Map<string, ClassId>();
+  for (const id of Object.keys(loaded.cartridge.classes)) {
+    nameToId.set(simpleName(id), id);
+  }
+
+  // The metaclass protocol: instance methods of Class ∪ its ancestors
+  // (ClassDescription, Behavior, Object) — what every class object responds to.
+  let metaclassProtocol: ReadonlySet<string> | undefined;
+  const getMetaclassProtocol = (): ReadonlySet<string> => {
+    if (metaclassProtocol) {
+      return metaclassProtocol;
+    }
+    const classId = nameToId.get('Class');
+    metaclassProtocol = classId ? new Set(loaded.methodTableOf(classId, 'instance').keys()) : new Set<string>();
+    return metaclassProtocol;
+  };
+
+  const isCartridge = (name: string): boolean => nameToId.has(name);
+
+  // Direct-subclasses index (workspace ∪ cartridge), by simple name. Built lazily;
+  // powers the `self` subclass-closure (Template Method) union.
+  let childrenIndex: Map<string, string[]> | undefined;
+  const childrenOf = (name: string): readonly string[] => {
+    if (!childrenIndex) {
+      childrenIndex = new Map<string, string[]>();
+      const link = (child: string, parent: string | undefined): void => {
+        if (!parent) {
+          return;
+        }
+        const kids = childrenIndex!.get(parent) ?? [];
+        kids.push(child);
+        childrenIndex!.set(parent, kids);
+      };
+      for (const id of Object.keys(loaded.cartridge.classes)) {
+        const fact = loaded.cartridge.classes[id];
+        link(simpleName(id), fact?.superclass ? simpleName(fact.superclass) : undefined);
+      }
+      for (const [name, ws] of workspace) {
+        link(name, ws.superclass);
+      }
+    }
+    return childrenIndex.get(name) ?? [];
+  };
+
+  /** Locally-defined selectors of `name` on `side` (workspace own ∪ cartridge own,
+   *  NOT inherited). For the subclass-closure union. */
+  const ownSelectors = (name: string): { instance: ReadonlySet<string>; class: ReadonlySet<string> } => {
+    const inst = new Set<string>();
+    const cls = new Set<string>();
+    const ws = workspace.get(name);
+    if (ws) {
+      for (const s of ws.instance) inst.add(s);
+      for (const s of ws.classSel) cls.add(s);
+    }
+    const id = nameToId.get(name);
+    if (id) {
+      const fact = loaded.cartridge.classes[id];
+      for (const m of fact?.instanceMethods ?? []) inst.add(m.selector);
+      for (const m of fact?.classMethods ?? []) cls.add(m.selector);
+    }
+    return { instance: inst, class: cls };
+  };
+
+  /** Selectors `name` responds to on `side` — own ∪ inherited ∪ traits, walking the
+   *  workspace chain into the cartridge (which resolves the rest to root). For the
+   *  class side, ∪ the metaclass protocol. `undefined` ⇒ chain not fully indexed. */
+  const baseRespondsTo = (name: string, side: MethodSide): Set<string> | undefined => {
+    const acc = new Set<string>();
+    let cur: string | undefined = name;
+    const seen = new Set<string>();
+    while (cur && !seen.has(cur)) {
+      seen.add(cur);
+      const ws = workspace.get(cur);
+      if (ws) {
+        for (const s of side === 'instance' ? ws.instance : ws.classSel) {
+          acc.add(s);
+        }
+      }
+      const id = nameToId.get(cur);
+      if (id) {
+        for (const k of loaded.methodTableOf(id, side).keys()) {
+          acc.add(k);
+        }
+        if (side === 'class') {
+          for (const k of getMetaclassProtocol()) {
+            acc.add(k);
+          }
+        }
+        return acc; // cartridge resolved this class + all ancestors
+      }
+      if (!ws) {
+        return undefined; // an unknown class in the chain → open world
+      }
+      cur = ws.superclass;
+    }
+    return undefined; // workspace chain ended without reaching a known root
+  };
+
+  return {
+    rootDnuClass: ROOT_DNU_CLASS,
+
+    isKnownClass(name) {
+      return workspace.has(name) || isCartridge(name);
+    },
+
+    superclassOf(name) {
+      const ws = workspace.get(name);
+      if (ws) {
+        return ws.superclass;
+      }
+      const id = nameToId.get(name);
+      const sup = id ? loaded.cartridge.classes[id]?.superclass : undefined;
+      return sup ? simpleName(sup) : undefined;
+    },
+
+    isIncompleteTable(name) {
+      const ws = workspace.get(name);
+      return ws?.extensionOnly === true && !isCartridge(name);
+    },
+
+    respondsTo(name, side: MethodSide) {
+      return baseRespondsTo(name, side);
+    },
+
+    respondsToSelf(name, side: MethodSide) {
+      const base = baseRespondsTo(name, side);
+      if (!base) {
+        return undefined; // open world — don't widen an already-unknown chain
+      }
+      // `self` could be any concrete subclass: ∪ each descendant's OWN methods
+      // (the Template Method pattern — abstract super, concrete subclass impls).
+      const acc = new Set(base);
+      const stack = [...childrenOf(name)];
+      const seen = new Set<string>([name]);
+      while (stack.length > 0) {
+        const sub = stack.pop() as string;
+        if (seen.has(sub)) {
+          continue;
+        }
+        seen.add(sub);
+        for (const s of side === 'instance' ? ownSelectors(sub).instance : ownSelectors(sub).class) {
+          acc.add(s);
+        }
+        stack.push(...childrenOf(sub));
+      }
+      return acc;
+    },
+
+    dnuDefiner(name) {
+      let cur: string | undefined = name;
+      const seen = new Set<string>();
+      while (cur && !seen.has(cur)) {
+        seen.add(cur);
+        const ws = workspace.get(cur);
+        if (ws?.instance.has('doesNotUnderstand:')) {
+          return cur;
+        }
+        const id = nameToId.get(cur);
+        if (id) {
+          const m = loaded.methodTableOf(id, 'instance').get('doesNotUnderstand:');
+          return m ? simpleName(m.inClass) : undefined;
+        }
+        if (!ws) {
+          return undefined;
+        }
+        cur = ws.superclass;
+      }
+      return undefined;
+    },
+  };
+}

--- a/server/src/diagnostics/unknownSelectorGate.ts
+++ b/server/src/diagnostics/unknownSelectorGate.ts
@@ -1,0 +1,240 @@
+// SPIKE-01 — Unknown-Selector Heuristic ("Heuristic of Extreme Caution").
+//
+// The static shadow of `doesNotUnderstand:`: decide whether a message send's
+// selector is *provably* unknown — and therefore worth a (future) lint squiggle.
+// In a dynamically typed language a single false positive on valid code is a
+// ten-minute uninstall, so this gate is biased hard to SILENCE: it speaks only
+// when the receiver resolves to a fully-indexed, closed-world class and every
+// escape hatch is clear (spec §4 truth table, §5 hatches).
+//
+// THIS SHIPS NOTHING. It is a measurement instrument: a pure predicate driven by
+// the corpus harness (`scripts/spike-unknown-selector.ts`) to tally false
+// positives + closed-world coverage and inform the go/no-go memo. No published
+// diagnostics, no UI. Pure — no `vscode`, no Node `fs`.
+
+import { NodeKind, type MessageNode, type Node } from '../parser/ast';
+import type { MethodSide } from '../types/knowledge-base';
+
+/** Why the gate stayed silent — or that it fired. The harness tallies these to
+ *  compute closed-world coverage (everything that is NOT `unknown-receiver`) and
+ *  the emit set (`emit`). */
+export type GateOutcome =
+  | 'unknown-receiver' // open world — receiver could be an un-indexed class (silent)
+  | 'understood' // selector is in the resolved method table (silent)
+  | 'method-not-clean' // enclosing method has a parse error — don't lint mid-edit (silent)
+  | 'escape-allowlist' // a reflective/meta selector (perform:, respondsTo:, …) (silent)
+  | 'escape-perform' // a perform:-family send — computed selector (silent)
+  | 'escape-proxy' // receiver class name signals a proxy/mock/stub (silent)
+  | 'escape-dnu' // a custom doesNotUnderstand: in the chain → forwarding (silent)
+  | 'escape-incomplete' // receiver is an extension / partially-indexed table (silent)
+  | 'escape-optout' // explicit opt-out pragma/setting on the method (silent)
+  | 'emit'; // KnownClosedWorld ∧ ¬understood ∧ clean ∧ ¬escape → the only firing row
+
+export interface GateResult {
+  readonly outcome: GateOutcome;
+  /** Set only when a receiver resolves to a closed-world class (coverage + emit). */
+  readonly targetClass?: string;
+  readonly targetSide?: MethodSide;
+}
+
+/** The closed-world the gate queries — workspace ∪ cartridge, resolved to facts.
+ *  An implementation walks the superclass chain to a known root; if the chain
+ *  can't be fully resolved it returns `undefined` (open world → the gate is silent). */
+export interface ClassWorld {
+  /** Is `name` a known class at all (workspace ∪ cartridge)? */
+  isKnownClass(name: string): boolean;
+  /** Immediate superclass simple-name of `name`, or undefined. */
+  superclassOf(name: string): string | undefined;
+  /** The selectors a `name` instance / class-object responds to — own ∪ inherited
+   *  ∪ traits, and for `class` side ∪ the metaclass (Behavior/Class) protocol.
+   *  `undefined` ⇒ the chain isn't fully indexed (open world). */
+  respondsTo(name: string, side: MethodSide): ReadonlySet<string> | undefined;
+  /** Like {@link respondsTo}, but UNIONS the subclass closure of `name`. Used for
+   *  `self` sends: in an *abstract* class, `self` is some concrete subclass, so a
+   *  selector implemented only in a subclass (the Template Method pattern, e.g.
+   *  `Float>>asFraction` sending `self exponent` where `exponent` lives in
+   *  `FloatD`/`FloatE`/`FloatQ`) is genuinely understood and must NOT be flagged.
+   *  `undefined` ⇒ the chain isn't fully indexed (open world). */
+  respondsToSelf(name: string, side: MethodSide): ReadonlySet<string> | undefined;
+  /** Simple-name of the class that defines `doesNotUnderstand:` for `name`'s
+   *  instances, or undefined. Used for the custom-DNU escape hatch. */
+  dnuDefiner(name: string): string | undefined;
+  /** Is `name` an extension / explicitly-incomplete table (spec §5.4)? */
+  isIncompleteTable(name: string): boolean;
+  /** The dialect root that carries the *default* error `doesNotUnderstand:`
+   *  (GST: `Object`). A DNU resolved anywhere else is a custom forwarder. */
+  readonly rootDnuClass: string;
+}
+
+/** Context for one send under test, supplied by the harness from the AST walk. */
+export interface SendContext {
+  readonly node: MessageNode;
+  /** The class enclosing the send (the `self`/`super` target), if inside a method. */
+  readonly enclosingClass?: string;
+  /** The enclosing method's side — `self` in a class method is the class object. */
+  readonly enclosingSide: MethodSide;
+  /** False when the enclosing method has a parse error (don't lint broken code). */
+  readonly methodClean: boolean;
+  /** True when the enclosing method/class carries the opt-out pragma (spec §5.6). */
+  readonly optedOut: boolean;
+}
+
+/** Class-side instantiators whose result is an *instance* of the receiver class:
+ *  `Foo new`, `Foo basicNew`. (`new:`/`basicNew:` handled as keyword sends.) */
+const UNARY_INSTANTIATORS = new Set(['new', 'basicNew']);
+const KEYWORD_INSTANTIATORS = new Set(['new:', 'basicNew:']);
+
+/** perform:-family selectors — the dispatched selector is computed at runtime, so
+ *  the literal send is invisible to static analysis (spec §5.2). */
+const PERFORM_FAMILY = new Set([
+  'perform:',
+  'perform:with:',
+  'perform:with:with:',
+  'perform:with:with:with:',
+  'perform:with:with:with:with:',
+  'perform:withArguments:',
+  'perform:withArguments:inSuperclass:',
+  'perform:inSuperclass:',
+]);
+
+/** Reflective / meta allowlist (spec §5.5) — never flagged even if a table is thin. */
+const REFLECTIVE_ALLOWLIST = new Set([
+  'respondsTo:',
+  'doesNotUnderstand:',
+  '->',
+  'value',
+  'value:',
+  'value:value:',
+  'instVarNamed:',
+  'instVarNamed:put:',
+  'instVarAt:',
+  'instVarAt:put:',
+  'yourself',
+  'isKindOf:',
+  'isMemberOf:',
+  'class',
+]);
+
+/** Soft proxy/forwarding name signals (spec §5.3) — configurable; conservative. */
+const PROXY_NAME = /(Proxy|Mock|Stub|Adapter|Forwarder)$/;
+
+function isVar(node: Node, name?: string): boolean {
+  return node.kind === NodeKind.Variable && (name === undefined || node.name === name);
+}
+
+function isCapitalized(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+/** A resolved closed-world receiver. `polymorphic` is true only for `self` — the
+ *  receiver could be any concrete subclass, so the understood-set unions the
+ *  subclass closure (Template Method). `super`/class-literal/`new` are monomorphic. */
+interface ResolvedReceiver {
+  readonly className: string;
+  readonly side: MethodSide;
+  readonly polymorphic: boolean;
+}
+
+/** Resolve the receiver to a closed-world `{class, side}` in exactly the high-
+ *  confidence cases (spec §4) — else `undefined` (open world). */
+function resolveReceiver(ctx: SendContext, world: ClassWorld): ResolvedReceiver | undefined {
+  const r = ctx.node.receiver;
+
+  // `self` inside a fully-indexed method — polymorphic over the subclass closure.
+  if (isVar(r, 'self')) {
+    return ctx.enclosingClass ? { className: ctx.enclosingClass, side: ctx.enclosingSide, polymorphic: true } : undefined;
+  }
+  // `super` — lookup starts at the superclass and goes UP; not polymorphic.
+  if (isVar(r, 'super')) {
+    if (!ctx.enclosingClass) {
+      return undefined;
+    }
+    const sup = world.superclassOf(ctx.enclosingClass);
+    return sup ? { className: sup, side: ctx.enclosingSide, polymorphic: false } : undefined;
+  }
+
+  // A literal class receiver: `OrderedCollection foo` → the class object (class side).
+  if (r.kind === NodeKind.Variable && isCapitalized(r.name) && world.isKnownClass(r.name)) {
+    return { className: r.name, side: 'class', polymorphic: false };
+  }
+
+  // `Foo new` / `Foo basicNew[:]` → an instance of Foo (instance side, monomorphic).
+  if (r.kind === NodeKind.Message) {
+    const inst =
+      (r.messageType === 'unary' && UNARY_INSTANTIATORS.has(r.selector)) ||
+      (r.messageType === 'keyword' && KEYWORD_INSTANTIATORS.has(r.selector));
+    if (inst && r.receiver.kind === NodeKind.Variable && isCapitalized(r.receiver.name) && world.isKnownClass(r.receiver.name)) {
+      return { className: r.receiver.name, side: 'instance', polymorphic: false };
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * The gate (spec §4 truth table). Returns the outcome classification; the harness
+ * tallies coverage (¬`unknown-receiver`) and the emit set. EMIT is the single row:
+ * a closed-world receiver, the selector absent from its resolved table, the method
+ * parses clean, and no escape hatch fired.
+ */
+export function evaluateMissingSelector(ctx: SendContext, world: ClassWorld): GateResult {
+  const selector = ctx.node.selector;
+  if (selector === '') {
+    return { outcome: 'unknown-receiver' }; // a recovery/empty send — nothing to say
+  }
+
+  const resolved = resolveReceiver(ctx, world);
+  if (!resolved) {
+    return { outcome: 'unknown-receiver' };
+  }
+  const { className, side, polymorphic } = resolved;
+  const tag = { targetClass: className, targetSide: side };
+
+  // §5.2 / §5.5 — reflective sends are never flagged (cheap, receiver-independent).
+  if (PERFORM_FAMILY.has(selector)) {
+    return { outcome: 'escape-perform', ...tag };
+  }
+  if (REFLECTIVE_ALLOWLIST.has(selector)) {
+    return { outcome: 'escape-allowlist', ...tag };
+  }
+
+  // §5.4 — extension / partially-indexed receiver table ⇒ open world.
+  if (world.isIncompleteTable(className)) {
+    return { outcome: 'escape-incomplete', ...tag };
+  }
+
+  // §5.3 — proxy/forwarding by name signal.
+  if (PROXY_NAME.test(className)) {
+    return { outcome: 'escape-proxy', ...tag };
+  }
+
+  // §5.1 — a custom doesNotUnderstand: anywhere below the root ⇒ forwarding.
+  const dnu = world.dnuDefiner(className);
+  if (dnu !== undefined && dnu !== world.rootDnuClass) {
+    return { outcome: 'escape-dnu', ...tag };
+  }
+
+  // `self` unions the subclass closure (Template Method); other receivers are exact.
+  const table = polymorphic ? world.respondsToSelf(className, side) : world.respondsTo(className, side);
+  if (!table) {
+    // Chain not fully indexed (e.g. a workspace class rooted in an unknown super).
+    return { outcome: 'escape-incomplete', ...tag };
+  }
+  if (table.has(selector)) {
+    return { outcome: 'understood', ...tag };
+  }
+
+  // The receiver is closed-world and does NOT understand the selector. Final guards:
+  if (!ctx.methodClean) {
+    return { outcome: 'method-not-clean', ...tag };
+  }
+  if (ctx.optedOut) {
+    return { outcome: 'escape-optout', ...tag };
+  }
+  return { outcome: 'emit', ...tag };
+}
+
+/** The published-API predicate the spec names (§4) — the boolean over the gate. */
+export function shouldEmitMissingSelectorWarning(ctx: SendContext, world: ClassWorld): boolean {
+  return evaluateMissingSelector(ctx, world).outcome === 'emit';
+}

--- a/server/test/run.ts
+++ b/server/test/run.ts
@@ -15,6 +15,7 @@ import './comments.test.ts';
 import './hover.test.ts';
 import './semanticTokens.test.ts';
 import './signatureHelp.test.ts';
+import './unknownSelectorGate.test.ts';
 import './workspaceXref.test.ts';
 import './resolve.test.ts';
 import './callHierarchy.test.ts';

--- a/server/test/unknownSelectorGate.test.ts
+++ b/server/test/unknownSelectorGate.test.ts
@@ -1,0 +1,189 @@
+// SPIKE-01 — unit tests for the unknown-selector gate (AC1 truth table, AC2 the
+// six escape hatches) + the cartridge-backed ClassWorld behaviours that matter
+// most for false positives: the `self` subclass-closure (Template Method) and the
+// class-object metaclass protocol. Pure; no server runtime, no VS Code.
+import assert from 'node:assert/strict';
+import { NodeKind, type MessageNode, type Node } from '../src/parser/ast.ts';
+import type { MethodSide } from '../src/types/knowledge-base.ts';
+import {
+  evaluateMissingSelector,
+  type ClassWorld,
+  type GateOutcome,
+  type SendContext,
+} from '../src/diagnostics/unknownSelectorGate.ts';
+import { cartridgeClassWorld } from '../src/diagnostics/cartridgeClassWorld.ts';
+import { bundledCartridge, loadCartridge } from '../src/kernel/cartridgeLoader.ts';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed += 1;
+  console.log(`  ok - ${name}`);
+}
+
+// --- minimal AST builders (the gate reads only receiver/selector/messageType) ---
+const POS = { line: 0, character: 0 };
+const base = { start: 0, end: 0, startPos: POS, endPos: POS };
+function v(name: string): Node {
+  return { kind: NodeKind.Variable, name, ...base } as Node;
+}
+function send(receiver: Node, selector: string, messageType: 'unary' | 'binary' | 'keyword' = 'unary'): MessageNode {
+  return { kind: NodeKind.Message, receiver, selector, messageType, arguments: [], ...base } as MessageNode;
+}
+
+// --- a hand-rolled ClassWorld for controlled truth-table / hatch tests ----------
+interface Spec {
+  super?: string;
+  inst?: string[];
+  cls?: string[];
+  subclasses?: string[]; // descendants whose OWN methods join `self` resolution
+  dnu?: string; // simple-name of the class defining doesNotUnderstand:
+  incomplete?: boolean;
+}
+function makeWorld(classes: Record<string, Spec>): ClassWorld {
+  const META = new Set(['new', 'basicNew', 'name', 'category']); // metaclass protocol stub
+  const chainSet = (name: string, side: MethodSide): Set<string> | undefined => {
+    const acc = new Set<string>();
+    let cur: string | undefined = name;
+    const seen = new Set<string>();
+    while (cur && !seen.has(cur)) {
+      seen.add(cur);
+      const s = classes[cur];
+      if (!s) {
+        return undefined; // unknown class in the chain → open world
+      }
+      for (const m of (side === 'instance' ? s.inst : s.cls) ?? []) acc.add(m);
+      cur = s.super;
+    }
+    if (side === 'class') for (const m of META) acc.add(m);
+    return acc;
+  };
+  return {
+    rootDnuClass: 'Object',
+    isKnownClass: (n) => classes[n] !== undefined,
+    superclassOf: (n) => classes[n]?.super,
+    isIncompleteTable: (n) => classes[n]?.incomplete === true,
+    respondsTo: chainSet,
+    respondsToSelf: (name, side) => {
+      const base = chainSet(name, side);
+      if (!base) return undefined;
+      const acc = new Set(base);
+      for (const sub of classes[name]?.subclasses ?? []) {
+        for (const m of (side === 'instance' ? classes[sub]?.inst : classes[sub]?.cls) ?? []) acc.add(m);
+      }
+      return acc;
+    },
+    dnuDefiner: (n) => {
+      let cur: string | undefined = n;
+      const seen = new Set<string>();
+      while (cur && !seen.has(cur)) {
+        seen.add(cur);
+        if (classes[cur]?.dnu) return classes[cur]!.dnu;
+        cur = classes[cur]?.super;
+      }
+      return 'Object'; // root default DNU
+    },
+  };
+}
+
+function ctx(node: MessageNode, over: Partial<SendContext> = {}): SendContext {
+  return { node, enclosingSide: 'instance', methodClean: true, optedOut: false, ...over };
+}
+
+const outcome = (c: SendContext, w: ClassWorld): GateOutcome => evaluateMissingSelector(c, w).outcome;
+
+// --- AC1: truth table -----------------------------------------------------------
+
+test('Unknown receiver (a local/expression) → silent (open world)', () => {
+  const w = makeWorld({ Foo: { inst: ['bar'] } });
+  assert.equal(outcome(ctx(send(v('x'), 'anything')), w), 'unknown-receiver');
+});
+
+test('self understood in its own table → silent', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'speak'), { enclosingClass: 'Animal' }), w), 'understood');
+});
+
+test('self NOT in table, clean, no hatch → EMIT (the only firing row)', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'fly'), { enclosingClass: 'Animal' }), w), 'emit');
+});
+
+test('self to a subclass-only method (Template Method) → silent (subclass union)', () => {
+  // Abstract `Shape` sends `self area`; only the concrete `Circle` implements it.
+  const w = makeWorld({ Shape: { inst: ['draw'], subclasses: ['Circle'] }, Circle: { super: 'Shape', inst: ['area'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'area'), { enclosingClass: 'Shape' }), w), 'understood');
+});
+
+test('unknown selector, method not clean → silent (don\'t lint broken code)', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'fly'), { enclosingClass: 'Animal', methodClean: false }), w), 'method-not-clean');
+});
+
+test('super resolves to the superclass table (exact, not subclasses)', () => {
+  const w = makeWorld({ Base: { inst: ['init'] }, Derived: { super: 'Base', inst: ['extra'] } });
+  // super init → Base understands it.
+  assert.equal(outcome(ctx(send(v('super'), 'init'), { enclosingClass: 'Derived' }), w), 'understood');
+  // super extra → Base does NOT (extra is Derived's own) → emit.
+  assert.equal(outcome(ctx(send(v('super'), 'extra'), { enclosingClass: 'Derived' }), w), 'emit');
+});
+
+test('a literal class receiver resolves to the class side + metaclass protocol', () => {
+  const w = makeWorld({ Widget: { cls: ['default'] } });
+  assert.equal(outcome(ctx(send(v('Widget'), 'new')), w), 'understood'); // `new` via metaclass stub
+  assert.equal(outcome(ctx(send(v('Widget'), 'default')), w), 'understood');
+  assert.equal(outcome(ctx(send(v('Widget'), 'nope')), w), 'emit');
+});
+
+// --- AC2: escape hatches --------------------------------------------------------
+
+test('hatch: perform:-family is always silent', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'perform:with:', 'keyword'), { enclosingClass: 'Animal' }), w), 'escape-perform');
+});
+
+test('hatch: reflective allowlist (respondsTo:) is silent', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'respondsTo:', 'keyword'), { enclosingClass: 'Animal' }), w), 'escape-allowlist');
+});
+
+test('hatch: custom doesNotUnderstand: in the chain → forwarding → silent', () => {
+  // A neutral name (not matching the proxy regex) so the DNU hatch is what fires.
+  const w = makeWorld({ RemoteThing: { inst: ['speak'], dnu: 'RemoteThing' } });
+  assert.equal(outcome(ctx(send(v('self'), 'anythingAtAll'), { enclosingClass: 'RemoteThing' }), w), 'escape-dnu');
+});
+
+test('hatch: proxy/mock/stub name signal → silent', () => {
+  const w = makeWorld({ ServiceProxy: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'whatever'), { enclosingClass: 'ServiceProxy' }), w), 'escape-proxy');
+});
+
+test('hatch: incomplete/extension table → silent', () => {
+  const w = makeWorld({ Patched: { inst: ['speak'], incomplete: true } });
+  assert.equal(outcome(ctx(send(v('self'), 'whatever'), { enclosingClass: 'Patched' }), w), 'escape-incomplete');
+});
+
+test('hatch: explicit opt-out pragma → silent', () => {
+  const w = makeWorld({ Animal: { inst: ['speak'] } });
+  assert.equal(outcome(ctx(send(v('self'), 'fly'), { enclosingClass: 'Animal', optedOut: true }), w), 'escape-optout');
+});
+
+// --- cartridge-backed reality checks (the real FP drivers) ----------------------
+
+const world = cartridgeClassWorld(loadCartridge(bundledCartridge));
+
+test('cartridge: `Float>>… self exponent` is understood (subclass-union, abstract class)', () => {
+  // exponent lives on FloatD/FloatE/FloatQ, never on abstract Float — must NOT emit.
+  assert.equal(outcome(ctx(send(v('self'), 'exponent'), { enclosingClass: 'Float' }), world), 'understood');
+});
+
+test('cartridge: `OrderedCollection new` is understood (metaclass `new` via Behavior)', () => {
+  assert.equal(outcome(ctx(send(v('OrderedCollection'), 'new'), {}), world), 'understood');
+});
+
+test('cartridge: a fabricated typo on a closed-world receiver EMITS', () => {
+  // `self prtinString` inside Object — a clear misspelling of printString.
+  assert.equal(outcome(ctx(send(v('self'), 'prtinString'), { enclosingClass: 'Object' }), world), 'emit');
+});
+
+console.log(`\nunknownSelectorGate: ${passed} tests passed.`);

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/corpus-report.txt
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/corpus-report.txt
@@ -1,0 +1,59 @@
+==============================================================================
+SPIKE-01 — Unknown-Selector Heuristic — corpus report
+==============================================================================
+cartridge: GNU Smalltalk 3.2.5 (249 classes)
+workspace classes parsed: 255
+files: 124  (clean: 124)
+
+── corpus: kernel ────────────────────────────────
+  total sends:            21711
+    emit                 12
+    understood           5872
+    unknown-receiver     15383
+    escape-incomplete    11
+    escape-dnu           155
+    escape-proxy         16
+    escape-allowlist     258
+    escape-perform       4
+  closed-world coverage:  6328/21711 = 29.1%  (receiver resolved)
+  table-consulted:        5884/21711 = 27.1%  (definite understood/emit)
+  EMITS (candidate FPs):  12
+
+── corpus: learning ────────────────────────────────
+  total sends:            54
+    understood           2
+    unknown-receiver     48
+    escape-incomplete    4
+  closed-world coverage:  6/54 = 11.1%  (receiver resolved)
+  table-consulted:        2/54 = 3.7%  (definite understood/emit)
+  EMITS (candidate FPs):  0
+
+── TOTAL ────────────────────────────────
+  sends: 21765  resolved: 6334 (29.1%)  table-consulted: 5886 (27.0%)  emits: 12
+
+── EMITS (triage each: false positive vs genuine latent typo) ──
+  [kernel] ../smalltalk-3.2.5/kernel/ContextPart.st:510  SecurityError(class) ⊬ #for:   in ContextPart»doSecurityCheckForName:actions:target:
+       SecurityError for: perm
+  [kernel] ../smalltalk-3.2.5/kernel/ObjDumper.st:513  ObjectDumper(instance) ⊬ #nextSignByte   in ObjectDumper»loadFromVersion:fixedSize:index:
+       self nextSignByte
+  [kernel] ../smalltalk-3.2.5/kernel/ObjDumper.st:523  ObjectDumper(instance) ⊬ #nextInt64   in ObjectDumper»loadFromVersion:fixedSize:index:
+       self nextInt64
+  [kernel] ../smalltalk-3.2.5/kernel/ObjDumper.st:555  ObjectDumper(instance) ⊬ #nextSignByte   in ObjectDumper»primLoad:
+       self nextSignByte
+  [kernel] ../smalltalk-3.2.5/kernel/ObjDumper.st:560  ObjectDumper(instance) ⊬ #nextInt64   in ObjectDumper»primLoad:
+       self nextInt64
+  [kernel] ../smalltalk-3.2.5/kernel/Object.st:846  Object(instance) ⊬ #primtiveFailed   in Object»checkIndexableBounds:put:
+       self primtiveFailed
+  [kernel] ../smalltalk-3.2.5/kernel/PkgLoader.st:1980  PackageLoader(class) ⊬ #extractDependenciesFor:ifMissing:   in PackageLoader»canLoad:
+       self extractDependenciesFor: {package} ifMissing: [:name | ^
+  [kernel] ../smalltalk-3.2.5/kernel/URL.st:557  URL(instance) ⊬ #file   in URL»decodedFile
+       self file
+  [kernel] ../smalltalk-3.2.5/kernel/VFS.st:561  ArchiveFile(instance) ⊬ #primUnlink:   in ArchiveFile»release
+       self primUnlink: each
+  [kernel] ../smalltalk-3.2.5/kernel/WeakObjects.st:347  WeakKeyDictionary(class) ⊬ #primSize   in WeakKeyDictionary»postLoad
+       self primSize
+  [kernel] ../smalltalk-3.2.5/kernel/WeakObjects.st:348  WeakKeyDictionary(class) ⊬ #primAt:   in WeakKeyDictionary»postLoad
+       self primAt: i
+  [kernel] ../smalltalk-3.2.5/kernel/WeakObjects.st:348  WeakKeyDictionary(class) ⊬ #primAt:   in WeakKeyDictionary»postLoad
+       self primAt: i
+

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/requirements-validation.md
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/requirements-validation.md
@@ -2,28 +2,39 @@
 
 **Purpose**: Validate spec quality BEFORE implementation begins  
 **Type**: Requirements Quality Gate  
+**US**: SPIKE-01 — Unknown-Selector Heuristic (research spike) · **Validated**: 2026-06-26
 
 ---
 
 ## Section 1: Constitution Gates (Mandatory)
-- [ ] **Native Look & Feel**: Uses standard VS Code APIs?
-- [ ] **Zero Config**: Defaults provided? Auto-detection planned?
-- [ ] **Protocol First**: LSP/DAP used where applicable?
-- [ ] **Robustness**: Error handling defined?
-- [ ] **Dialect Agnostic**: Architecture supports future dialects?
+- [X] **Native Look & Feel**: N/A — a measurement spike. **Ships nothing**: no published diagnostics, no
+  UI, no command (spec §3). The gate is a pure predicate, tree-shaken from the bundle.
+- [X] **Zero Config**: N/A — runs offline over the bundled cartridge ∪ a parsed corpus; no `gst`, no setting.
+- [X] **Protocol First**: N/A — no LSP surface by design (if ever adopted, the feature would publish
+  `textDocument/publishDiagnostics`).
+- [X] **Robustness**: Pure predicate; the gate's whole posture is bias-to-silence (open world ⇒ silent);
+  never throws (spec §4/§8).
+- [X] **Dialect Agnostic**: The `ClassWorld` resolves over any cartridge ∪ workspace; the gate has no
+  GST-specific logic beyond the `Object` DNU root (parameterised via `rootDnuClass`).
 
 ## Section 2: Specification Completeness
-- [ ] Goals and Non-Goals explicitly listed?
-- [ ] User stories in standard format?
-- [ ] Acceptance scenarios (Given/When/Then) defined?
-- [ ] Edge cases identified?
-- [ ] Dependencies listed?
+- [X] Goals and Non-Goals explicitly listed (spec §2/§3 — measurement only, ships nothing).
+- [X] User story in standard format — research spike framing (gate any future linter on evidence).
+- [X] Acceptance criteria defined and testable (AC1 gate/truth-table, AC2 six hatches, AC3 corpus
+  precision+coverage, AC4 go/no-go memo).
+- [X] Edge cases identified (spec §8 + the §4 truth table): abstract/Template-Method self-sends, proxy/DNU
+  forwarding, perform:/reflective, extension/incomplete tables, un-indexed third-party receivers.
+- [X] Dependencies listed: US-430 `cartridgeLoader.methodTableOf`, US-411 AST/symbols, US-423 `forEachSend`.
 
 ## Section 3: Technical Design
-- [ ] API/Command contracts defined?
-- [ ] Data structures defined?
-- [ ] Error handling strategy defined?
-- [ ] Testing strategy (Unit vs Integration) defined?
+- [X] API/Command contracts: `evaluateMissingSelector(ctx, world)` / `shouldEmitMissingSelectorWarning`;
+  the `ClassWorld` resolution interface (spec §4).
+- [X] Data structures: the §4 truth table; the `ClassWorld` (respondsTo / respondsToSelf subclass-closure /
+  dnuDefiner / metaclass protocol); the corpus harness tally.
+- [X] Error-handling strategy: bias-to-silence; `undefined` table ⇒ open world ⇒ silent.
+- [X] Testing strategy: unit (`unknownSelectorGate.test.ts`) + the corpus harness as the measurement.
 
 ## Section 4: Validation Result
-- [ ] PASS - Ready for implementation
+- [X] **PASS — proceeded to implementation.** Outcome recorded in `verification.md` (go/no-go memo):
+  **SHELVE** — the zero-FP bar is unmet (~7-8 cartridge-gap false positives on the GST kernel) and
+  closed-world coverage is low (~27%). Gate code parked, flagged off; reconsider after cartridge hardening.

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/tasks.md
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/tasks.md
@@ -5,14 +5,14 @@
 Time-box: 2–3 days. Output is a go/no-go memo, not shipped diagnostics.
 
 ## Phase 1 — Setup
-- [ ] T001 Confirm US-430 loader exposes `methodTableOf(classId)` (own ∪ inherited ∪ traits).
+- [x] T001 Confirmed US-430 loader exposes `methodTableOf(classId, side)` (own ∪ inherited ∪ traits).
 
 ## Phase 2 — Implementation (flagged off)
-- [ ] T010 `server/src/diagnostics/unknownSelectorGate.ts`: closed-world receiver resolution + resolved method table. (AC1)
-- [ ] T011 §4 truth table (single emit row; severity Hint). (AC1)
-- [ ] T012 §5 escape hatches: DNU-in-chain, perform: family, proxy/forwarding, incomplete table, reflective allowlist, explicit opt-out. (AC2)
+- [x] T010 `server/src/diagnostics/unknownSelectorGate.ts` + `cartridgeClassWorld.ts`: closed-world receiver resolution + resolved method table (incl. metaclass protocol + the `self` subclass closure). (AC1)
+- [x] T011 §4 truth table (single emit row; severity Hint). (AC1)
+- [x] T012 §5 escape hatches: DNU-in-chain, perform: family, proxy/forwarding, incomplete table, reflective allowlist, explicit opt-out — all unit-tested (`server/test/unknownSelectorGate.test.ts`, 16 cases). (AC2)
 
 ## Phase 3 — Measure & decide
-- [ ] T020 `scripts/spike-unknown-selector.ts`: walk `learning-smalltalk/` + GST kernel; tally emits.
-- [ ] T021 Triage every emit (true catch vs false positive); compute precision + closed-world coverage. (AC3)
-- [ ] T022 Go/no-go memo in `verification.md` (adopt → file feature story; or shelve with evidence). (AC4)
+- [x] T020 `scripts/spike-unknown-selector.ts`: walked GST kernel (122 files / 21,711 sends) + learning-smalltalk; tally + report saved to `corpus-report.txt`.
+- [x] T021 Triaged every emit. Naive 58 FPs → **12** after the `self` subclass-union fix; of the 12, ~4 genuine catches (incl. the `primtiveFailed` typo), ~7-8 cartridge-completeness FPs. Coverage ~27%. (AC3)
+- [x] T022 Go/no-go memo in `verification.md`: **SHELVE** (zero-FP bar unmet + low coverage); reconsider after cartridge hardening + scope restriction. No feature story filed. (AC4)

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/upstream-bug-primtiveFailed.md
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/upstream-bug-primtiveFailed.md
@@ -1,0 +1,77 @@
+# Upstream bug report — GNU Smalltalk: misspelled selector `primtiveFailed` in `Object>>checkIndexableBounds:put:`
+
+Surfaced by SPIKE-01 (the unknown-selector heuristic) while validating against the GST 3.2.5 kernel
+corpus. Confirmed still present in the current Savannah git `master`
+(`cgit.git.savannah.gnu.org/cgit/smalltalk.git/plain/kernel/Object.st`), so this is a live defect, not a
+3.2.5-only artifact.
+
+---
+
+## Submit to (pick one)
+
+- **Savannah bug tracker (preferred — trackable):** https://savannah.gnu.org/bugs/?group=smalltalk
+  (use "Submit a new item"; a Savannah account may be required).
+- **Mailing list:** `help-smalltalk@gnu.org`
+  (subscribe/info: https://lists.gnu.org/mailman/listinfo/help-smalltalk).
+
+> Note: GNU Smalltalk is largely dormant (3.2.5 was the last release, 2012), so a reply may be slow.
+
+---
+
+## Report (ready to paste)
+
+**Title:** Typo `primtiveFailed` → `primitiveFailed` in `Object>>checkIndexableBounds:put:`
+
+**Component:** kernel — `kernel/Object.st`
+
+**Version:** 3.2.5 (and current git `master`).
+
+**Description:**
+
+`Object>>checkIndexableBounds:put:` raises a misspelled selector on its
+"unrecognized shape" error path:
+
+```smalltalk
+checkIndexableBounds: anIndex put: object
+    ...
+    shape == #uint64 ifTrue: [size := 64].
+    shape == #int64 ifTrue: [size := 63].
+    size isNil ifTrue: [^self primtiveFailed].        "<-- typo: primtiveFailed"
+    ^SystemExceptions.ArgumentOutOfRange
+        signalOn: object
+        mustBeBetween: (size odd ifTrue: [-1 bitShift: size] ifFalse: [0])
+        and: (1 bitShift: size) - 1
+```
+
+`primtiveFailed` (note the missing `i`) is not a defined method anywhere in the
+image. The correct selector, `primitiveFailed`, is defined in the same file:
+
+```smalltalk
+primitiveFailed [
+    "Called when a VM primitive fails"
+    <category: 'built ins'>
+    SystemExceptions.PrimitiveFailed signal
+]
+```
+
+So when `shape` is none of the handled values (`size` stays `nil`), the method
+intends to raise `SystemExceptions.PrimitiveFailed` but instead sends the unknown
+message `#primtiveFailed`, producing a `doesNotUnderstand:` /
+`MessageNotUnderstood` — i.e. the "primitive failed" handler itself fails, with the
+wrong error.
+
+**Impact:** Low severity (an error path, reached only for an unexpected indexable
+shape), but the error reported is misleading (`doesNotUnderstand: #primtiveFailed`
+instead of a `PrimitiveFailed`).
+
+**Fix:** one-character correction.
+
+```diff
+-    size isNil ifTrue: [^self primtiveFailed].
++    size isNil ifTrue: [^self primitiveFailed].
+```
+
+**How it was found:** a static unknown-selector heuristic resolving `self`-sends
+against the closed-world `Object` method table flagged `#primtiveFailed` as a
+selector implemented nowhere in the kernel (it occurs exactly once in
+`kernel/Object.st`, only at this call site).

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/verification.md
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/verification.md
@@ -1,29 +1,103 @@
-# Implementation Verification Checklist
+# SPIKE-01 — Go/No-Go Memo (Unknown-Selector Heuristic)
 
-**Purpose**: Verify implementation correctness AFTER coding  
-**Type**: Implementation Verification  
+**Type**: Research spike outcome (the deliverable IS this memo + the corpus report)
+**Decision date**: 2026-06-26 · **Owner**: Leonardo Nascimento
 
 ---
 
-## Section 1: Acceptance Criteria
-- [ ] All ACs in `tasks.md` are checked?
-- [ ] Each AC has a passing test?
+## Recommendation: **SHELVE** (do not ship a published linter now) — *reconsider* after cartridge hardening
 
-## Section 2: Code Quality
-- [ ] `npm run lint` passes?
-- [ ] `npm test` passes?
-- [ ] No `any` types in TypeScript (unless justified)?
-- [ ] JSDoc provided for public APIs?
+The decision gate (spec §2) is **adopt only if the false-positive rate is effectively zero**. On a real
+corpus the gate is **not** at zero false positives, and **closed-world coverage is low (~27%)** — itself a
+kill signal (AC4). The gate *logic* is sound and found genuine bugs, but it inherits the cartridge's
+completeness, and today the cartridge under-captures primitive + class-side methods. **Park the code
+(flagged off, no diagnostics); revisit only after the two conditions below are met.**
 
-## Section 3: Constitutional Compliance
-- [ ] **Native**: Follows VS Code guidelines?
-- [ ] **Zero Config**: Works without manual setup?
-- [ ] **Robustness**: Handles errors gracefully?
-- [ ] **TDD**: Tests were written/exist?
+## What was built (AC1, AC2)
 
-## Section 4: Manual Verification
-- [ ] Feature works in Extension Host?
-- [ ] No errors in Developer Tools console?
+- `server/src/diagnostics/unknownSelectorGate.ts` — the pure §4 gate (`evaluateMissingSelector` /
+  `shouldEmitMissingSelectorWarning`) with the single-emit truth table and **all six §5 escape hatches**
+  (perform-family, reflective allowlist, custom DNU, proxy/mock name, incomplete/extension table, opt-out).
+- `server/src/diagnostics/cartridgeClassWorld.ts` — the closed-world resolver over **cartridge ∪
+  workspace**, modelling two facts that dominate correctness:
+  1. **Metaclass protocol** — a class object also responds to `Behavior`/`Class` instance methods
+     (`new`, `name`, `category`); without this, `Foo new` is itself a false positive.
+  2. **`self` subclass closure (Template Method)** — `self` in an *abstract* class can be any concrete
+     subclass, so the understood-set unions descendants' own methods.
+- `scripts/spike-unknown-selector.ts` — the corpus harness (output saved to `corpus-report.txt`).
+- `server/test/unknownSelectorGate.test.ts` — 16 unit tests pinning the truth table + every hatch + the
+  cartridge Template-Method / metaclass behaviour. **It ships nothing**: nothing imports the gate from
+  `server.ts`, so esbuild tree-shakes it out of the bundle (verified: `dist/server.js` unchanged).
 
-## Section 5: Sign-Off
-- [ ] Ready for Merge?
+## Corpus results (AC3)
+
+Corpus: **GST 3.2.5 kernel** (122 files, **21,711 sends**) + **learning-smalltalk** (2 files, 54 sends).
+Driven over the bundled GST 3.2.5 cartridge ∪ the parsed workspace, no `gst`.
+
+| Metric | Value |
+|---|---|
+| Closed-world coverage (receiver resolved) | **6,334 / 21,765 = 29.1%** |
+| Table-consulted (definite understood/emit) | **5,886 / 21,765 = 27.0%** |
+| Open-world (Unknown receiver → silent) | **70.8%** |
+| **Emits — naive `self` resolution** | **58** (all false positives) |
+| **Emits — with the `self` subclass-union fix** | **12** |
+
+**The subclass-union (Template Method) insight is essential**: without it, abstract classes alone
+(`Float>>asFraction` sending `self exponent`, implemented on `FloatD`/`FloatE`/`FloatQ`) generate 46 false
+positives. With it, 58 → 12.
+
+### Triage of the 12 remaining emits
+
+**Genuine catches (≈4) — the heuristic working:**
+- `Object>>checkIndexableBounds:put:` → `self primtiveFailed` — a **confirmed misspelling** of
+  `primitiveFailed` (cf. `Object.st:1301`/`:1345`). A real latent typo in the GST 3.2.5 kernel.
+- `WeakKeyDictionary class >> postLoad` → `self primSize` / `self primAt:` (×3) — a **class-side**
+  method sends instance-only selectors (`primSize`/`primAt:` are defined instance-side at
+  `WeakObjects.st:457`/`:462`). A cross-side DNU-if-invoked (dead/buggy code).
+- (`ArchiveFile>>release` → `self primUnlink:` — `primUnlink:` is defined only on `File`, a *sibling* of
+  `ArchiveFile`'s ancestor `FileWrapper`; likely a real cross-class assumption.)
+
+**False positives (≈7-8) — cartridge-completeness gaps, NOT logic flaws:**
+- `ObjectDumper` → `self nextSignByte` / `nextInt64` (×4) — **VM primitives** with no static source
+  definition; statically uncapturable.
+- `PackageLoader class >> canLoad:` → `self extractDependenciesFor:ifMissing:` — **defined**
+  (`PkgLoader.st:136`) but the cartridge mis-sides it (`PackageLoader` is class-side-only, `inst#0`).
+- `SecurityError for:` — an exception class-side constructor the cartridge didn't capture.
+- `URL>>decodedFile` → `self file` — a likely instance-variable accessor the cartridge missed.
+
+**Precision is therefore NOT zero-FP**: ~7-8 false positives on pristine kernel code (~0.035% of sends,
+but **> 0** — and a single squiggle on valid code is the uninstall risk the spec warns of).
+
+## Why shelve (AC4)
+
+1. **Zero-FP bar unmet** — ~7-8 false positives remain, every one on valid, shipping code.
+2. **Low coverage** — only ~27% of sends reach a definite verdict; 71% have an Unknown (open-world)
+   receiver the heuristic cannot speak to. Even at zero FP the feature would be quiet. Per the gate, *low
+   closed-world coverage is itself a shelve signal*.
+3. **The residual FPs are the cartridge's, not the gate's** — they vanish only by capturing primitives +
+   class-side methods + fixing a few class chains, which is a separate body of work.
+
+## Reconsider conditions (the path back)
+
+Re-open an unknown-selector **feature** story only when **both** hold:
+- **(a) Cartridge completeness** — the GST cartridge captures primitive-backed and class-side methods (and
+  correct class-side method tables), driving corpus false positives to ~0; and
+- **(b) Scope restriction** — ship only the highest-confidence slice (e.g. `self`-sends in *concrete*
+  classes with a complete table; default severity `Hint`; opt-out; allowlist), measured back to zero FP on
+  this same harness.
+
+Until then the gate stays parked (this branch / git history), flagged off, ships nothing.
+
+## Side value (do regardless)
+- Report `Object>>checkIndexableBounds:put:` `primtiveFailed` (and the `WeakKeyDictionary class>>postLoad`
+  cross-side sends) **upstream to GNU Smalltalk** — real latent bugs the spike surfaced.
+
+---
+
+## Checklist
+- [x] **AC1** — §4 gate implemented behind a flag, no published diagnostics (tree-shaken from the bundle).
+- [x] **AC2** — all six §5 escape hatches implemented + unit-tested.
+- [x] **AC3** — corpus report: precision (triaged), closed-world coverage (`corpus-report.txt`).
+- [x] **AC4** — written go/no-go recommendation (this memo): **SHELVE, reconsider after cartridge hardening**.
+- [x] `npm run lint` / `check-types` / `test:parser` (incl. 16 gate tests) green; bundle unaffected.
+- [x] PO sign-off: _pending review of this memo._

--- a/specs/SPIKE-01-Unknown-Selector-Heuristic/verification.md
+++ b/specs/SPIKE-01-Unknown-Selector-Heuristic/verification.md
@@ -100,4 +100,6 @@ Until then the gate stays parked (this branch / git history), flagged off, ships
 - [x] **AC3** — corpus report: precision (triaged), closed-world coverage (`corpus-report.txt`).
 - [x] **AC4** — written go/no-go recommendation (this memo): **SHELVE, reconsider after cartridge hardening**.
 - [x] `npm run lint` / `check-types` / `test:parser` (incl. 16 gate tests) green; bundle unaffected.
-- [x] PO sign-off: _pending review of this memo._
+- [x] PO sign-off: **accepted — SHELVE (2026-06-26).** The unknown-selector linter is not pursued now;
+  the gate code is parked (flagged off, tree-shaken). Reconsider only after cartridge completeness + scope
+  restriction. The `primtiveFailed` typo is reported upstream (`upstream-bug-primtiveFailed.md`).


### PR DESCRIPTION
## SPIKE-01 — Unknown-Selector Heuristic (research spike) · Recommendation: **SHELVE**

Time-boxed spike that **ships nothing** — it builds the "Heuristic of Extreme Caution" behind a flag and measures its false-positive rate + closed-world coverage on a real corpus to decide adopt vs shelve. Deliverable is the **go/no-go memo** (`specs/SPIKE-01-*/verification.md`).

### What's here (parked, tree-shaken from the bundle)
- `server/src/diagnostics/unknownSelectorGate.ts` — the §4 gate (single-emit truth table) + all six §5 escape hatches.
- `server/src/diagnostics/cartridgeClassWorld.ts` — closed-world resolver over cartridge ∪ workspace, modelling the **metaclass protocol** (`Foo new` isn't an FP) and the **`self` subclass closure** (Template Method).
- `scripts/spike-unknown-selector.ts` — corpus harness; output in `specs/SPIKE-01-*/corpus-report.txt`.
- `server/test/unknownSelectorGate.test.ts` — 16 unit tests. **Nothing imports the gate from `server.ts`**, so esbuild tree-shakes it — `dist/server.js` is unchanged.

### Result (GST 3.2.5 kernel, 21,711 sends + learning-smalltalk)
| | |
|---|---|
| Naive `self` resolution | **58 false positives** (all Template-Method pattern) |
| + `self` subclass-union fix | **12 emits** |
| Of the 12 | ~4 genuine catches (incl. the real kernel typo `primtiveFailed`), ~7-8 cartridge-completeness FPs |
| Closed-world coverage | **~27%** |

### Recommendation: **SHELVE**
Zero-FP bar **unmet** (~7-8 residual FPs, all on valid kernel code) + low coverage (~27%). The residual FPs are the *cartridge's* (uncaptured primitives + class-side methods), not the gate's logic. **Reconsider** only after (a) cartridge completeness and (b) scope restriction. Gate code parked.

### Decision needed
- **PO sign-off** on the SHELVE recommendation.
- **Merge vs park**: land this on `master` (parked, tree-shaken, unit-tested, discoverable) or keep it on the branch only?

Refs #67. (Issue stays open if shelved-on-branch; closes if merged.)