### PR TITLE
chore(US-416): close cycle — manual-QA sign-off

### DIFF
--- a/specs/US-416-Formatting/manual-qa-workspace/.vscode/settings.json
+++ b/specs/US-416-Formatting/manual-qa-workspace/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "smalltalk.format.enable": true,
+    "smalltalk.format.blockStyle": "expand"
+}

--- a/specs/US-416-Formatting/tasks.md
+++ b/specs/US-416-Formatting/tasks.md
@@ -27,6 +27,6 @@ Mark each task `[x]` as it lands. Map tasks to acceptance criteria where possibl
 
 ## Phase 4 — Verify
 - [x] T900 All acceptance tests GREEN: `test:parser` (incl. format property 26 + 122/122 kernel files idempotent & token-invariant), `test:server` (handshake), `eval` (incl. formatting 17), `test:e2e` (US-416 5/5). `check-types` + `lint` clean.
-- [~] T901 Created `specs/US-416-Formatting/manual-qa-workspace/` (README matrix A–D + `Messy.st` valid/0-diag fixture + `Broken.st` malformed fixture) and filled `verification.md`. **Extension-Host matrix run still pending** (verification.md §4).
-- [ ] T902 CI green on Linux/macOS/Windows + e2e job (after PR).
+- [x] T901 Created `specs/US-416-Formatting/manual-qa-workspace/` (README matrix A–E + `Messy.st` valid/0-diag fixture + `Broken.st` malformed fixture) and filled `verification.md`. **Extension-Host matrix Parts A–E passed by the owner (2026-06-29).**
+- [x] T902 CI green on Linux/macOS/Windows + e2e job (PR #106). Merged squash `15a9564`; closed #28.
 - [x] T903 Doc-rot sweep (v0.10.0): version `0.9.2`→`0.10.0`; CHANGELOG `[0.10.0]` entry; README (Formatting feature + `smalltalk.format.*` config docs); user-stories US-416 → Done + status-summary line; EPIC-004 status (effectively complete); ROADMAP (0.10 row = Formatting shipped, Hardening→0.11, 1.0 drops formatting, parity scorecard `✅0.10`, Next-up + dated delta); CLAUDE.md (date, Shipped v0.10.0 bullet, Next, code map + formatting bullet).

--- a/specs/US-416-Formatting/verification.md
+++ b/specs/US-416-Formatting/verification.md
@@ -44,15 +44,16 @@
   the one dialect-sensitive rule (keep `Scope` tight) is structural, not GST-lexeme-specific. ADR-0005.
 
 ## Section 4: Manual Verification
-- [ ] Feature works in Extension Host — run `specs/US-416-Formatting/manual-qa-workspace/` matrix
-  (Parts A–D): off-by-default no-op; document format matches the documented golden; idempotent second pass;
-  range/on-type; comments + blank lines + `SystemExceptions.NotYetImplemented` (tight `Scope`) preserved;
-  `Broken.st` left byte-for-byte intact. *(To run before release, with both real code and a clean VSIX.)*
-- [ ] No errors in Developer Tools console during the matrix.
+- [x] Feature works in Extension Host — `specs/US-416-Formatting/manual-qa-workspace/` matrix
+  (Parts A–E) passed by the owner (2026-06-29): off-by-default no-op; document format matches the
+  documented golden; idempotent second pass; range/on-type; comments + blank lines +
+  `SystemExceptions.NotYetImplemented` (tight `Scope`) preserved; `Broken.st` left byte-for-byte intact;
+  `blockStyle: expand` reflows bodies one-statement-per-line. "Everything still working."
+- [x] No errors in Developer Tools console during the matrix.
 
 ## Section 5: Sign-Off
-- [ ] Ready for Merge — pending the Part A–D Extension-Host pass + PO acceptance + green CI on
-  Linux/macOS/Windows.
+- [x] **Ready for Merge** — Extension-Host Parts A–E passed + PO accepted + CI green on
+  Linux/macOS/Windows + e2e. **Merged via PR #106 (squash, `15a9564`); closed #28; shipped as v0.10.0.**
 
 ---
 
@@ -61,5 +62,6 @@
 Kernel corpus: 122/122 idempotent + token-invariant **in both `preserve` and `expand` modes**.
 The opt-in `blockStyle: expand` (default `preserve`) delivers the expanded/one-statement-per-line aesthetic
 via structural forced-breaks — still whitespace-only (ADR-0005).
-**Remaining for Done:** manual-QA matrix in the Extension Host (§4), doc-rot sweep + version bump + CHANGELOG
-(staged in `tasks.md` T903), PO sign-off, CI green on all three OSes.
+**Done (2026-06-29):** automated layers green, doc-rot sweep + v0.10.0 bump + CHANGELOG (T903), manual-QA
+Parts A–E passed, PO sign-off, PR #106 merged (closes #28). Remaining outside this story: cut the
+`v0.10.0` GitHub Release to publish to the Marketplace.


### PR DESCRIPTION
Post-merge housekeeping for US-416 (formatting, shipped v0.10.0): flips the verification gate to done now that the owner has passed the Extension-Host manual-QA matrix (Parts A–E) and PR #106 merged (closed #28). Docs-only.