### PR TITLE
chore: gitignore manual-QA workspace .vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ syntaxes/gnu-smalltalk.tmLanguage.json
 
 # e2e fixture workspace settings written by VS Code during tests
 client/test-e2e/fixtures/.vscode/
+# manual-QA workspace settings written by VS Code when the folder is opened
+specs/**/manual-qa-workspace/.vscode/

--- a/specs/US-416-Formatting/manual-qa-workspace/.vscode/settings.json
+++ b/specs/US-416-Formatting/manual-qa-workspace/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "smalltalk.format.enable": true,
-    "smalltalk.format.blockStyle": "expand"
-}


### PR DESCRIPTION
VS Code regenerates `specs/**/manual-qa-workspace/.vscode/settings.json` when the QA folder is opened; it slipped into #107 with `format.enable: true` and would break manual-QA Part A (the off-by-default check). Untrack + ignore it, mirroring the existing e2e-fixtures rule.